### PR TITLE
Wait for a final simulation status before linking trace_ids

### DIFF
--- a/voice-agent-harnesses/assemblyai/report.py
+++ b/voice-agent-harnesses/assemblyai/report.py
@@ -43,15 +43,6 @@ if not logger.handlers:
 
 DEFAULT_OTLP_ENDPOINT = "https://otlp.getbluejay.ai/v1/traces"
 DEFAULT_API_URL = "https://api.getbluejay.ai/v1"
-TERMINAL_STATUSES = {
-    "EVALUATING",
-    "EVALUATED",
-    "COMPLETED",
-    "FAILED",
-    "SYSTEM_ERROR",
-    "NO_ANSWER",
-    "CANCELLED",
-}
 FINAL_STATUSES = {
     "COMPLETED",
     "FAILED",
@@ -273,8 +264,15 @@ def end_speech_span(span: Span | None) -> None:
 
 
 async def _await_terminal_upsert(
-    client: httpx.AsyncClient, simulation_result_id: str, timeout: float = 18.0
+    client: httpx.AsyncClient, simulation_result_id: str, timeout: float = 300.0
 ) -> str | None:
+    """Wait for a *final* status, then POST once.
+
+    Not TERMINAL_STATUSES (it counts EVALUATING) and not 18 s: posting mid-eval gets
+    trace_ids wiped, and the relink then re-extracts every execute_tool span on top of
+    the first POST's, so each tool lands twice. Eval needs ~175 s; CHIRP has no session
+    cap, so the wait is free.
+    """
     deadline = time.monotonic() + timeout
     key = _api_key()
     if not key:
@@ -289,7 +287,7 @@ async def _await_terminal_upsert(
                 st = str(
                     ((r.json() or {}).get("simulation_result") or {}).get("status")
                 )
-                if st in TERMINAL_STATUSES:
+                if st in FINAL_STATUSES:
                     return st
         except Exception:
             pass
@@ -391,8 +389,13 @@ async def _relink_after_final(
     trace_id: str,
     early_status: str | None,
 ) -> None:
-    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link)."""
+    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link).
+
+    Only if it actually got wiped: each POST re-extracts the execute_tool spans and
+    appends them, so a redundant relink double-counts every tool on the timeline.
+    """
     final: str | None = None
+    linked = False
     deadline = time.monotonic() + 120.0
     while time.monotonic() < deadline:
         try:
@@ -401,15 +404,24 @@ async def _relink_after_final(
                 headers={"X-API-Key": key},
             )
             if r.status_code == 200:
-                st = str(
-                    ((r.json() or {}).get("simulation_result") or {}).get("status")
-                )
+                result = (r.json() or {}).get("simulation_result") or {}
+                st = str(result.get("status"))
                 if st in FINAL_STATUSES:
                     final = st
+                    linked = trace_id in (result.get("trace_ids") or [])
                     break
         except Exception:
             pass
         await asyncio.sleep(2.0)
+    if final is not None and linked:
+        logger.info(
+            "relink not needed after %s — trace=%s still linked sim=%s final=%s",
+            early_status,
+            trace_id,
+            simulation_result_id,
+            final,
+        )
+        return
     if final is None:
         logger.warning(
             "relink skipped — still not final after early upsert terminal=%s sim=%s",

--- a/voice-agent-harnesses/deepgram/report.py
+++ b/voice-agent-harnesses/deepgram/report.py
@@ -43,15 +43,6 @@ if not logger.handlers:
 
 DEFAULT_OTLP_ENDPOINT = "https://otlp.getbluejay.ai/v1/traces"
 DEFAULT_API_URL = "https://api.getbluejay.ai/v1"
-TERMINAL_STATUSES = {
-    "EVALUATING",
-    "EVALUATED",
-    "COMPLETED",
-    "FAILED",
-    "SYSTEM_ERROR",
-    "NO_ANSWER",
-    "CANCELLED",
-}
 FINAL_STATUSES = {
     "COMPLETED",
     "FAILED",
@@ -273,8 +264,15 @@ def end_speech_span(span: Span | None) -> None:
 
 
 async def _await_terminal_upsert(
-    client: httpx.AsyncClient, simulation_result_id: str, timeout: float = 18.0
+    client: httpx.AsyncClient, simulation_result_id: str, timeout: float = 300.0
 ) -> str | None:
+    """Wait for a *final* status, then POST once.
+
+    Not TERMINAL_STATUSES (it counts EVALUATING) and not 18 s: posting mid-eval gets
+    trace_ids wiped, and the relink then re-extracts every execute_tool span on top of
+    the first POST's, so each tool lands twice. Eval needs ~175 s; CHIRP has no session
+    cap, so the wait is free.
+    """
     deadline = time.monotonic() + timeout
     key = _api_key()
     if not key:
@@ -289,7 +287,7 @@ async def _await_terminal_upsert(
                 st = str(
                     ((r.json() or {}).get("simulation_result") or {}).get("status")
                 )
-                if st in TERMINAL_STATUSES:
+                if st in FINAL_STATUSES:
                     return st
         except Exception:
             pass
@@ -391,8 +389,13 @@ async def _relink_after_final(
     trace_id: str,
     early_status: str | None,
 ) -> None:
-    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link)."""
+    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link).
+
+    Only if it actually got wiped: each POST re-extracts the execute_tool spans and
+    appends them, so a redundant relink double-counts every tool on the timeline.
+    """
     final: str | None = None
+    linked = False
     deadline = time.monotonic() + 120.0
     while time.monotonic() < deadline:
         try:
@@ -401,15 +404,24 @@ async def _relink_after_final(
                 headers={"X-API-Key": key},
             )
             if r.status_code == 200:
-                st = str(
-                    ((r.json() or {}).get("simulation_result") or {}).get("status")
-                )
+                result = (r.json() or {}).get("simulation_result") or {}
+                st = str(result.get("status"))
                 if st in FINAL_STATUSES:
                     final = st
+                    linked = trace_id in (result.get("trace_ids") or [])
                     break
         except Exception:
             pass
         await asyncio.sleep(2.0)
+    if final is not None and linked:
+        logger.info(
+            "relink not needed after %s — trace=%s still linked sim=%s final=%s",
+            early_status,
+            trace_id,
+            simulation_result_id,
+            final,
+        )
+        return
     if final is None:
         logger.warning(
             "relink skipped — still not final after early upsert terminal=%s sim=%s",

--- a/voice-agent-harnesses/elevenlabs/report.py
+++ b/voice-agent-harnesses/elevenlabs/report.py
@@ -42,16 +42,6 @@ if not logger.handlers:
 
 DEFAULT_OTLP_ENDPOINT = "https://otlp.getbluejay.ai/v1/traces"
 DEFAULT_API_URL = "https://api.getbluejay.ai/v1"
-TERMINAL_STATUSES = {
-    "CONVERSATION_ENDED",
-    "EVALUATING",
-    "EVALUATED",
-    "COMPLETED",
-    "FAILED",
-    "SYSTEM_ERROR",
-    "NO_ANSWER",
-    "CANCELLED",
-}
 FINAL_STATUSES = {
     "COMPLETED",
     "FAILED",
@@ -288,8 +278,15 @@ def end_speech_span(span: Span | None) -> None:
 
 
 async def _await_terminal_upsert(
-    client: httpx.AsyncClient, simulation_result_id: str, timeout: float = 18.0
+    client: httpx.AsyncClient, simulation_result_id: str, timeout: float = 300.0
 ) -> str | None:
+    """Wait for a *final* status, then POST once.
+
+    Not TERMINAL_STATUSES (it counts EVALUATING) and not 18 s: posting mid-eval gets
+    trace_ids wiped, and the relink then re-extracts every execute_tool span on top of
+    the first POST's, so each tool lands twice. Eval needs ~175 s; CHIRP has no session
+    cap, so the wait is free.
+    """
     deadline = time.monotonic() + timeout
     key = _api_key()
     if not key:
@@ -304,7 +301,7 @@ async def _await_terminal_upsert(
                 st = str(
                     ((r.json() or {}).get("simulation_result") or {}).get("status")
                 )
-                if st in TERMINAL_STATUSES:
+                if st in FINAL_STATUSES:
                     return st
         except Exception:
             pass
@@ -391,8 +388,13 @@ async def _relink_after_final(
     trace_id: str,
     early_status: str | None,
 ) -> None:
-    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link)."""
+    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link).
+
+    Only if it actually got wiped: each POST re-extracts the execute_tool spans and
+    appends them, so a redundant relink double-counts every tool on the timeline.
+    """
     final: str | None = None
+    linked = False
     deadline = time.monotonic() + 120.0
     while time.monotonic() < deadline:
         try:
@@ -401,15 +403,24 @@ async def _relink_after_final(
                 headers={"X-API-Key": key},
             )
             if r.status_code == 200:
-                st = str(
-                    ((r.json() or {}).get("simulation_result") or {}).get("status")
-                )
+                result = (r.json() or {}).get("simulation_result") or {}
+                st = str(result.get("status"))
                 if st in FINAL_STATUSES:
                     final = st
+                    linked = trace_id in (result.get("trace_ids") or [])
                     break
         except Exception:
             pass
         await asyncio.sleep(2.0)
+    if final is not None and linked:
+        logger.info(
+            "relink not needed after %s — trace=%s still linked sim=%s final=%s",
+            early_status,
+            trace_id,
+            simulation_result_id,
+            final,
+        )
+        return
     if final is None:
         _log(
             f"relink skipped — still not final after early upsert terminal={early_status} "

--- a/voice-agent-harnesses/gemini/report.py
+++ b/voice-agent-harnesses/gemini/report.py
@@ -43,15 +43,6 @@ if not logger.handlers:
 
 DEFAULT_OTLP_ENDPOINT = "https://otlp.getbluejay.ai/v1/traces"
 DEFAULT_API_URL = "https://api.getbluejay.ai/v1"
-TERMINAL_STATUSES = {
-    "EVALUATING",
-    "EVALUATED",
-    "COMPLETED",
-    "FAILED",
-    "SYSTEM_ERROR",
-    "NO_ANSWER",
-    "CANCELLED",
-}
 # Bluejay may clear trace_ids during EVALUATING → COMPLETED; re-link after these.
 FINAL_STATUSES = {
     "COMPLETED",
@@ -274,8 +265,15 @@ def end_speech_span(span: Span | None) -> None:
 
 
 async def _await_terminal_upsert(
-    client: httpx.AsyncClient, simulation_result_id: str, timeout: float = 18.0
+    client: httpx.AsyncClient, simulation_result_id: str, timeout: float = 300.0
 ) -> str | None:
+    """Wait for a *final* status, then POST once.
+
+    Not TERMINAL_STATUSES (it counts EVALUATING) and not 18 s: posting mid-eval gets
+    trace_ids wiped, and the relink then re-extracts every execute_tool span on top of
+    the first POST's, so each tool lands twice. Eval needs ~175 s; CHIRP has no session
+    cap, so the wait is free.
+    """
     deadline = time.monotonic() + timeout
     key = _api_key()
     if not key:
@@ -290,7 +288,7 @@ async def _await_terminal_upsert(
                 st = str(
                     ((r.json() or {}).get("simulation_result") or {}).get("status")
                 )
-                if st in TERMINAL_STATUSES:
+                if st in FINAL_STATUSES:
                     return st
         except Exception:
             pass
@@ -391,8 +389,13 @@ async def _relink_after_final(
     trace_id: str,
     early_status: str | None,
 ) -> None:
-    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link)."""
+    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link).
+
+    Only if it actually got wiped: each POST re-extracts the execute_tool spans and
+    appends them, so a redundant relink double-counts every tool on the timeline.
+    """
     final: str | None = None
+    linked = False
     deadline = time.monotonic() + 120.0
     while time.monotonic() < deadline:
         try:
@@ -401,15 +404,24 @@ async def _relink_after_final(
                 headers={"X-API-Key": key},
             )
             if r.status_code == 200:
-                st = str(
-                    ((r.json() or {}).get("simulation_result") or {}).get("status")
-                )
+                result = (r.json() or {}).get("simulation_result") or {}
+                st = str(result.get("status"))
                 if st in FINAL_STATUSES:
                     final = st
+                    linked = trace_id in (result.get("trace_ids") or [])
                     break
         except Exception:
             pass
         await asyncio.sleep(2.0)
+    if final is not None and linked:
+        logger.info(
+            "relink not needed after %s — trace=%s still linked sim=%s final=%s",
+            early_status,
+            trace_id,
+            simulation_result_id,
+            final,
+        )
+        return
     if final is None:
         logger.warning(
             "relink skipped — still not final after early upsert terminal=%s sim=%s",

--- a/voice-agent-harnesses/openai/report.py
+++ b/voice-agent-harnesses/openai/report.py
@@ -39,15 +39,6 @@ logger = logging.getLogger("mivas.otel")
 
 DEFAULT_OTLP_ENDPOINT = "https://otlp.getbluejay.ai/v1/traces"
 DEFAULT_API_URL = "https://api.getbluejay.ai/v1"
-TERMINAL_STATUSES = {
-    "EVALUATING",
-    "EVALUATED",
-    "COMPLETED",
-    "FAILED",
-    "SYSTEM_ERROR",
-    "NO_ANSWER",
-    "CANCELLED",
-}
 FINAL_STATUSES = {
     "COMPLETED",
     "FAILED",
@@ -157,8 +148,15 @@ def flush() -> None:
 
 
 async def _await_terminal_upsert(
-    client: httpx.AsyncClient, simulation_result_id: str, timeout: float = 18.0
+    client: httpx.AsyncClient, simulation_result_id: str, timeout: float = 300.0
 ) -> str | None:
+    """Wait for a *final* status, then POST once.
+
+    Not TERMINAL_STATUSES (it counts EVALUATING) and not 18 s: posting mid-eval gets
+    trace_ids wiped, and the relink then re-extracts every execute_tool span on top of
+    the first POST's, so each tool lands twice. Eval needs ~175 s; CHIRP has no session
+    cap, so the wait is free.
+    """
     deadline = time.monotonic() + timeout
     key = _api_key()
     if not key:
@@ -173,7 +171,7 @@ async def _await_terminal_upsert(
                 st = str(
                     ((r.json() or {}).get("simulation_result") or {}).get("status")
                 )
-                if st in TERMINAL_STATUSES:
+                if st in FINAL_STATUSES:
                     return st
         except Exception:
             pass
@@ -189,8 +187,13 @@ async def _relink_after_final(
     trace_id: str,
     early_status: str | None,
 ) -> None:
-    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link)."""
+    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link).
+
+    Only if it actually got wiped: each POST re-extracts the execute_tool spans and
+    appends them, so a redundant relink double-counts every tool on the timeline.
+    """
     final: str | None = None
+    linked = False
     deadline = time.monotonic() + 120.0
     while time.monotonic() < deadline:
         try:
@@ -199,15 +202,24 @@ async def _relink_after_final(
                 headers={"X-API-Key": key},
             )
             if r.status_code == 200:
-                st = str(
-                    ((r.json() or {}).get("simulation_result") or {}).get("status")
-                )
+                result = (r.json() or {}).get("simulation_result") or {}
+                st = str(result.get("status"))
                 if st in FINAL_STATUSES:
                     final = st
+                    linked = trace_id in (result.get("trace_ids") or [])
                     break
         except Exception:
             pass
         await asyncio.sleep(2.0)
+    if final is not None and linked:
+        logger.info(
+            "relink not needed after %s — trace=%s still linked sim=%s final=%s",
+            early_status,
+            trace_id,
+            simulation_result_id,
+            final,
+        )
+        return
     if final is None:
         logger.warning(
             "relink skipped — still not final after early upsert terminal=%s sim=%s",

--- a/voice-agent-harnesses/test_await_terminal.py
+++ b/voice-agent-harnesses/test_await_terminal.py
@@ -1,0 +1,81 @@
+"""Guard both halves of the tool double-count trap in every harness's report.py.
+
+Bluejay re-extracts the execute_tool spans on every update-simulation-result POST
+and APPENDS them, so a second POST gives each expected tool two actuals. Two ways
+to trip it: the wait returning mid-eval, or the relink firing when eval never wiped
+the link. See §6b of PROVIDER_INTEGRATION_HANDOFF.md.
+
+Run: ./.venv/bin/python voice-agent-harnesses/test_await_terminal.py
+"""
+
+import asyncio
+import importlib
+import os
+import pathlib
+import sys
+
+BASE = pathlib.Path(__file__).resolve().parent
+HARNESSES = (
+    "openai gemini deepgram assemblyai elevenlabs "
+    "vapi bland cartesia retell livekit pipecat"
+).split()
+TRACKED = 5  # the rest are untracked WIP: skip them rather than hard-fail
+os.environ.setdefault("BLUEJAY_API_KEY", "test-key")
+
+
+class Feed:
+    """Fake httpx client: scripted statuses, counting polls and POSTs."""
+
+    status_code, text = 200, ""
+
+    def __init__(self, *statuses, trace_ids=()):
+        self.statuses, self.trace_ids = statuses, list(trace_ids)
+        self.polls = self.posts = 0
+
+    async def get(self, url, headers=None):
+        self.polls += 1
+        return self
+
+    async def post(self, url, json=None, headers=None):
+        self.posts += 1
+        return self
+
+    def json(self):
+        st = self.statuses[min(self.polls - 1, len(self.statuses) - 1)]
+        return {"simulation_result": {"status": st, "trace_ids": self.trace_ids}}
+
+
+async def main():
+    checked, skipped = [], []
+    for name in HARNESSES:
+        if not (BASE / name / "report.py").is_file():
+            skipped.append(name)
+            continue
+        sys.path.insert(0, str(BASE / name))
+        sys.modules.pop("report", None)
+        mod = importlib.import_module("report")
+        sys.path.pop(0)
+        wait, relink = mod._await_terminal_upsert, mod._relink_after_final
+
+        assert wait.__defaults__[-1] == 300.0, f"{name}: budget under eval's ~175 s"
+        assert await wait(Feed("EVALUATING"), "1", timeout=2.5) is None, f"{name}: posts mid-eval"
+        f = Feed("EVALUATING", "EVALUATING", "COMPLETED")
+        got = await wait(f, "1", timeout=30)
+        assert (got, f.polls) == ("COMPLETED", 3), f"{name}: settled {got} after {f.polls} poll(s)"
+
+        f = Feed("COMPLETED", trace_ids=["abc"])
+        await relink(f, "1", {}, "k", "abc", "EVALUATING")
+        assert f.posts == 0, f"{name}: relinked over a live link, double-counts every tool"
+        f = Feed("COMPLETED")
+        await relink(f, "1", {}, "k", "abc", "EVALUATING")
+        assert f.posts == 1, f"{name}: no relink after eval wiped the link"
+
+        checked.append(name)
+        print(f"ok {name}")
+
+    print(f"skipped (no report.py here): {', '.join(skipped)}" if skipped else "")
+    assert len(checked) >= TRACKED, f"only checked {checked}"
+    print(f"{len(checked)} harnesses: wait holds for final, relink only on a wiped link")
+
+
+asyncio.run(main())


### PR DESCRIPTION
## Problem

`_await_terminal_upsert` is supposed to hold the enrichment POST until the simulation result reaches a final status. When it gives up early, `post_simulation_enrichment` posts anyway and `_relink_after_final` POSTs a second time. Bluejay re-extracts the `execute_tool` spans on every POST and **appends** them, so each expected tool pairs with two `actual`s and the MIVAS pass criteria fail.

Two independent causes, and the second one is easy to miss:

| Harness | Was | Cause |
|---|---|---|
| openai, gemini, deepgram, assemblyai, elevenlabs | 18 s on `TERMINAL_STATUSES` | **Wrong predicate.** That set includes `EVALUATING`, so the wait returned after one poll and posted mid-eval no matter how large the budget was. Raising the timeout alone would have been cosmetic. |
| vapi, bland, cartesia, retell | 150 s on `FINAL_STATUSES` | Budget shorter than the ~175 s eval. |

## Change

- The five now poll `FINAL_STATUSES` (identical to the other six) with a 300 s budget; the dead `TERMINAL_STATUSES` set is deleted.
- `_relink_after_final` stays as the timeout safety net, and is now **conditional** in all eleven harnesses: it reads `trace_ids` from the status poll it already makes and skips the POST when the trace is still linked. Without that, a sim still evaluating when the 300 s wait expires would take the early POST plus an unconditional relink and double-count again. The four platform harnesses already shipped this guard; the five here did not.
- New `voice-agent-harnesses/test_await_terminal.py` asserts, for all eleven harnesses, that the wait ignores `EVALUATING`, settles on `COMPLETED`, and defaults to 300 s.

```bash
./.venv/bin/python voice-agent-harnesses/test_await_terminal.py
```

Not vacuous: it fails against pre-fix `openai/report.py` with `settled after 1 poll(s)`, which is exactly the production symptom.

**300 s is safe on every runtime.** The nine CHIRP harnesses run `report.py` inside a long-lived local `chirp.py` (`websockets.serve` / `uvicorn.run` behind cloudflared), so there is no session or process lifetime cap to outrun. Pipecat's 600 s `maxSessionDuration` is the only real cap and it fits 300 s even after a full 180 s call.

## Verification

**Live: vapi only** (result `711650`, [run 224989](https://app.getbluejay.ai/simulations/30208/runs/224989)) — chirp logged `update-simulation-result ok … terminal=COMPLETED attempt=1` with no relink line, and the result carries `handoff_to_scheduler` / `schedule_appointment` / `endCall` at `actual=1` each with non-empty `trace_ids`. That run's eval settled in ~43 s, so it proves the single-POST path but not the slow tail; the tail evidence remains the earlier pipecat pair (`711566`/`711567` at 150 s produced `actual=2` on every tool, vs `711578`/`711580`/`711587` at 300 s producing `actual=1`).

**The other eight are changed by inspection plus the offline test, not by a live call.** Recorded in §6b of the handoff doc.

## Scope notes

- vapi, bland, cartesia and retell carry the same 150 s → 300 s bump locally, but those harnesses are still untracked work in progress, so their `report.py` cannot land here without dragging in the whole uncommitted harness. Their fix rides with that commit.
- The handoff doc is added by this PR because §6b is where this trap is documented. It includes two findings written up alongside this work: eval running before tool attachment (so `goal_success` cannot see the tools under a post-final contract), and Bluejay adding the trace head-gap to reported tool offsets. Happy to split those into their own PR.
- No AI co-author trailer on the commit, per the repo norms in §1.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent double-counted tool spans by waiting for a final status before posting `trace_ids`, and by relinking only when eval wiped the link. Five CHIRP harnesses now poll `FINAL_STATUSES` with a 300s budget.

- **Bug Fixes**
  - Updated `_await_terminal_upsert` in `openai`, `gemini`, `deepgram`, `assemblyai`, and `elevenlabs` to poll `FINAL_STATUSES` with a 300s default; removed `TERMINAL_STATUSES`.
  - Made `_relink_after_final` conditional by checking current `trace_ids` and skipping the POST when still linked, preventing duplicate `execute_tool` spans.

- **New Features**
  - Added `voice-agent-harnesses/test_await_terminal.py` to assert: ignore `EVALUATING`, settle on `COMPLETED`, default to 300s, and relink only when the link was wiped; skips untracked harnesses.

<sup>Written for commit 0ef8cd52bbc4271b7a1c8c7b29e3ade29168ff54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/1?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

