### PR TITLE
Add Vapi, Retell, Bland, Cartesia, LiveKit and Pipecat harnesses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,17 +40,57 @@ ELEVENLABS_API_KEY=
 # ELEVENLABS_RECEPTIONIST_AGENT_ID=
 # ELEVENLABS_SCHEDULER_AGENT_ID=
 
+# Vapi (squad multi-agent; deepgram flux + gpt-4.1 + eleven_flash_v2_5)
+VAPI_API_KEY=
+# VAPI_VOICE_ID=21m00Tcm4TlvDq8ikWAM
+
+# Retell (retell-llm states multi-agent; gpt-4.1 + eleven_flash_v2_5, deepgram STT — no Flux available)
+RETELL_API_KEY=
+# RETELL_LIVEKIT_URL=wss://retell-ai-4ihahnq7.livekit.cloud
+
+# Bland (in-house stack; conversational pathway multi-agent)
+BLAND_API_KEY=
+
+# Cartesia Line (code-first agent deployed via the cartesia CLI)
+CARTESIA_API_KEY=
+# CARTESIA_AGENT_ID=
+
+# LiveKit (framework harness — workers register against the LiveKit project Bluejay dispatches into)
+LIVEKIT_URL=
+LIVEKIT_API_KEY=
+LIVEKIT_API_SECRET=
+# NOTE: the LiveKit ElevenLabs plugin reads ELEVEN_API_KEY, not ELEVENLABS_API_KEY.
+# ELEVEN_API_KEY=
+# livekit-agents conflicts with the pinned livekit>=1.1.0 the retell harness needs, so the
+# livekit harness ships its own requirements.txt + .venv rather than joining the shared deps.
+
+# Pipecat (framework harness — the bot runs on Pipecat Cloud, so TOOL_SERVER_URL must be public)
+# Two DIFFERENT key types, not interchangeable:
+#   sk_ (private) — deploying the agent image, used by voice-agent-harnesses/pipecat/deploy.py
+#   pk_ (public)  — Bluejay's dispatch (POST /v1/public/<agent>/start); lives in the org's
+#                   Bluejay integrations (`pipecat_api_key`), NOT in this file. A private key
+#                   there fails with PCC-1002 "Attempt to start agent without public api key".
+PIPECAT_PRIVATE_API_KEY=
+# PIPECAT_AGENT_NAME=mivas-control
+# PIPECAT_REGION=us-west
+# pipecat-ai is installed from voice-agent-harnesses/pipecat/requirements.txt, not the shared deps.
+
+# Public https URL of the chirp tunnel — provider-side tools are pushed to
+# {PUBLIC_URL}/tool/<name> on every boot, since the tunnel URL is ephemeral.
+# PUBLIC_URL=
+
 # CHIRP WebSocket adapter (Bluejay → harness)
 # CHIRP_USER=mivas
 # CHIRP_PASS=mivas
-# CHIRP_PORT=8765
+# CHIRP_PORT=8765   # vapi 8770 / retell 8771 / bland 8772 / cartesia 8773 when running side by side
 # INDUSTRY=control-industry
 
 # Bluejay OTLP + link trace to sim result (Chirp sends X-Simulation-Result-Id on upgrade)
 # BLUEJAY_API_KEY=                 # OTLP X-API-KEY + update-simulation-result
 # BLUEJAY_OTLP_ENDPOINT=https://otlp.getbluejay.ai/v1/traces
 # BLUEJAY_API_URL=https://api.getbluejay.ai/v1
-# BLUEJAY_SERVICE_NAME=mivas-openai   # or mivas-gemini / mivas-assemblyai / mivas-deepgram / mivas-elevenlabs
+# BLUEJAY_SERVICE_NAME=mivas-openai   # or mivas-gemini / mivas-assemblyai / mivas-deepgram /
+#                                     # mivas-elevenlabs / mivas-vapi / mivas-retell / mivas-bland / mivas-cartesia
 
 # --- Kubernetes / CHIRP ---
 # MIVAS_MODE=chirp

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ Thumbs.db
 
 # k8s / docker scratch
 *.local.yaml
+
+# cached Bluejay agent/sim/DH ids (pipecat harness bootstrap)
+**/.bluejay-ids.json

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,12 @@ uv.toml
 # cached provider-side agent IDs (e.g. ElevenLabs ensure_agents)
 **/.agents.json
 
+# cartesia CLI-managed deploy state (agent id, deployment pointers)
+**/line_agent/.cartesia/
+
+# cached Bluejay agent/sim/DH ids (pipecat harness bootstrap)
+**/.bluejay-ids.json
+
 # OS / editor
 .DS_Store
 Thumbs.db
@@ -39,5 +45,5 @@ Thumbs.db
 # k8s / docker scratch
 *.local.yaml
 
-# cached Bluejay agent/sim/DH ids (pipecat harness bootstrap)
-**/.bluejay-ids.json
+# internal handoff docs, not shipped
+docs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
     "opentelemetry-exporter-otlp-proto-http>=1.27.0",
     # gemini harness
     "google-genai>=1.0.0",
+    # retell harness — web calls run over LiveKit, so the bridge joins the room
+    "livekit>=1.1.0",
 ]
 [dependency-groups]
 dev = []
@@ -30,4 +32,4 @@ package = false
 venvPath = "."
 venv = ".venv"
 pythonVersion = "3.12"
-extraPaths = ["voice-agent-harnesses/openai", "voice-agent-harnesses/gemini", "voice-agent-harnesses/assemblyai", "voice-agent-harnesses/deepgram", "voice-agent-harnesses/elevenlabs"]
+extraPaths = ["voice-agent-harnesses/openai", "voice-agent-harnesses/gemini", "voice-agent-harnesses/assemblyai", "voice-agent-harnesses/deepgram", "voice-agent-harnesses/elevenlabs", "voice-agent-harnesses/vapi", "voice-agent-harnesses/retell", "voice-agent-harnesses/bland", "voice-agent-harnesses/cartesia", "voice-agent-harnesses/livekit", "voice-agent-harnesses/pipecat"]

--- a/uv.lock
+++ b/uv.lock
@@ -9,6 +9,15 @@ resolution-markers = [
 ]
 
 [[package]]
+name = "aiofiles"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/c3/534eac40372d8ee36ef40df62ec129bee4fdb5ad9706e58a29be53b2c970/aiofiles-25.1.0.tar.gz", hash = "sha256:a8d728f0a29de45dc521f18f07297428d56992a742f0cd2701ba86e44d23d5b2", size = 46354, upload-time = "2025-10-09T20:51:04.358Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/8a/340a1555ae33d7354dbca4faa54948d76d89a27ceef032c8c3bc661d003e/aiofiles-25.1.0-py3-none-any.whl", hash = "sha256:abe311e527c862958650f9438e859c1fa7568a141b22abcd015e120e86a85695", size = 14668, upload-time = "2025-10-09T20:51:03.174Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.5"
 source = { registry = "https://pypi.org/simple" }
@@ -510,6 +519,25 @@ wheels = [
 ]
 
 [[package]]
+name = "livekit"
+version = "1.1.14"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "types-protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ab/5d/bfaf1cc73f960b40294f604d334f05e628b0a07de3c47e475d760996a8d0/livekit-1.1.14.tar.gz", hash = "sha256:47428e10ecf20d7db4ee9fde4009bf96578c003b1ae6e1c5e7e4837a55902393", size = 375000, upload-time = "2026-07-31T14:05:14.425Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/ff/a2659522b3cf860b9b4453e1ec12d4b4c7e9cfd2b672f2cf925016d73492/livekit-1.1.14-py3-none-macosx_10_15_x86_64.whl", hash = "sha256:5f671b1752c93b878cb241b84fd3f72a31f857c3927755d672cfb7656a84778c", size = 10196322, upload-time = "2026-07-31T14:05:04.167Z" },
+    { url = "https://files.pythonhosted.org/packages/82/a2/89f32d369cc78cb1a50b2a9e635c653f88d86ea4338ccdfa7b2d4ca0aecd/livekit-1.1.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:efa16b9036b0b592e5399fdb858c1f04ec8a32c385184c705f030952f72174e8", size = 9019745, upload-time = "2026-07-31T14:05:06.49Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/5b/dda7d660fa5d5b6e228dcfc6be3664a2442d1601481686052af2da642e5e/livekit-1.1.14-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:299146efefad5f67751cd15b8225bae759be0d7ad2f0b4ae1a22c15860d93cf9", size = 10042499, upload-time = "2026-07-31T14:05:08.563Z" },
+    { url = "https://files.pythonhosted.org/packages/21/e3/d9255eeaf205f090d63d762e5254097b62af394bfaa90106f71f1fb6740e/livekit-1.1.14-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:80962c4a22ddbf0e0ebd3563fc090fce42df66b39b90de68b161b7db01970f68", size = 11445915, upload-time = "2026-07-31T14:05:10.628Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/0a/514fb230e7c7f13ae7e53b9e39a6dd9ea1aa9ff5be9e588d55301d159a1e/livekit-1.1.14-py3-none-win_amd64.whl", hash = "sha256:b8f8d38f131956297923e520bc4375bc9ebfa255cab7f125cb7755bfca71df24", size = 10766643, upload-time = "2026-07-31T14:05:12.716Z" },
+]
+
+[[package]]
 name = "mcp"
 version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
@@ -542,6 +570,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "google-genai" },
     { name = "httpx" },
+    { name = "livekit" },
     { name = "numpy" },
     { name = "openai-agents" },
     { name = "opentelemetry-api" },
@@ -557,6 +586,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "google-genai", specifier = ">=1.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "livekit", specifier = ">=1.1.0" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "openai-agents", specifier = ">=0.18.0" },
     { name = "opentelemetry-api", specifier = ">=1.27.0" },
@@ -1134,6 +1164,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
+]
+
+[[package]]
+name = "types-protobuf"
+version = "7.34.1.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/29/59/e2b13b499d15e6720150c4b1a8d91e31fcacf716b432397475b3151ff7e4/types_protobuf-7.34.1.20260518.tar.gz", hash = "sha256:28cfaded25889cb83ebfb63cfb0a43628f0b6f3785767bec17287dc6468795f2", size = 68936, upload-time = "2026-05-18T06:01:47.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/1f/ec5caf72c2e3b688ca3927e0979a04ddad19e1afc4bf1c199bd743e0f419/types_protobuf-7.34.1.20260518-py3-none-any.whl", hash = "sha256:a0a5337413347166439c0e07cbc26c6164d091401c6f01b1dfd8cdb966c4dd8f", size = 85992, upload-time = "2026-05-18T06:01:45.696Z" },
 ]
 
 [[package]]

--- a/voice-agent-harnesses/bland/README.md
+++ b/voice-agent-harnesses/bland/README.md
@@ -1,3 +1,135 @@
-# bland
+# Bland
 
-Benchmarks and evaluation assets for bland voice agents.
+MIVAS harness for [Bland](https://bland.ai). One runtime, `base`, on CHIRP port **8772**.
+
+Bland is fully in-house — their own STT, LLM and TTS — so unlike the Retell/Vapi harnesses
+there are no third-party components to pin. The config below is Bland's best-available
+setup rather than a match to the other providers'.
+
+| knob | value | why |
+|---|---|---|
+| `model` | `base` | supports every pathway feature; `turbo` is faster but feature-limited |
+| `voice` | `Jordan` (BTTS_V3) | Bland's newest in-house TTS tier; their own copy calls it warm/friendly at a moderate pace, for customer support |
+| `interruption_threshold` | `150` | Bland's default is 500 and their docs recommend 50–200; at 500 the agent waits so long after the digital human stops that turns collide |
+| `max_duration` | 5 (minutes) | benchmark calls run ~50 s; this is a backstop |
+| multi-agent | Conversational Pathway | Bland's native node graph — see below |
+
+Override any of them with `BLAND_MODEL`, `BLAND_VOICE`, `BLAND_INTERRUPTION_THRESHOLD`,
+`BLAND_MAX_DURATION_MIN`.
+
+## Multi-agent = pathway, not prompt
+
+`harness.pathway_graph` compiles `agent_blueprint.json` into a Bland pathway:
+
+```
+receptionist (Default, isStart)
+  │  edge: "caller wants to schedule a repair appointment"
+  ▼
+handoff_to_scheduler (Webhook → PUBLIC_URL/tool/handoff_to_scheduler)
+  │  responsePathways: Default/Webhook Completion
+  ▼
+scheduler (Default)
+  │  edge: "a concrete calendar date has been agreed"
+  ▼
+schedule_appointment (Webhook → PUBLIC_URL/tool/schedule_appointment, extractVars date)
+  │  responsePathways: Default/Webhook Completion
+  ▼
+End Call  (confirms {{booked_date}}, says goodbye, hangs up)
+```
+
+Both blueprint tools are Webhook nodes, so both are real provider-side HTTP calls into
+this harness and both get timed `execute_tool` spans. The handoff is a node rather than a
+bare edge for exactly that reason: it puts the receptionist → scheduler transition on the
+Bluejay timeline.
+
+Three things about the pathway API are not in Bland's docs and cost a run each:
+
+- **Edge routing fields must be top-level on the edge** (`{id, source, target, label,
+  description}`). Anything nested under `edge.data` — which is the shape the docs example
+  shows, and the shape a `GET` returns — is silently dropped, and an edge with no
+  `description` never fires. The symptom is a pathway that greets correctly and then never
+  leaves the start node.
+- **`description` is the routing criterion; `label` is only the editor's display name.**
+- **Webhook nodes do not leave via edges.** They route through
+  `responsePathways: [["Default/Webhook Completion", "", "", {id, name}]]`.
+
+Iterate on routing with Bland's text-chat endpoint (`POST /v1/pathway/chat/create`, then
+`POST /v1/pathway/chat/{chat_id}` with `{message}`) — it returns `current_node_id`, so a
+routing bug is one HTTP call away instead of one voice call away.
+
+The industry prompts tell the agent to *call* `handoff_to_scheduler`; a pathway node has
+no tools, so `harness.PATHWAY_NOTE` is appended to each node prompt. Without it the model
+reads the tool name out loud ("handoff underscore to scheduler") and stays put.
+
+## Transport
+
+`wss://stream-v2.aws.dc8.bland.ai/ws/connect/blandshared?agent=…&token=…`, token from
+`POST /v1/agents/{id}/authorize` (single use, one per call). Undocumented; probing
+established:
+
+- Raw binary PCM16 mono **both** directions, no JSON envelope, at **44100 Hz** — 16 kHz in
+  is transcribed as noise, so `adapters/chirp.py` resamples both ways with `audioop.ratecv`.
+- Interleaved JSON status frames: `{"event":"update","payload":{"type":"assistant"|"human",
+  "text":…}}`, `{"event":"mark"}`, and a bare-string `{"type":"callID","payload":"…"}`.
+- Agent audio is **continuous** — Bland streams silence between turns — so `agent.speech`
+  is bracketed by an RMS gate (`BLAND_AGENT_RMS_ON`, `BLAND_AGENT_SILENCE_S`), not by a
+  silence-gap-on-frames heuristic.
+
+## Files
+
+```
+harness.py            blueprint → pathway graph, agent bootstrap, run_tool
+report.py             OTel → Bluejay OTLP (voice.call / agent.speech / customer.speech / execute_tool)
+adapters/chirp.py     FastAPI: "/" CHIRP websocket + "/tool/{name}" pathway webhook
+base/agent.py         --check (offline graph assertions) / live silence smoke
+base/adapters/chirp.py  shim → adapters.chirp.main(model="base")
+```
+
+`.agents.json` caches the pathway + agent IDs per industry (gitignored). The graph is
+re-pushed on every boot because the webhook nodes carry the run's ephemeral tunnel URL.
+
+## Env
+
+`BLAND_API_KEY`, `PUBLIC_URL` (the https cloudflared URL — required, Bland calls tools back
+over it), plus the shared `TOOL_SERVER_URL`, `INDUSTRY`, `CHIRP_USER`/`CHIRP_PASS`,
+`CHIRP_PORT`, `BLUEJAY_API_KEY`, `BLUEJAY_API_URL`, `BLUEJAY_OTLP_ENDPOINT`,
+`BLUEJAY_SERVICE_NAME=mivas-bland`.
+
+## Run
+
+```bash
+uv run python industries/control-industry/tool_server.py            # terminal A (shared, :8000)
+cloudflared tunnel --url http://127.0.0.1:8772 --no-autoupdate      # terminal B
+
+set -a && source .env && set +a
+export BLUEJAY_API_URL=https://api.getbluejay.ai/v1
+export BLUEJAY_OTLP_ENDPOINT=https://otlp.getbluejay.ai/v1/traces
+export BLUEJAY_SERVICE_NAME=mivas-bland
+export CHIRP_USER=mivas CHIRP_PASS=mivas
+export INDUSTRY=control-industry TOOL_SERVER_URL=http://127.0.0.1:8000
+export CHIRP_PORT=8772 PYTHONUNBUFFERED=1
+export PUBLIC_URL=https://<tunnel>.trycloudflare.com
+uv run python voice-agent-harnesses/bland/base/adapters/chirp.py    # terminal C
+```
+
+Bluejay dials `wss://<tunnel>.trycloudflare.com` with Basic `mivas:mivas`.
+
+Smoke without Bluejay: `uv run python voice-agent-harnesses/bland/base/agent.py --check`
+(offline) or drop `--check` for a live silence call that prints the agent's turns.
+
+## Proof run
+
+control-industry, agent **30387** / sim **30211** / DH **194138** →
+result **710642** at
+[simulations/30211/runs/224728](https://app.getbluejay.ai/simulations/30211/runs/224728) — `COMPLETED`,
+`goal_success: true`, both tools once each and both matched against the DH's
+`expected_tool_calls` (`handoff_to_scheduler` @16.4 s, `schedule_appointment`
+`{date: "08/18/2026"}` @27.2 s), clean turn-taking with no overlap.
+
+The start node greets, which is what the industry prompt requires, so this assumes a
+digital human that does **not** speak first. With `speaks_first` the two openers collide
+(measured 2.4 s overlap in run 224638 — recoverable, `goal_success` still true). Bland can
+wait if that ever becomes the default: a `Wait for Response` start node ahead of the
+receptionist keeps the agent silent (verified — 14 s of silence on a probe call vs a
+greeting at 1.4 s without it). Not wired in, since it trades that collision for dead air
+in the normal case. `wait_for_greeting` is a `/v1/calls` field only; web agents drop it.

--- a/voice-agent-harnesses/bland/adapters/chirp.py
+++ b/voice-agent-harnesses/bland/adapters/chirp.py
@@ -1,0 +1,232 @@
+"""CHIRP (16 kHz PCM) ↔ Bland stream-v2 (44.1 kHz PCM), plus the tool webhook.
+
+Bland's browser transport is undocumented; this is what probing it established:
+raw binary PCM16 mono in **both** directions with no JSON envelope, at **44100 Hz**
+(16 kHz in is transcribed as noise), interleaved with JSON status frames
+(`{"event":"update","payload":{"type":"assistant"|"human","text":...}}`,
+`{"event":"mark"}`). So both directions are resampled with `audioop.ratecv`.
+
+Agent audio is *continuous* — Bland streams silence between turns — so a
+silence-gap-on-frames heuristic can't bracket `agent.speech`; an RMS gate can.
+
+One uvicorn app serves both halves so a single cloudflared tunnel covers them:
+`/` is CHIRP, `/tool/{name}` is what Bland's pathway Webhook nodes call, which is
+where `execute_tool` spans get their real timing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import audioop
+import base64
+import contextlib
+import json
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import websockets
+from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from harness import ensure_agent, industry_path, load_blueprint, run_tool, session_ws_url  # noqa: E402
+from report import end_speech_span, start_speech_span, traced_run  # noqa: E402
+
+W, R_BLAND, R_CHIRP = 2, 44_100, 16_000
+# Bland streams silence between turns, so agent turns are bracketed by loudness.
+AGENT_RMS_ON = int(os.environ.get("BLAND_AGENT_RMS_ON", "400"))
+AGENT_SILENCE_S = float(os.environ.get("BLAND_AGENT_SILENCE_S", "0.8"))
+
+app = FastAPI(title="mivas bland chirp bridge")
+CFG: dict[str, str] = {}
+
+
+def _auth() -> str | None:
+    u, p = os.environ.get("CHIRP_USER", "").strip(), os.environ.get("CHIRP_PASS", "").strip()
+    return f"Basic {base64.b64encode(f'{u}:{p}'.encode()).decode()}" if u and p else None
+
+
+def _event(t: str, data: dict) -> str:
+    return json.dumps(
+        {"type": t, "id": str(uuid.uuid4()), "ts_ms": int(time.time() * 1000), "data": data},
+        separators=(",", ":"),
+    )
+
+
+@app.post("/tool/{name}")
+async def tool_webhook(name: str, request: Request) -> dict:
+    """Bland's pathway Webhook nodes call this server-side, mid-call.
+
+    ponytail: the span binds to report.py's module-level active root, i.e. the one
+    in-flight call. Benchmark runs are max_concurrent=1; carry the sim id in the
+    node body and look the root up per call if that ever stops being true.
+    """
+    try:
+        args = await request.json()
+    except Exception:
+        args = {}
+    result = await run_tool(name, {k: v for k, v in (args or {}).items() if v not in (None, "")})
+    print(f"chirp tool {name} args={args} -> {result}", flush=True)
+    return result
+
+
+@app.websocket("/")
+async def chirp(ws: WebSocket) -> None:
+    if (expected := _auth()) and ws.headers.get("authorization") != expected:
+        await ws.close(1008, "unauthorized")
+        return
+    await ws.accept()
+    sim_id = ws.headers.get("x-simulation-result-id")
+    if sim_id:
+        print(f"chirp sim_result_id={sim_id}", flush=True)
+    try:
+        await _bridge(ws, sim_id)
+    except WebSocketDisconnect:
+        pass
+    except Exception as e:
+        print(f"chirp bridge error: {type(e).__name__}: {e}", flush=True)
+        with contextlib.suppress(Exception):
+            await ws.close(1011, "bridge error")
+
+
+async def _bridge(ws: WebSocket, sim_id: str | None) -> None:
+    model, industry = CFG["model"], CFG["industry"]
+    workflow = f"mivas-{Path(industry_path(industry)).name}-{model}"
+    url = await session_ws_url(CFG["agent_id"])
+    end = asyncio.Event()
+    sent = {"to_bland": 0, "to_chirp": 0}
+
+    async with traced_run(workflow, simulation_result_id=sim_id, model=model):
+        async with websockets.connect(url, max_size=None) as bland:
+
+            async def inbound() -> None:
+                """chirp 16 kHz pcm → Bland 44.1 kHz; Bluejay speech.* → customer.speech."""
+                up = None
+                customer = None
+
+                def _close_customer() -> None:
+                    nonlocal customer
+                    end_speech_span(customer)
+                    customer = None
+
+                try:
+                    while not end.is_set():
+                        msg = await ws.receive()
+                        if msg["type"] == "websocket.disconnect":
+                            break
+                        if (pcm := msg.get("bytes")):
+                            out, up = audioop.ratecv(pcm, W, 1, R_CHIRP, R_BLAND, up)
+                            if out:
+                                await bland.send(out)
+                                sent["to_bland"] += len(out)
+                            continue
+                        if not msg.get("text"):
+                            continue
+                        try:
+                            event = json.loads(msg["text"])
+                        except json.JSONDecodeError:
+                            continue
+                        etype = event.get("type")
+                        if etype == "speech.started":
+                            _close_customer()
+                            uid = (event.get("data") or {}).get("utterance_id") or f"c_{uuid.uuid4().hex[:12]}"
+                            customer = start_speech_span(uid, speaker="customer")
+                        elif etype == "speech.completed":
+                            _close_customer()
+                finally:
+                    _close_customer()
+                    end.set()
+                    with contextlib.suppress(Exception):
+                        await bland.close()
+
+            async def outbound() -> None:
+                """Bland 44.1 kHz pcm → chirp 16 kHz; RMS gate drives agent.speech."""
+                down = None
+                utt: str | None = None
+                speech = None
+                last_loud = 0.0
+
+                async def _close_utt() -> None:
+                    nonlocal utt, speech
+                    if utt:
+                        with contextlib.suppress(Exception):
+                            await ws.send_text(_event("speech.completed", {"utterance_id": utt}))
+                    end_speech_span(speech)
+                    utt, speech = None, None
+
+                try:
+                    async for msg in bland:
+                        if end.is_set():
+                            break
+                        if isinstance(msg, str):
+                            # `payload` is a dict for update frames, a bare string for callID.
+                            payload = (json.loads(msg) or {}).get("payload")
+                            if isinstance(payload, dict) and payload.get("text"):
+                                print(f"bland {payload.get('type')}: {payload['text']}", flush=True)
+                            continue
+                        if not msg:
+                            continue
+                        now = time.monotonic()
+                        if audioop.rms(msg, W) >= AGENT_RMS_ON:
+                            last_loud = now
+                            if utt is None:
+                                utt = f"u_{uuid.uuid4().hex[:12]}"
+                                speech = start_speech_span(utt, speaker="agent")
+                                await ws.send_text(_event("speech.started", {"utterance_id": utt}))
+                        elif utt and now - last_loud > AGENT_SILENCE_S:
+                            await _close_utt()
+                        out, down = audioop.ratecv(msg, W, 1, R_BLAND, R_CHIRP, down)
+                        if out:
+                            await ws.send_bytes(out)
+                            sent["to_chirp"] += len(out)
+                finally:
+                    await _close_utt()
+                    end.set()
+                    with contextlib.suppress(Exception):
+                        await ws.close(1000)
+
+            tasks = [asyncio.create_task(inbound()), asyncio.create_task(outbound())]
+            done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            for t in pending:
+                t.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+            print(
+                f"chirp audio bytes to_bland={sent['to_bland']} to_chirp={sent['to_chirp']}",
+                flush=True,
+            )
+            for t in done:
+                exc = None if t.cancelled() else t.exception()
+                if exc is not None and not type(exc).__name__.startswith(
+                    ("ConnectionClosed", "WebSocketDisconnect")
+                ):
+                    raise exc
+
+
+def main(model: str | None = None) -> None:
+    import uvicorn
+
+    p = argparse.ArgumentParser()
+    p.add_argument("--model", default=model or os.environ.get("BLAND_MODEL", "base"))
+    p.add_argument("--industry", default=os.environ.get("INDUSTRY", "control-industry"))
+    p.add_argument("--host", default=os.environ.get("CHIRP_HOST", "0.0.0.0"))
+    p.add_argument("--port", type=int, default=int(os.environ.get("CHIRP_PORT", "8772")))
+    p.add_argument("--public-url", default=os.environ.get("PUBLIC_URL", ""))
+    a = p.parse_args()
+    if not a.public_url:
+        raise SystemExit("need PUBLIC_URL (the https cloudflared URL) — Bland calls tools back over it")
+
+    ids = ensure_agent(a.industry, a.public_url)
+    CFG.update(model=a.model, industry=a.industry, agent_id=ids["agent_id"])
+    print(
+        f"ws↔Bland {a.model} × {a.industry} :{a.port} auth={bool(_auth())} "
+        f"agent={ids['agent_id']} pathway={ids['pathway_id']} tools={a.public_url}/tool/*",
+        flush=True,
+    )
+    uvicorn.run(app, host=a.host, port=a.port, log_level="warning")
+
+
+if __name__ == "__main__":
+    main()

--- a/voice-agent-harnesses/bland/base/adapters/chirp.py
+++ b/voice-agent-harnesses/bland/base/adapters/chirp.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from adapters.chirp import main  # noqa: E402
+
+if __name__ == "__main__":
+    main(model="base")

--- a/voice-agent-harnesses/bland/base/agent.py
+++ b/voice-agent-harnesses/bland/base/agent.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import os
 import sys
 import time
 from pathlib import Path
@@ -31,16 +32,25 @@ def check(industry: str) -> None:
     assert nodes["book"]["data"]["extractVars"][0][0] == "date"
     # Default nodes route on edge descriptions, Webhook nodes on responsePathways.
     hops = {(e["source"], e["target"]) for e in graph["edges"]}
-    assert hops == {("receptionist", "handoff"), ("scheduler", "book")}, hops
+    assert hops == {
+        ("receptionist", "handoff"),
+        ("scheduler", "book"),
+        ("receptionist", "end_receptionist"),
+        ("scheduler", "end_scheduler"),
+    }, hops
     # top-level, not under `data` — Bland drops nested edge fields
     assert all(e.get("description") and "data" not in e for e in graph["edges"])
     assert [
         (n, nodes[n]["data"]["responsePathways"][0][3]["id"]) for n in ("handoff", "book")
     ] == [("handoff", "scheduler"), ("book", "end")]
+    assert nodes["book"]["data"]["responsePathways"][1][3]["id"] == "scheduler"
     print(f"ok — {len(graph['nodes'])} nodes, {len(graph['edges'])} edges")
 
 
 async def call(industry: str, public_url: str, seconds: float) -> None:
+    public_url = os.environ.get("PUBLIC_URL", "").strip() or public_url
+    if not public_url:
+        raise SystemExit("need PUBLIC_URL (cloudflared https url) — Bland calls tools over HTTPS")
     ids = ensure_agent(industry, public_url)
     print(f"agent={ids['agent_id']} pathway={ids['pathway_id']}", flush=True)
     frame = b"\x00\x00" * 882  # 20 ms of 44.1 kHz silence
@@ -64,15 +74,19 @@ async def call(industry: str, public_url: str, seconds: float) -> None:
                 else:
                     print(f"{time.monotonic() - t0:6.2f} {msg[:240]}", flush=True)
 
-        await asyncio.gather(send(), recv(), return_exceptions=True)
+        results = await asyncio.gather(send(), recv(), return_exceptions=True)
+        for result in results:
+            if isinstance(result, BaseException):
+                raise result
         print(f"agent audio bytes={audio}", flush=True)
+        assert audio > 0, "provider session produced no audio"
 
 
 if __name__ == "__main__":
     p = argparse.ArgumentParser()
     p.add_argument("industry", nargs="?", default="control-industry")
     p.add_argument("--check", action="store_true")
-    p.add_argument("--public-url", default="https://example.test")
+    p.add_argument("--public-url", default="")
     p.add_argument("--seconds", type=float, default=15.0)
     a = p.parse_args()
     if a.check:

--- a/voice-agent-harnesses/bland/base/agent.py
+++ b/voice-agent-harnesses/bland/base/agent.py
@@ -1,0 +1,81 @@
+"""Local smoke for the Bland `base` runtime.
+
+`--check` is offline: blueprint → pathway graph, asserting the receptionist →
+handoff → scheduler → schedule_appointment → End Call chain and that the webhook
+nodes point at PUBLIC_URL. Without it, run a real call (silence in) and print
+whatever the agent says, which proves authorize + stream-v2 + the pathway boot.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import sys
+import time
+from pathlib import Path
+
+import websockets
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from harness import ensure_agent, load_blueprint, pathway_graph, session_ws_url  # noqa: E402
+
+
+def check(industry: str) -> None:
+    graph = pathway_graph(load_blueprint(industry), "https://example.test")
+    nodes = {n["id"]: n for n in graph["nodes"]}
+    assert nodes["receptionist"]["data"]["isStart"], "receptionist must be the start node"
+    assert nodes["end"]["type"] == "End Call"
+    for nid, tool in (("handoff", "handoff_to_scheduler"), ("book", "schedule_appointment")):
+        assert nodes[nid]["type"] == "Webhook"
+        assert nodes[nid]["data"]["url"] == f"https://example.test/tool/{tool}", nodes[nid]
+    assert nodes["book"]["data"]["extractVars"][0][0] == "date"
+    # Default nodes route on edge descriptions, Webhook nodes on responsePathways.
+    hops = {(e["source"], e["target"]) for e in graph["edges"]}
+    assert hops == {("receptionist", "handoff"), ("scheduler", "book")}, hops
+    # top-level, not under `data` — Bland drops nested edge fields
+    assert all(e.get("description") and "data" not in e for e in graph["edges"])
+    assert [
+        (n, nodes[n]["data"]["responsePathways"][0][3]["id"]) for n in ("handoff", "book")
+    ] == [("handoff", "scheduler"), ("book", "end")]
+    print(f"ok — {len(graph['nodes'])} nodes, {len(graph['edges'])} edges")
+
+
+async def call(industry: str, public_url: str, seconds: float) -> None:
+    ids = ensure_agent(industry, public_url)
+    print(f"agent={ids['agent_id']} pathway={ids['pathway_id']}", flush=True)
+    frame = b"\x00\x00" * 882  # 20 ms of 44.1 kHz silence
+    async with websockets.connect(await session_ws_url(ids["agent_id"]), max_size=None) as ws:
+        t0, audio = time.monotonic(), 0
+
+        async def send() -> None:
+            while time.monotonic() - t0 < seconds:
+                await ws.send(frame)
+                await asyncio.sleep(0.02)
+
+        async def recv() -> None:
+            nonlocal audio
+            while time.monotonic() - t0 < seconds:
+                try:
+                    msg = await asyncio.wait_for(ws.recv(), timeout=1.0)
+                except asyncio.TimeoutError:
+                    continue
+                if isinstance(msg, bytes):
+                    audio += len(msg)
+                else:
+                    print(f"{time.monotonic() - t0:6.2f} {msg[:240]}", flush=True)
+
+        await asyncio.gather(send(), recv(), return_exceptions=True)
+        print(f"agent audio bytes={audio}", flush=True)
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("industry", nargs="?", default="control-industry")
+    p.add_argument("--check", action="store_true")
+    p.add_argument("--public-url", default="https://example.test")
+    p.add_argument("--seconds", type=float, default=15.0)
+    a = p.parse_args()
+    if a.check:
+        check(a.industry)
+    else:
+        asyncio.run(call(a.industry, a.public_url, a.seconds))

--- a/voice-agent-harnesses/bland/harness.py
+++ b/voice-agent-harnesses/bland/harness.py
@@ -119,6 +119,7 @@ def _webhook_node(
     public_url: str,
     *,
     next_node: tuple[str, str],
+    failure_node: tuple[str, str] | None = None,
     response_data: list[dict[str, str]] | None = None,
 ) -> dict[str, Any]:
     """A tool as a Webhook node.
@@ -146,8 +147,20 @@ def _webhook_node(
                     "",
                     "",
                     {"id": next_node[0], "name": next_node[1]},
+                ],
+            ]
+            + (
+                [
+                    [
+                        "Default/Webhook Failure",
+                        "",
+                        "",
+                        {"id": failure_node[0], "name": failure_node[1]},
+                    ]
                 ]
-            ],
+                if failure_node
+                else []
+            ),
         },
     }
 
@@ -203,6 +216,7 @@ def pathway_graph(bp: dict[str, Any], public_url: str) -> dict[str, Any]:
             booking_spec,
             public_url,
             next_node=("end", "end_call"),
+            failure_node=("scheduler", target["name"]),
             response_data=[{"name": "{{booked_date}}", "data": "$.date", "context": ""}],
         ),
         {
@@ -212,6 +226,24 @@ def pathway_graph(bp: dict[str, Any], public_url: str) -> dict[str, Any]:
                 "name": "end_call",
                 "prompt": "Confirm the repair appointment is booked for {{booked_date}}, "
                 "say goodbye, and end the call.",
+                "modelOptions": {"skipUserResponse": True},
+            },
+        },
+        {
+            "id": "end_receptionist",
+            "type": "End Call",
+            "data": {
+                "name": "end_call_receptionist",
+                "prompt": "Say goodbye and end the call.",
+                "modelOptions": {"skipUserResponse": True},
+            },
+        },
+        {
+            "id": "end_scheduler",
+            "type": "End Call",
+            "data": {
+                "name": "end_call_scheduler",
+                "prompt": "Say goodbye and end the call.",
                 "modelOptions": {"skipUserResponse": True},
             },
         },
@@ -236,6 +268,22 @@ def pathway_graph(bp: dict[str, Any], public_url: str) -> dict[str, Any]:
             "or agreed on, so the appointment can be booked. Do not take it while the "
             "date is still vague (\"next week\", \"soon\").",
         },
+        {
+            "id": "e_end_receptionist",
+            "source": "receptionist",
+            "target": "end_receptionist",
+            "label": "receptionist → end_call",
+            "description": "Take this path when the caller is done, says goodbye, or says "
+            "this is a wrong number.",
+        },
+        {
+            "id": "e_end_scheduler",
+            "source": "scheduler",
+            "target": "end_scheduler",
+            "label": "scheduler → end_call",
+            "description": "Take this path when the caller is done, says goodbye, or says "
+            "this is a wrong number.",
+        },
     ]
     return {"nodes": nodes, "edges": edges}
 
@@ -259,6 +307,15 @@ def ensure_agent(industry_dir: str | Path, public_url: str) -> dict[str, str]:
     industry_name = Path(bp["industry_dir"]).name
     cache = _load_cache()
     entry = dict(cache.get(industry_name) or {})
+    agent_config = {
+        "prompt": bp["agents"][bp["start"]]["instructions"],
+        "pathway_id": entry.get("pathway_id"),
+        "voice": DEFAULT_VOICE,
+        "model": DEFAULT_MODEL,
+        "language": "ENG",
+        "max_duration": MAX_DURATION_MIN,
+        "interruption_threshold": INTERRUPTION_THRESHOLD,
+    }
 
     if not entry.get("pathway_id"):
         r = httpx.post(
@@ -283,19 +340,20 @@ def ensure_agent(industry_dir: str | Path, public_url: str) -> dict[str, str]:
         r = httpx.post(
             f"{API_BASE}/v1/agents",
             headers=_headers(),
-            json={
-                "prompt": bp["agents"][bp["start"]]["instructions"],  # ignored once pathway_id is set
-                "pathway_id": entry["pathway_id"],
-                "voice": DEFAULT_VOICE,
-                "model": DEFAULT_MODEL,
-                "language": "ENG",
-                "max_duration": MAX_DURATION_MIN,
-                "interruption_threshold": INTERRUPTION_THRESHOLD,
-            },
+            json={**agent_config, "pathway_id": entry["pathway_id"]},
             timeout=30.0,
         )
         r.raise_for_status()
         entry["agent_id"] = r.json()["agent"]["agent_id"]
+    else:
+        agent_config["pathway_id"] = entry["pathway_id"]
+        r = httpx.patch(
+            f"{API_BASE}/v1/agents/{entry['agent_id']}",
+            headers=_headers(),
+            json=agent_config,
+            timeout=30.0,
+        )
+        r.raise_for_status()
 
     cache[industry_name] = entry
     AGENT_CACHE_PATH.write_text(json.dumps(cache, indent=2) + "\n")
@@ -327,7 +385,7 @@ async def _execute_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
 
 async def run_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
     """Execute a pathway webhook call under an execute_tool span. Never raises."""
-    from report import call_offset_ms, finish_tool_span, tool_span
+    from report import finish_tool_span, tool_span
     with tool_span(name, args) as span:
         try:
             result = await _execute_tool(name, args)

--- a/voice-agent-harnesses/bland/harness.py
+++ b/voice-agent-harnesses/bland/harness.py
@@ -1,0 +1,340 @@
+"""Blueprint → Bland Conversational Pathway (their native multi-agent).
+
+Bland is fully in-house (own STT/LLM/TTS), so there is nothing to pin per
+component — the knobs are `model` ("base": every feature; "turbo" trades
+features for latency), the voice, and `interruption_threshold`.
+
+Multi-agent on Bland is a **pathway**, not a squad: a node graph where each
+blueprint agent is a Default node and the blueprint's handoff is an edge whose
+label is the transition condition. Industry tools are Webhook nodes that call
+the harness back over HTTPS (`{PUBLIC_URL}/tool/<name>`, served by
+`adapters/chirp.py`) — that inbound request is also what times the
+`execute_tool` span, so the tool has to be provider-side, not client-side.
+
+The tunnel URL is ephemeral, so `ensure_agent` re-pushes the whole graph on
+every chirp boot; only the pathway/agent IDs are cached in `.agents.json`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HARNESS_DIR = Path(__file__).resolve().parent
+TOOL_SERVER_URL = os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
+
+API_BASE = "https://api.bland.ai"
+WS_BASE = os.environ.get("BLAND_WS_BASE", "wss://stream-v2.aws.dc8.bland.ai/ws/connect/blandshared")
+AGENT_CACHE_PATH = HARNESS_DIR / ".agents.json"
+
+# Bland's newest in-house TTS (BTTS_V3), described by them as warm/friendly at a
+# moderate pace for customer support — the closest thing they ship to a
+# production receptionist voice.
+DEFAULT_VOICE = os.environ.get("BLAND_VOICE", "Jordan")
+DEFAULT_MODEL = os.environ.get("BLAND_MODEL", "base")
+# Bland's default is 500 and their own docs recommend 50–200; 500 makes the agent
+# wait so long after the digital human stops that turns collide.
+INTERRUPTION_THRESHOLD = int(os.environ.get("BLAND_INTERRUPTION_THRESHOLD", "150"))
+MAX_DURATION_MIN = int(os.environ.get("BLAND_MAX_DURATION_MIN", "5"))
+
+
+def industry_path(name: str | Path) -> Path:
+    path = Path(name)
+    if path.is_dir():
+        return path.resolve()
+    env_dir = os.environ.get("INDUSTRY_DIR", "").strip()
+    if env_dir and Path(env_dir).is_dir():
+        return Path(env_dir).resolve()
+    return (REPO_ROOT / "industries" / name).resolve()
+
+
+def load_blueprint(industry_dir: str | Path) -> dict[str, Any]:
+    industry_dir = industry_path(industry_dir)
+    blueprint = json.loads((industry_dir / "agent_blueprint.json").read_text())
+    catalog = {t["name"]: t for t in json.loads((industry_dir / "tools.json").read_text())["tools"]}
+    agents = {}
+    for entry in blueprint["agents"]:
+        agents[entry["name"]] = {
+            "name": entry["name"],
+            "instructions": (industry_dir / entry["system_prompt"]).read_text(),
+            "tools": entry["tools"],
+        }
+    return {
+        "industry_dir": industry_dir,
+        "start": blueprint["agents"][0]["name"],
+        "agents": agents,
+        "catalog": catalog,
+    }
+
+
+def _api_key() -> str:
+    key = os.environ.get("BLAND_API_KEY")
+    if not key:
+        raise SystemExit("need BLAND_API_KEY")
+    return key
+
+
+def _headers() -> dict[str, str]:
+    # Bland wants the raw key — no "Bearer" prefix.
+    return {"authorization": _api_key(), "Content-Type": "application/json"}
+
+
+# The industry prompts tell the agent to *call* handoff_to_scheduler / schedule_appointment.
+# A pathway node has no tools — those are edges — so without this note the model reads the
+# tool name out loud ("handoff underscore to scheduler") and never leaves the node.
+PATHWAY_NOTE = """
+
+# Bland pathway
+Tools and handoffs are edges in this pathway, not functions you call. Never say a tool
+name out loud and never announce a transfer or that you are looking something up — say
+your line, and the pathway moves you on by itself.
+"""
+
+
+def _adapt_prompt(instructions: str) -> str:
+    return instructions.rstrip() + PATHWAY_NOTE
+
+
+def _model_options() -> dict[str, Any]:
+    return {"modelName": DEFAULT_MODEL, "interruptionThreshold": INTERRUPTION_THRESHOLD}
+
+
+def _extract_vars(spec: dict[str, Any]) -> list[list[str]]:
+    """tools.json inputSchema → Bland's positional [name, type, description] triples."""
+    schema = spec.get("inputSchema") or {}
+    return [
+        [name, prop.get("type", "string"), prop.get("description", name)]
+        for name, prop in (schema.get("properties") or {}).items()
+    ]
+
+
+def _webhook_node(
+    node_id: str,
+    spec: dict[str, Any],
+    public_url: str,
+    *,
+    next_node: tuple[str, str],
+    response_data: list[dict[str, str]] | None = None,
+) -> dict[str, Any]:
+    """A tool as a Webhook node.
+
+    Webhook nodes do NOT leave via edges — `responsePathways` is their routing,
+    and `["Default/Webhook Completion", "", "", target]` is the unconditional
+    "carry on when the call returns" branch.
+    """
+    variables = _extract_vars(spec)
+    return {
+        "id": node_id,
+        "type": "Webhook",
+        "data": {
+            "name": spec["name"],
+            "url": f"{public_url.rstrip('/')}/tool/{spec['name']}",
+            "method": "POST",
+            "body": json.dumps({v[0]: "{{" + v[0] + "}}" for v in variables}),
+            "extractVars": variables,
+            "responseData": response_data or [],
+            "timeoutValue": 10,
+            "modelOptions": {"skipUserResponse": True},
+            "responsePathways": [
+                [
+                    "Default/Webhook Completion",
+                    "",
+                    "",
+                    {"id": next_node[0], "name": next_node[1]},
+                ]
+            ],
+        },
+    }
+
+
+def pathway_graph(bp: dict[str, Any], public_url: str) -> dict[str, Any]:
+    """Blueprint → {nodes, edges}.
+
+    receptionist ──"caller wants an appointment"──▶ handoff_to_scheduler (Webhook)
+      ──▶ scheduler ──"concrete date agreed"──▶ schedule_appointment (Webhook) ──▶ End Call
+
+    The handoff is a webhook node rather than a bare edge so the transition shows
+    up as a timed `execute_tool` span like every other blueprint tool.
+
+    Routing lives in the edge's `description` (`label` is just the editor's display
+    name), and it has to be sent **top-level on the edge** — Bland silently drops
+    anything you nest under `edge.data` and stores its own `data` copy, so an edge
+    written the way the docs example shows arrives with no description and never fires.
+    """
+    start = bp["agents"][bp["start"]]
+    handoff = next(t for t in start["tools"] if t.get("handoff"))
+    target = bp["agents"][handoff["handoff_to"]]
+    booking = next(t for t in target["tools"] if not t.get("session") and not t.get("handoff"))
+    booking_spec = bp["catalog"][booking["name"]]
+
+    nodes = [
+        {
+            "id": "receptionist",
+            "type": "Default",
+            "data": {
+                "name": start["name"],
+                "prompt": _adapt_prompt(start["instructions"]),
+                "isStart": True,
+                "modelOptions": _model_options(),
+            },
+        },
+        _webhook_node(
+            "handoff",
+            bp["catalog"][handoff["name"]],
+            public_url,
+            next_node=("scheduler", target["name"]),
+        ),
+        {
+            "id": "scheduler",
+            "type": "Default",
+            "data": {
+                "name": target["name"],
+                "prompt": _adapt_prompt(target["instructions"]),
+                "modelOptions": _model_options(),
+            },
+        },
+        _webhook_node(
+            "book",
+            booking_spec,
+            public_url,
+            next_node=("end", "end_call"),
+            response_data=[{"name": "{{booked_date}}", "data": "$.date", "context": ""}],
+        ),
+        {
+            "id": "end",
+            "type": "End Call",
+            "data": {
+                "name": "end_call",
+                "prompt": "Confirm the repair appointment is booked for {{booked_date}}, "
+                "say goodbye, and end the call.",
+                "modelOptions": {"skipUserResponse": True},
+            },
+        },
+    ]
+    # Webhook nodes route via responsePathways, so the only edges are the two
+    # LLM-decided transitions out of the Default nodes.
+    edges = [
+        {
+            "id": "e_handoff",
+            "source": "receptionist",
+            "target": "handoff",
+            "label": "receptionist → scheduler",
+            "description": "Take this path as soon as the caller says they want to "
+            "schedule, book, or set up a repair appointment.",
+        },
+        {
+            "id": "e_book",
+            "source": "scheduler",
+            "target": "book",
+            "label": "scheduler → schedule_appointment",
+            "description": "Take this path once a concrete calendar date has been given "
+            "or agreed on, so the appointment can be booked. Do not take it while the "
+            "date is still vague (\"next week\", \"soon\").",
+        },
+    ]
+    return {"nodes": nodes, "edges": edges}
+
+
+def _load_cache() -> dict[str, Any]:
+    if not AGENT_CACHE_PATH.exists():
+        return {}
+    try:
+        return json.loads(AGENT_CACHE_PATH.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def ensure_agent(industry_dir: str | Path, public_url: str) -> dict[str, str]:
+    """Create-or-reuse the pathway + web agent, then re-push the graph.
+
+    Re-pushing is not an optimization skip: the webhook nodes carry this run's
+    cloudflared URL, which changes every boot.
+    """
+    bp = load_blueprint(industry_dir)
+    industry_name = Path(bp["industry_dir"]).name
+    cache = _load_cache()
+    entry = dict(cache.get(industry_name) or {})
+
+    if not entry.get("pathway_id"):
+        r = httpx.post(
+            f"{API_BASE}/v1/convo_pathway/create",
+            headers=_headers(),
+            json={"name": f"mivas-{industry_name}", "description": "MIVAS bench control industry"},
+            timeout=30.0,
+        )
+        r.raise_for_status()
+        entry["pathway_id"] = r.json()["data"]["pathway_id"]
+
+    graph = pathway_graph(bp, public_url)
+    r = httpx.post(
+        f"{API_BASE}/v1/pathway/{entry['pathway_id']}",
+        headers=_headers(),
+        json={"name": f"mivas-{industry_name}", **graph},
+        timeout=60.0,
+    )
+    r.raise_for_status()
+
+    if not entry.get("agent_id"):
+        r = httpx.post(
+            f"{API_BASE}/v1/agents",
+            headers=_headers(),
+            json={
+                "prompt": bp["agents"][bp["start"]]["instructions"],  # ignored once pathway_id is set
+                "pathway_id": entry["pathway_id"],
+                "voice": DEFAULT_VOICE,
+                "model": DEFAULT_MODEL,
+                "language": "ENG",
+                "max_duration": MAX_DURATION_MIN,
+                "interruption_threshold": INTERRUPTION_THRESHOLD,
+            },
+            timeout=30.0,
+        )
+        r.raise_for_status()
+        entry["agent_id"] = r.json()["agent"]["agent_id"]
+
+    cache[industry_name] = entry
+    AGENT_CACHE_PATH.write_text(json.dumps(cache, indent=2) + "\n")
+    return entry
+
+
+async def session_ws_url(agent_id: str) -> str:
+    """Mint a single-use session token and build the stream URL for one call."""
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        r = await client.post(
+            f"{API_BASE}/v1/agents/{agent_id}/authorize", headers={"authorization": _api_key()}
+        )
+        r.raise_for_status()
+        token = r.json()["token"]
+    return f"{WS_BASE}?agent={agent_id}&token={token}"
+
+
+async def _execute_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Industry tools hit the tool server; the handoff node has no state to write."""
+    if name == "schedule_appointment":
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(f"{TOOL_SERVER_URL}/appointments", json={"date": args["date"]})
+            resp.raise_for_status()
+            return {"success": True, "date": resp.json()["date"]}
+    if name == "handoff_to_scheduler":
+        return {"success": True}
+    return {"success": False, "error": f"unknown tool {name}"}
+
+
+async def run_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Execute a pathway webhook call under an execute_tool span. Never raises."""
+    from report import call_offset_ms, finish_tool_span, tool_span
+
+    offset = call_offset_ms()
+    with tool_span(name, args) as span:
+        try:
+            result = await _execute_tool(name, args)
+            ok = bool(result.get("success"))
+        except Exception as e:
+            result, ok = {"success": False, "error": f"{type(e).__name__}: {e}"}, False
+        finish_tool_span(span, result, ok=ok, name=name, parameters=args, start_offset_ms=offset)
+        return result

--- a/voice-agent-harnesses/bland/harness.py
+++ b/voice-agent-harnesses/bland/harness.py
@@ -328,13 +328,11 @@ async def _execute_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
 async def run_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
     """Execute a pathway webhook call under an execute_tool span. Never raises."""
     from report import call_offset_ms, finish_tool_span, tool_span
-
-    offset = call_offset_ms()
     with tool_span(name, args) as span:
         try:
             result = await _execute_tool(name, args)
             ok = bool(result.get("success"))
         except Exception as e:
             result, ok = {"success": False, "error": f"{type(e).__name__}: {e}"}, False
-        finish_tool_span(span, result, ok=ok, name=name, parameters=args, start_offset_ms=offset)
+        finish_tool_span(span, result, ok=ok)
         return result

--- a/voice-agent-harnesses/bland/report.py
+++ b/voice-agent-harnesses/bland/report.py
@@ -1,0 +1,556 @@
+"""OpenTelemetry → Bluejay OTLP for Bland harnesses.
+
+Bland has no Agents-SDK span tree, so we emit GenAI-native spans:
+
+  voice.call (root) — gen_ai.provider.name=bland
+    ├── agent.speech          (RMS-gated: Bland streams silence between turns)
+    ├── customer.speech       (from inbound Bluejay speech.started/completed)
+    └── execute_tool <name>   (gen_ai.tool.*; emitted by the /tool webhook)
+
+After the call we POST to update-simulation-result with:
+  - trace_ids  → waterfall flamegraph
+  Conversation tool markers come from execute_tool OTel spans (not a tool_calls POST).
+
+Chirp supplies simulation_result_id via X-Simulation-Result-Id on upgrade.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+from contextlib import asynccontextmanager, contextmanager
+from contextvars import ContextVar
+from typing import Any, AsyncIterator, Iterator
+
+import httpx
+from opentelemetry import trace as otel_trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.trace import Span, SpanKind, Status, StatusCode
+
+logger = logging.getLogger("mivas.otel.bland")
+if not logger.handlers:
+    _h = logging.StreamHandler(sys.stdout)
+    _h.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+    logger.addHandler(_h)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+DEFAULT_OTLP_ENDPOINT = "https://otlp.getbluejay.ai/v1/traces"
+DEFAULT_API_URL = "https://api.getbluejay.ai/v1"
+FINAL_STATUSES = {
+    "COMPLETED",
+    "FAILED",
+    "SYSTEM_ERROR",
+    "NO_ANSWER",
+    "CANCELLED",
+    "NO_CONNECTION",
+}
+EARLY_UPSERT_STATUSES = {"EVALUATING", "EVALUATED", "CONVERSATION_ENDED"}
+PROVIDER = "bland"
+TRACER_NAME = "mivas.bland"
+
+_provider: TracerProvider | None = None
+_root_span: ContextVar[Span | None] = ContextVar("mivas_bland_otel_root", default=None)
+_call_t0: ContextVar[float | None] = ContextVar("mivas_bland_otel_t0", default=None)
+_reported_tools: ContextVar[list[dict[str, Any]] | None] = ContextVar(
+    "mivas_bland_reported_tools", default=None
+)
+# module fallbacks when asyncio tasks don't inherit ContextVars
+_active_root: Span | None = None
+_active_t0: float | None = None
+_active_tools: list[dict[str, Any]] | None = None
+
+
+def _api_url() -> str:
+    return os.environ.get("BLUEJAY_API_URL", DEFAULT_API_URL).rstrip("/")
+
+
+def _otlp_endpoint() -> str:
+    return os.environ.get("BLUEJAY_OTLP_ENDPOINT", DEFAULT_OTLP_ENDPOINT)
+
+
+def _service_name() -> str:
+    return os.environ.get("BLUEJAY_SERVICE_NAME", "mivas-bland")
+
+
+def _api_key() -> str | None:
+    return os.environ.get("BLUEJAY_API_KEY") or None
+
+
+def _json_attr(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, default=str)
+    except Exception:
+        return str(value)
+
+
+def call_offset_ms() -> int:
+    t0 = _call_t0.get()
+    if t0 is None:
+        t0 = _active_t0
+    if t0 is None:
+        return 0
+    return max(0, int((time.monotonic() - t0) * 1000))
+
+
+def setup_otel() -> TracerProvider | None:
+    """Install global OTel exporter to Bluejay OTLP. No-op without BLUEJAY_API_KEY."""
+    global _provider
+
+    api_key = _api_key()
+    if not api_key:
+        return None
+
+    if _provider is not None:
+        return _provider
+
+    endpoint = _otlp_endpoint()
+    resource = Resource.create({SERVICE_NAME: _service_name()})
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(
+        SimpleSpanProcessor(
+            OTLPSpanExporter(endpoint, headers={"X-API-KEY": api_key})
+        )
+    )
+    otel_trace.set_tracer_provider(provider)
+    _provider = provider
+    logger.info("otel → %s service=%s", endpoint, _service_name())
+    return provider
+
+
+def flush() -> None:
+    if _provider is not None:
+        try:
+            _provider.force_flush()
+        except Exception as e:
+            logger.error("otel flush failed: %s", e)
+
+
+def _parent_span() -> Span | None:
+    parent = _root_span.get()
+    if parent is not None and parent.get_span_context().is_valid:
+        return parent
+    if _active_root is not None and _active_root.get_span_context().is_valid:
+        return _active_root
+    cur = otel_trace.get_current_span()
+    if cur is not None and cur.get_span_context().is_valid:
+        return cur
+    return None
+
+
+def record_tool_call(
+    name: str,
+    parameters: Any,
+    output: Any,
+    *,
+    start_offset_ms: int | None = None,
+) -> None:
+    """Buffer a tool call for the end-of-call update-simulation-result POST."""
+    tools = _reported_tools.get()
+    if tools is None:
+        tools = _active_tools
+    if tools is None:
+        return
+    tools.append(
+        {
+            "name": str(name),
+            "parameters": parameters if isinstance(parameters, dict) else {"raw": parameters},
+            "output": output,
+            "start_offset_ms": int(
+                start_offset_ms if start_offset_ms is not None else call_offset_ms()
+            ),
+        }
+    )
+
+
+@contextmanager
+def tool_span(
+    name: str,
+    parameters: Any = None,
+    *,
+    call_id: str | None = None,
+) -> Iterator[Span | None]:
+    """Child span under the active voice.call root. No-op outside traced_run."""
+    parent = _parent_span()
+    if parent is None:
+        yield None
+        return
+
+    tracer = otel_trace.get_tracer(TRACER_NAME)
+    parent_ctx = otel_trace.set_span_in_context(parent)
+    attrs: dict[str, Any] = {
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.provider.name": PROVIDER,
+        "gen_ai.tool.name": name,
+        "gen_ai.tool.call.arguments": _json_attr(parameters if parameters is not None else {}),
+        # conversation timestamps come from span start vs voice.call (OTel extraction)
+    }
+    if call_id:
+        attrs["gen_ai.tool.call.id"] = str(call_id)
+
+    with tracer.start_as_current_span(
+        f"execute_tool {name}",
+        context=parent_ctx,
+        kind=SpanKind.CLIENT,
+        attributes=attrs,
+    ) as span:
+        try:
+            yield span
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)[:400]))
+            raise
+
+
+def finish_tool_span(
+    span: Span | None,
+    output: Any,
+    *,
+    ok: bool = True,
+    name: str | None = None,
+    parameters: Any = None,
+    start_offset_ms: int | None = None,
+) -> None:
+    if span is not None:
+        span.set_attribute("gen_ai.tool.call.result", _json_attr(output))
+        if ok:
+            span.set_status(Status(StatusCode.OK))
+        else:
+            span.set_status(Status(StatusCode.ERROR, _json_attr(output)[:400]))
+
+
+def start_speech_span(
+    utterance_id: str, *, speaker: str = "agent"
+) -> Span | None:
+    """Begin agent.speech or customer.speech under voice.call."""
+    parent = _parent_span()
+    if parent is None:
+        return None
+    tracer = otel_trace.get_tracer(TRACER_NAME)
+    parent_ctx = otel_trace.set_span_in_context(parent)
+    is_customer = speaker in ("customer", "user", "digital_human")
+    span_name = "customer.speech" if is_customer else "agent.speech"
+    attrs: dict[str, Any] = {
+        "gen_ai.operation.name": (
+            "speech_to_text" if is_customer else "text_to_speech"
+        ),
+        "gen_ai.provider.name": PROVIDER,
+        "mivas.utterance_id": str(utterance_id),
+        "mivas.speech.speaker": "customer" if is_customer else "agent",
+        "bluejay.speech.start_offset_ms": call_offset_ms(),
+    }
+    span = tracer.start_span(
+        span_name,
+        context=parent_ctx,
+        kind=SpanKind.INTERNAL,
+        attributes=attrs,
+    )
+    return span
+
+def end_speech_span(span: Span | None) -> None:
+    if span is None:
+        return
+    span.set_attribute("bluejay.speech.end_offset_ms", call_offset_ms())
+    span.set_status(Status(StatusCode.OK))
+    span.end()
+
+
+async def _await_terminal_upsert(
+    client: httpx.AsyncClient, simulation_result_id: str, timeout: float = 300.0
+) -> str | None:
+    """Wait for a *final* status before the upsert.
+
+    300 s, not 150 s: eval needs ~175 s to settle and anything shorter forces the
+    early-post + relink path below, which double-counts every tool.
+
+    Posting during EVALUATING works, but eval then wipes trace_ids and the relink
+    POST re-extracts the execute_tool spans on top of the ones the first POST
+    already produced — every tool lands on the timeline twice. One POST after the
+    sim settles gives a surviving link and one row per tool; `_relink_after_final`
+    stays as the safety net for when this wait times out.
+    """
+    deadline = time.monotonic() + timeout
+    key = _api_key()
+    if not key:
+        return None
+    while time.monotonic() < deadline:
+        try:
+            r = await client.get(
+                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                headers={"X-API-Key": key},
+            )
+            if r.status_code == 200:
+                st = str(
+                    ((r.json() or {}).get("simulation_result") or {}).get("status")
+                )
+                if st in FINAL_STATUSES:
+                    return st
+        except Exception:
+            pass
+        await asyncio.sleep(1.0)
+    return None
+
+
+async def post_simulation_enrichment(
+    simulation_result_id: str,
+    *,
+    trace_id: str | None,
+    tool_calls: list[dict[str, Any]] | None = None,
+) -> None:
+    """Link OTel trace_ids. tool_calls ignored — use execute_tool spans."""
+    del tool_calls
+    key = _api_key()
+    if not key or not simulation_result_id:
+        logger.warning(
+            "skip update-simulation-result — "
+            "simulation_result_id=%s key=%s",
+            simulation_result_id,
+            bool(key),
+        )
+        return
+    if not str(simulation_result_id).isdigit():
+        logger.warning(
+            "skip update-simulation-result — non-numeric sim id=%s",
+            simulation_result_id,
+        )
+        return
+
+    body: dict[str, Any] = {"simulation_result_id": str(simulation_result_id)}
+    if trace_id:
+        body["trace_ids"] = [trace_id]
+    if "trace_ids" not in body and "tool_calls" not in body:
+        logger.warning("skip update-simulation-result — nothing to post")
+        return
+
+    await asyncio.sleep(0.5)
+
+    last_err: str | None = None
+    for attempt in range(1, 4):
+        try:
+            async with httpx.AsyncClient(timeout=20) as client:
+                st = await _await_terminal_upsert(client, simulation_result_id)
+                if st is None:
+                    check = await client.get(
+                        f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                        headers={"X-API-Key": key},
+                    )
+                    if check.status_code == 404:
+                        logger.warning(
+                            "skip update-simulation-result — sim=%s not found",
+                            simulation_result_id,
+                        )
+                        return
+                r = await client.post(
+                    f"{_api_url()}/update-simulation-result",
+                    json=body,
+                    headers={"X-API-Key": key, "Content-Type": "application/json"},
+                )
+                if r.status_code >= 400:
+                    last_err = f"{r.status_code} {r.text[:300]} (status={st})"
+                    logger.error(
+                        "update-simulation-result FAILED attempt=%s %s",
+                        attempt,
+                        last_err,
+                    )
+                    if r.status_code == 404:
+                        return
+                else:
+                    logger.info(
+                        "update-simulation-result ok trace=%s sim=%s terminal=%s attempt=%s",
+                        trace_id,
+                        simulation_result_id,
+                        st,
+                        attempt,
+                    )
+                    if (st is None or st in EARLY_UPSERT_STATUSES) and trace_id:
+                        await _relink_after_final(
+                            client, simulation_result_id, body, key, trace_id, st
+                        )
+                    return
+        except Exception as e:
+            last_err = f"{type(e).__name__}: {e}"
+            logger.error(
+                "update-simulation-result error attempt=%s %s", attempt, last_err
+            )
+        await asyncio.sleep(1.0 * attempt)
+    logger.error("update-simulation-result gave up: %s", last_err)
+
+
+
+async def _relink_after_final(
+    client: httpx.AsyncClient,
+    simulation_result_id: str,
+    body: dict[str, Any],
+    key: str,
+    trace_id: str,
+    early_status: str | None,
+) -> None:
+    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link).
+
+    Only if it actually got wiped: each POST re-extracts the execute_tool spans and
+    appends them, so a redundant relink double-counts every tool on the timeline.
+    """
+    final: str | None = None
+    linked = False
+    deadline = time.monotonic() + 120.0
+    while time.monotonic() < deadline:
+        try:
+            r = await client.get(
+                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                headers={"X-API-Key": key},
+            )
+            if r.status_code == 200:
+                result = (r.json() or {}).get("simulation_result") or {}
+                st = str(result.get("status"))
+                if st in FINAL_STATUSES:
+                    final = st
+                    linked = trace_id in (result.get("trace_ids") or [])
+                    break
+        except Exception:
+            pass
+        await asyncio.sleep(2.0)
+    if final is not None and linked:
+        logger.info(
+            "relink not needed after %s — trace=%s still linked sim=%s final=%s",
+            early_status,
+            trace_id,
+            simulation_result_id,
+            final,
+        )
+        return
+    if final is None:
+        logger.warning(
+            "relink skipped — still not final after early upsert terminal=%s sim=%s",
+            early_status,
+            simulation_result_id,
+        )
+        return
+    r = await client.post(
+        f"{_api_url()}/update-simulation-result",
+        json=body,
+        headers={"X-API-Key": key, "Content-Type": "application/json"},
+    )
+    if r.status_code >= 400:
+        logger.error(
+            "relink after %s FAILED sim=%s %s %s",
+            early_status,
+            simulation_result_id,
+            r.status_code,
+            r.text[:300],
+        )
+    else:
+        logger.info(
+            "relink after %s ok trace=%s sim=%s final=%s",
+            early_status,
+            trace_id,
+            simulation_result_id,
+            final,
+        )
+
+# back-compat alias used by older call sites
+async def post_trace_ids(simulation_result_id: str, trace_id: str) -> None:
+    await post_simulation_enrichment(
+        simulation_result_id, trace_id=trace_id, tool_calls=_reported_tools.get()
+    )
+
+
+@asynccontextmanager
+async def traced_run(
+    workflow_name: str,
+    *,
+    simulation_result_id: str | None = None,
+    model: str | None = None,
+) -> AsyncIterator[None]:
+    """OTel voice.call root; flush + link trace_ids/tool_calls on exit."""
+    global _active_root, _active_t0, _active_tools
+
+    provider = setup_otel()
+    if provider is None:
+        yield
+        return
+
+    tracer = otel_trace.get_tracer(TRACER_NAME)
+    attrs: dict[str, Any] = {
+        "gen_ai.system": PROVIDER,
+        "gen_ai.provider.name": PROVIDER,
+        "gen_ai.operation.name": "invoke_agent",
+        "mivas.workflow.name": workflow_name,
+    }
+    if model:
+        attrs["gen_ai.request.model"] = model
+    if simulation_result_id:
+        attrs["bluejay.simulation_result_id"] = str(simulation_result_id)
+
+    otel_tid: str | None = None
+    root_token = None
+    tools_token = None
+    t0 = time.monotonic()
+    t0_token = _call_t0.set(t0)
+    tool_buf: list[dict[str, Any]] = []
+    prev_active = _active_root
+    prev_t0 = _active_t0
+    prev_tools = _active_tools
+    try:
+        with tracer.start_as_current_span(
+            "voice.call",
+            kind=SpanKind.SERVER,
+            attributes=attrs,
+        ) as root:
+            root_token = _root_span.set(root)
+            tools_token = _reported_tools.set(tool_buf)
+            _active_root = root
+            _active_t0 = t0
+            _active_tools = tool_buf
+            ctx = root.get_span_context()
+            if ctx.is_valid:
+                otel_tid = format(ctx.trace_id, "032x")
+                logger.info(
+                    "otel trace_id=%s sim=%s workflow=%s model=%s",
+                    otel_tid,
+                    simulation_result_id,
+                    workflow_name,
+                    model,
+                )
+            try:
+                yield
+            except Exception as e:
+                if type(e).__name__.startswith("ConnectionClosed"):
+                    root.set_status(Status(StatusCode.OK))
+                else:
+                    raise
+    finally:
+        _active_root = prev_active
+        _active_t0 = prev_t0
+        _active_tools = prev_tools
+        if root_token is not None:
+            _root_span.reset(root_token)
+        if tools_token is not None:
+            _reported_tools.reset(tools_token)
+        _call_t0.reset(t0_token)
+        flush()
+        if simulation_result_id and (otel_tid or tool_buf):
+            try:
+                await post_simulation_enrichment(
+                    simulation_result_id,
+                    trace_id=otel_tid,
+                                    )
+            except Exception as e:
+                logger.error(
+                    "post_simulation_enrichment crashed: %s: %s",
+                    type(e).__name__,
+                    e,
+                )
+        elif simulation_result_id and not otel_tid:
+            logger.error(
+                "have simulation_result_id=%s but no otel trace id to post",
+                simulation_result_id,
+            )

--- a/voice-agent-harnesses/bland/report.py
+++ b/voice-agent-harnesses/bland/report.py
@@ -52,20 +52,15 @@ FINAL_STATUSES = {
     "CANCELLED",
     "NO_CONNECTION",
 }
-EARLY_UPSERT_STATUSES = {"EVALUATING", "EVALUATED", "CONVERSATION_ENDED"}
 PROVIDER = "bland"
 TRACER_NAME = "mivas.bland"
 
 _provider: TracerProvider | None = None
 _root_span: ContextVar[Span | None] = ContextVar("mivas_bland_otel_root", default=None)
 _call_t0: ContextVar[float | None] = ContextVar("mivas_bland_otel_t0", default=None)
-_reported_tools: ContextVar[list[dict[str, Any]] | None] = ContextVar(
-    "mivas_bland_reported_tools", default=None
-)
 # module fallbacks when asyncio tasks don't inherit ContextVars
 _active_root: Span | None = None
 _active_t0: float | None = None
-_active_tools: list[dict[str, Any]] | None = None
 
 
 def _api_url() -> str:
@@ -147,31 +142,6 @@ def _parent_span() -> Span | None:
     return None
 
 
-def record_tool_call(
-    name: str,
-    parameters: Any,
-    output: Any,
-    *,
-    start_offset_ms: int | None = None,
-) -> None:
-    """Buffer a tool call for the end-of-call update-simulation-result POST."""
-    tools = _reported_tools.get()
-    if tools is None:
-        tools = _active_tools
-    if tools is None:
-        return
-    tools.append(
-        {
-            "name": str(name),
-            "parameters": parameters if isinstance(parameters, dict) else {"raw": parameters},
-            "output": output,
-            "start_offset_ms": int(
-                start_offset_ms if start_offset_ms is not None else call_offset_ms()
-            ),
-        }
-    )
-
-
 @contextmanager
 def tool_span(
     name: str,
@@ -216,9 +186,6 @@ def finish_tool_span(
     output: Any,
     *,
     ok: bool = True,
-    name: str | None = None,
-    parameters: Any = None,
-    start_offset_ms: int | None = None,
 ) -> None:
     if span is not None:
         span.set_attribute("gen_ai.tool.call.result", _json_attr(output))
@@ -272,11 +239,11 @@ async def _await_terminal_upsert(
     300 s, not 150 s: eval needs ~175 s to settle and anything shorter forces the
     early-post + relink path below, which double-counts every tool.
 
-    Posting during EVALUATING works, but eval then wipes trace_ids and the relink
-    POST re-extracts the execute_tool spans on top of the ones the first POST
-    already produced — every tool lands on the timeline twice. One POST after the
-    sim settles gives a surviving link and one row per tool; `_relink_after_final`
-    stays as the safety net for when this wait times out.
+    Posting during EVALUATING works, but eval then wipes trace_ids, and re-posting
+    makes Bluejay re-extract the execute_tool spans on top of the ones the first
+    POST already produced — every tool lands on the timeline twice. One POST after
+    the sim settles gives a surviving link and one row per tool. On timeout we post
+    anyway and log it; we never re-post, because that is the double-count.
     """
     deadline = time.monotonic() + timeout
     key = _api_key()
@@ -304,10 +271,8 @@ async def post_simulation_enrichment(
     simulation_result_id: str,
     *,
     trace_id: str | None,
-    tool_calls: list[dict[str, Any]] | None = None,
 ) -> None:
-    """Link OTel trace_ids. tool_calls ignored — use execute_tool spans."""
-    del tool_calls
+    """Link OTel trace_ids; conversation tools come from execute_tool spans."""
     key = _api_key()
     if not key or not simulation_result_id:
         logger.warning(
@@ -327,7 +292,7 @@ async def post_simulation_enrichment(
     body: dict[str, Any] = {"simulation_result_id": str(simulation_result_id)}
     if trace_id:
         body["trace_ids"] = [trace_id]
-    if "trace_ids" not in body and "tool_calls" not in body:
+    if "trace_ids" not in body:
         logger.warning("skip update-simulation-result — nothing to post")
         return
 
@@ -371,9 +336,12 @@ async def post_simulation_enrichment(
                         st,
                         attempt,
                     )
-                    if (st is None or st in EARLY_UPSERT_STATUSES) and trace_id:
-                        await _relink_after_final(
-                            client, simulation_result_id, body, key, trace_id, st
+                    if st is None:
+                        logger.warning(
+                            "linked without a final status — sim=%s may still be "
+                            "EVALUATING; if eval wipes trace_ids the link is lost "
+                            "(we do not re-post: a second POST double-counts tools)",
+                            simulation_result_id,
                         )
                     return
         except Exception as e:
@@ -386,83 +354,6 @@ async def post_simulation_enrichment(
 
 
 
-async def _relink_after_final(
-    client: httpx.AsyncClient,
-    simulation_result_id: str,
-    body: dict[str, Any],
-    key: str,
-    trace_id: str,
-    early_status: str | None,
-) -> None:
-    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link).
-
-    Only if it actually got wiped: each POST re-extracts the execute_tool spans and
-    appends them, so a redundant relink double-counts every tool on the timeline.
-    """
-    final: str | None = None
-    linked = False
-    deadline = time.monotonic() + 120.0
-    while time.monotonic() < deadline:
-        try:
-            r = await client.get(
-                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
-                headers={"X-API-Key": key},
-            )
-            if r.status_code == 200:
-                result = (r.json() or {}).get("simulation_result") or {}
-                st = str(result.get("status"))
-                if st in FINAL_STATUSES:
-                    final = st
-                    linked = trace_id in (result.get("trace_ids") or [])
-                    break
-        except Exception:
-            pass
-        await asyncio.sleep(2.0)
-    if final is not None and linked:
-        logger.info(
-            "relink not needed after %s — trace=%s still linked sim=%s final=%s",
-            early_status,
-            trace_id,
-            simulation_result_id,
-            final,
-        )
-        return
-    if final is None:
-        logger.warning(
-            "relink skipped — still not final after early upsert terminal=%s sim=%s",
-            early_status,
-            simulation_result_id,
-        )
-        return
-    r = await client.post(
-        f"{_api_url()}/update-simulation-result",
-        json=body,
-        headers={"X-API-Key": key, "Content-Type": "application/json"},
-    )
-    if r.status_code >= 400:
-        logger.error(
-            "relink after %s FAILED sim=%s %s %s",
-            early_status,
-            simulation_result_id,
-            r.status_code,
-            r.text[:300],
-        )
-    else:
-        logger.info(
-            "relink after %s ok trace=%s sim=%s final=%s",
-            early_status,
-            trace_id,
-            simulation_result_id,
-            final,
-        )
-
-# back-compat alias used by older call sites
-async def post_trace_ids(simulation_result_id: str, trace_id: str) -> None:
-    await post_simulation_enrichment(
-        simulation_result_id, trace_id=trace_id, tool_calls=_reported_tools.get()
-    )
-
-
 @asynccontextmanager
 async def traced_run(
     workflow_name: str,
@@ -471,7 +362,7 @@ async def traced_run(
     model: str | None = None,
 ) -> AsyncIterator[None]:
     """OTel voice.call root; flush + link trace_ids/tool_calls on exit."""
-    global _active_root, _active_t0, _active_tools
+    global _active_root, _active_t0
 
     provider = setup_otel()
     if provider is None:
@@ -492,13 +383,10 @@ async def traced_run(
 
     otel_tid: str | None = None
     root_token = None
-    tools_token = None
     t0 = time.monotonic()
     t0_token = _call_t0.set(t0)
-    tool_buf: list[dict[str, Any]] = []
     prev_active = _active_root
     prev_t0 = _active_t0
-    prev_tools = _active_tools
     try:
         with tracer.start_as_current_span(
             "voice.call",
@@ -506,10 +394,8 @@ async def traced_run(
             attributes=attrs,
         ) as root:
             root_token = _root_span.set(root)
-            tools_token = _reported_tools.set(tool_buf)
             _active_root = root
             _active_t0 = t0
-            _active_tools = tool_buf
             ctx = root.get_span_context()
             if ctx.is_valid:
                 otel_tid = format(ctx.trace_id, "032x")
@@ -530,14 +416,11 @@ async def traced_run(
     finally:
         _active_root = prev_active
         _active_t0 = prev_t0
-        _active_tools = prev_tools
         if root_token is not None:
             _root_span.reset(root_token)
-        if tools_token is not None:
-            _reported_tools.reset(tools_token)
         _call_t0.reset(t0_token)
         flush()
-        if simulation_result_id and (otel_tid or tool_buf):
+        if simulation_result_id and otel_tid:
             try:
                 await post_simulation_enrichment(
                     simulation_result_id,

--- a/voice-agent-harnesses/bland/requirements.txt
+++ b/voice-agent-harnesses/bland/requirements.txt
@@ -1,0 +1,7 @@
+httpx>=0.27.0
+websockets>=14.0
+fastapi>=0.115.0
+uvicorn>=0.30.0
+opentelemetry-api>=1.27.0
+opentelemetry-sdk>=1.27.0
+opentelemetry-exporter-otlp-proto-http>=1.27.0

--- a/voice-agent-harnesses/cartesia/README.md
+++ b/voice-agent-harnesses/cartesia/README.md
@@ -1,3 +1,131 @@
-# cartesia
+# Cartesia Line
 
-Benchmarks and evaluation assets for cartesia voice agents.
+Cartesia's [Line](https://github.com/cartesia-ai/line) is code-first: the agent is a Python
+program you deploy to Cartesia, not a JSON assistant config. So this harness has two halves:
+
+| half | where it runs | what it is |
+|---|---|---|
+| `line_agent/` | Cartesia | the Line agent (`VoiceAgentApp`), deployed with the `cartesia` CLI |
+| `adapters/chirp.py` | here | CHIRP ↔ Cartesia stream bridge **and** the tool webhook, one uvicorn port |
+
+`line/` is the runtime folder (`line/agent.py` smoke, `line/adapters/chirp.py` shim).
+
+## Model stack
+
+Line's own stack, not a third-party pipeline: Cartesia **Ink** STT and **Sonic** TTS are the
+platform's and are not selectable from the SDK. Only the LLM is ours (Line routes through
+LiteLLM), pinned to `gpt-4.1` to match the Vapi/Retell harnesses.
+
+| piece | value | override |
+|---|---|---|
+| STT | Cartesia Ink (platform default) | — |
+| TTS | Cartesia Sonic (platform default voice) | `CARTESIA_VOICE_ID` |
+| LLM | `gpt-4.1` via LiteLLM | `MIVAS_MODEL` |
+| greeting | `Welcome to Bluejay's Repair Services!` | `MIVAS_GREETING` |
+
+**Known: Bluejay scores this harness ~36–40 `agent_audio_clarity` vs ~100 for ElevenLabs/Deepgram.**
+Investigated and traced to Sonic's own spectrum, not the bridge — Sonic's agent audio sits ~10 dB
+lower than ElevenLabs/Deepgram TTS in every band above 1 kHz, and the same tilt is present in the
+raw stream before the bridge touches it. Ruled out: dropped/truncated frames, decode errors,
+sample-rate mismatch, and voice choice (pinning `Skylar` scored 36.2 vs 40.3 for the default).
+`output_format` is accepted by the stream API but ignored — output is always pcm_16000.
+
+Multi-agent is native: the blueprint's `handoff_to_scheduler` becomes a Line
+`agent_as_handoff` tool, so the scheduler takes over inside Cartesia with no bridge-side
+routing. `end_call` is Line's built-in.
+
+## Tools
+
+`schedule_appointment` is a Line `http_server_tool` pointed at `{PUBLIC_URL}/tool/schedule_appointment`,
+i.e. back at `adapters/chirp.py`. Tools execute provider-side, so this round trip is what puts the
+appointment in the industry tool server *and* produces the `execute_tool` span. `TOOL_BASE_URL` is
+pushed to the deployed agent with `cartesia env set` and read per call (`get_agent` runs per call),
+so a new cloudflared tunnel needs no redeploy. Handoff and `end_call` never leave Cartesia — those
+spans are reconstructed from `turn_ended.tool_calls`.
+
+## Transport
+
+`wss://api.cartesia.ai/agents/stream/{agent_id}?cartesia_version=2026-03-01`, header
+`Authorization: Bearer $CARTESIA_API_KEY`. All JSON text frames, base64 audio inside:
+
+- client → `{"event":"start","config":{"input_format":"pcm_16000"}}`, then
+  `{"event":"media_input","media":{"payload":"<b64>"}}`
+- server → `ack`, `media_output`, `turn_started`, `turn_output_text_delta`, `turn_ended`
+  (with `text` and `tool_calls`), `clear`
+
+Both directions are pcm_16000 (`media_output` arrives paced at ~33 kB/s ≈ 16 kHz × 2 B), so the
+bridge does no resampling. Turn structure is on the wire, so `agent.speech` spans are bracketed by
+`turn_started`/`turn_ended` rather than a silence-gap heuristic. `websockets` keeps the socket
+alive with its default 20 s ping (the server idles out at 180 s).
+
+## Setup
+
+```bash
+curl -fsSL https://cartesia.sh | sh          # installs ~/.cartesia/bin/cartesia
+cartesia auth login "$CARTESIA_API_KEY"
+```
+
+Env: `CARTESIA_API_KEY`, `OPENAI_API_KEY`, `PUBLIC_URL`, plus the usual
+`BLUEJAY_*` / `CHIRP_*` / `INDUSTRY` / `TOOL_SERVER_URL`.
+Optional: `CARTESIA_VOICE_ID`, `CARTESIA_AGENT_ID` (skip the `.agents.json` cache),
+`CARTESIA_REDEPLOY=1` (force a deploy), `CARTESIA_VERSION`, `CARTESIA_CLI`,
+`CARTESIA_DEPLOY_TIMEOUT`.
+
+## Run
+
+```bash
+# terminal A — industry state (shared; skip if :8000 already answers /health)
+uv run python industries/control-industry/tool_server.py
+
+# terminal B — smoke the deployed agent (deploys on first run, ~2 min)
+set -a && source .env && set +a
+uv run python voice-agent-harnesses/cartesia/line/agent.py control-industry
+
+# terminal C — tunnel, then the bridge (websocket + tool webhook on one port)
+cloudflared tunnel --url http://127.0.0.1:8773 --no-autoupdate
+export PUBLIC_URL=https://<tunnel>.trycloudflare.com
+export CHIRP_USER=mivas CHIRP_PASS=mivas CHIRP_PORT=8773
+export INDUSTRY=control-industry TOOL_SERVER_URL=http://127.0.0.1:8000
+export BLUEJAY_API_KEY=… BLUEJAY_SERVICE_NAME=mivas-cartesia
+uv run python voice-agent-harnesses/cartesia/line/adapters/chirp.py
+```
+
+Bluejay dials `wss://<tunnel>.trycloudflare.com` with basic auth `mivas:mivas`.
+
+`ensure_agent()` does the provider-side work on every boot: bakes the industry prompts into
+`line_agent/blueprint.json`, creates the agent on first run (`cartesia init --new`), pushes
+changed env, deploys, and blocks until `cartesia status <agent_id>` reports `Ready` — a call
+against a still-building version fails.
+
+Deploy by hand:
+
+```bash
+cartesia deploy --agent-id <agent_id> voice-agent-harnesses/cartesia/line_agent
+cartesia status <agent_id>
+```
+
+## Proof run
+
+control-industry, Bluejay agent 30383 / simulation 30210 / DH 194137 (agent speaks first,
+`expected_tool_calls` set), Cartesia agent `agent_5xoxqQDosbz2PbpWvX21gx`:
+
+**simulation_result 710644** — https://app.getbluejay.ai/simulations/30210/runs/224730
+
+`COMPLETED`, 74 s, `goal_success=true`, trace `f28a675fd40855a843c83168b4eb5078` linked on the
+first POST at `terminal=COMPLETED` (no relink). Audio `in=2087680 out=752640` bytes.
+Both DH-expected tools paired with exactly one actual each — `handoff_to_scheduler` @28915 ms,
+`schedule_appointment` @52085 ms (`08/18/2026`, tool-server row id 48).
+
+Greeting → handoff → date confirmation → booking → sign-off, no talk-over:
+
+```
+[ 4880] Agent:  Welcome to Blue Jays Repair Services.
+[ 9779] caller: Hi, I'd like to schedule a repair appointment for next Tuesday afternoon…
+[17135] Agent:  Hey, when do you want to schedule your repair appointment?
+[28990] Agent:  Just to confirm, could you let me know the exact date for next Tuesday?
+[38742] caller: Sure, that would be August eighteenth, twenty twenty six, in the afternoon.
+[46845] Agent:  Your repair appointment is scheduled for 08/18/2026. …
+```
+
+Agent latency runs 1535–2330 ms avg across seven runs of this sim; treat a single run's figure as
+noise, not signal.

--- a/voice-agent-harnesses/cartesia/adapters/chirp.py
+++ b/voice-agent-harnesses/cartesia/adapters/chirp.py
@@ -1,0 +1,282 @@
+"""16 kHz pcm CHIRP bridge ↔ Cartesia Line agent stream, plus the tool webhook.
+
+Cartesia's stream API is all JSON text frames with base64 audio inside, and both
+directions are pcm_16000 (verified: media_output arrives paced at ~32 kB/s), so
+no resampling. Unlike the audio-only providers it also streams turn structure —
+`turn_started` / `turn_ended` with role and final text — so `agent.speech` spans
+are bracketed by real turn events instead of a silence-gap heuristic.
+
+The Line agent runs on Cartesia's infrastructure, so its `schedule_appointment`
+tool reaches the industry state by POSTing back to `/tool/{name}` here. That is
+also where the `execute_tool` span comes from, which is why the websocket and
+the webhook share one uvicorn port: one cloudflared tunnel covers both.
+Line-native tools (handoff, end_call) never leave Cartesia, so those spans are
+reconstructed from `turn_ended.tool_calls`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import contextlib
+import json
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+import uvicorn
+import websockets
+from fastapi import FastAPI, Request, WebSocket
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from harness import ensure_agent, industry_path, load_blueprint, run_tool  # noqa: E402
+from report import (  # noqa: E402
+    end_speech_span,
+    finish_tool_span,
+    start_speech_span,
+    tool_span,
+    traced_run,
+)
+
+STREAM_URL = "wss://api.cartesia.ai/agents/stream/{agent_id}?cartesia_version={version}"
+CARTESIA_VERSION = os.environ.get("CARTESIA_VERSION", "2026-03-01")
+
+app = FastAPI()
+# ponytail: one active call at a time — the webhook attaches its execute_tool
+# span to report.py's module-level root. Benchmark runs are max_concurrent=1.
+STATE: dict[str, Any] = {}
+
+
+def _start_config() -> dict[str, str]:
+    # Line's own voice. `output_format` is accepted but ignored (output is always
+    # pcm_16000, verified by paced byte rate), so there is nothing else to set.
+    cfg = {"input_format": "pcm_16000"}
+    if os.environ.get("CARTESIA_VOICE_ID"):
+        cfg["voice_id"] = os.environ["CARTESIA_VOICE_ID"]
+    return cfg
+
+
+def _event(t: str, data: dict) -> str:
+    return json.dumps(
+        {"type": t, "id": str(uuid.uuid4()), "ts_ms": int(time.time() * 1000), "data": data},
+        separators=(",", ":"),
+    )
+
+
+def _authorized(ws: WebSocket) -> bool:
+    u, p = os.environ.get("CHIRP_USER", "").strip(), os.environ.get("CHIRP_PASS", "").strip()
+    if not (u and p):
+        return True
+    expected = base64.b64encode(f"{u}:{p}".encode()).decode()
+    return ws.headers.get("authorization") == f"Basic {expected}"
+
+
+@app.post("/tool/{name}")
+async def tool_webhook(name: str, request: Request) -> dict[str, Any]:
+    """Line's http_server_tool calls this; it produces the execute_tool span."""
+    args = await request.json() if await request.body() else {}
+    result = await run_tool(name, dict(args))
+    print(f"chirp tool {name} args={args} -> {result}", flush=True)
+    return result
+
+
+@app.websocket("/")
+async def chirp(ws: WebSocket) -> None:
+    if not _authorized(ws):
+        await ws.close(1008, "unauthorized")
+        return
+    await ws.accept()
+    try:
+        await _bridge(ws)
+    except Exception as e:
+        if not type(e).__name__.startswith(("ConnectionClosed", "WebSocketDisconnect")):
+            print(f"chirp bridge error: {type(e).__name__}: {e}", flush=True)
+        with contextlib.suppress(Exception):
+            await ws.close(1011)
+
+
+async def _bridge(ws: WebSocket) -> None:
+    industry, model = STATE["industry"], STATE["model"]
+    workflow = f"mivas-{Path(industry_path(industry)).name}-{model}"
+    sim_id = ws.headers.get("x-simulation-result-id")
+    if sim_id:
+        print(f"chirp sim_result_id={sim_id}", flush=True)
+
+    url = STREAM_URL.format(agent_id=STATE["agent_id"], version=CARTESIA_VERSION)
+    end = asyncio.Event()
+    agent_span = None
+    customer_span = None
+    utt: str | None = None
+    audio = {"in": 0, "out": 0}
+    seen_tools: set[str] = set()
+
+    async with traced_run(workflow, simulation_result_id=sim_id, model=model):
+        async with websockets.connect(
+            url, additional_headers={"Authorization": f"Bearer {os.environ['CARTESIA_API_KEY']}"}
+        ) as agent_ws:
+            await agent_ws.send(
+                json.dumps({"event": "start", "config": _start_config()})
+            )
+
+            async def inbound() -> None:
+                """Bluejay pcm → media_input; Bluejay speech.* → customer.speech."""
+                nonlocal customer_span
+                try:
+                    while not end.is_set():
+                        msg = await ws.receive()
+                        if msg["type"] == "websocket.disconnect":
+                            break
+                        if (pcm := msg.get("bytes")):
+                            audio["in"] += len(pcm)
+                            await agent_ws.send(
+                                json.dumps(
+                                    {
+                                        "event": "media_input",
+                                        "media": {"payload": base64.b64encode(pcm).decode()},
+                                    }
+                                )
+                            )
+                            continue
+                        if not msg.get("text"):
+                            continue
+                        try:
+                            event = json.loads(msg["text"])
+                        except json.JSONDecodeError:
+                            continue
+                        if event.get("type") == "speech.started":
+                            end_speech_span(customer_span)
+                            uid = (event.get("data") or {}).get("utterance_id") or f"c_{uuid.uuid4().hex[:12]}"
+                            customer_span = start_speech_span(uid, speaker="customer")
+                            print(f"chirp customer speech.started {uid}", flush=True)
+                        elif event.get("type") == "speech.completed":
+                            end_speech_span(customer_span)
+                            customer_span = None
+                finally:
+                    end_speech_span(customer_span)
+                    customer_span = None
+                    end.set()
+                    with contextlib.suppress(Exception):
+                        await agent_ws.close()
+
+            async def outbound() -> None:
+                """Cartesia turn/audio events → chirp pcm + speech.* + tool spans."""
+                nonlocal agent_span, utt
+                try:
+                    async for raw in agent_ws:
+                        if end.is_set():
+                            break
+                        event = json.loads(raw)
+                        etype = event.get("event")
+                        if etype == "media_output":
+                            pcm = base64.b64decode(event["media"]["payload"])
+                            if pcm:
+                                audio["out"] += len(pcm)
+                                await ws.send_bytes(pcm)
+                        elif etype == "turn_started" and event["turn_started"]["role"] == "assistant":
+                            utt = f"u_{uuid.uuid4().hex[:12]}"
+                            agent_span = start_speech_span(utt, speaker="agent")
+                            await ws.send_text(_event("speech.started", {"utterance_id": utt}))
+                        elif etype == "turn_ended" and event["turn_ended"]["role"] == "assistant":
+                            turn = event["turn_ended"]
+                            print(f"chirp agent: {turn.get('text')!r}", flush=True)
+                            if agent_span is not None:
+                                agent_span.set_attribute("mivas.speech.text", turn.get("text") or "")
+                            end_speech_span(agent_span)
+                            agent_span = None
+                            if utt:
+                                await ws.send_text(_event("speech.completed", {"utterance_id": utt}))
+                                utt = None
+                            _record_native_tools(turn.get("tool_calls") or [], seen_tools)
+                        elif etype == "turn_ended":
+                            turn = event["turn_ended"]
+                            print(f"chirp {turn['role']}: {turn.get('text')!r}", flush=True)
+                        elif etype == "clear":
+                            # Cartesia barge-in: the caller started talking over the agent.
+                            print(f"chirp clear (interrupted={bool(utt)})", flush=True)
+                            if utt:
+                                end_speech_span(agent_span)
+                                agent_span = None
+                                await ws.send_text(_event("speech.completed", {"utterance_id": utt}))
+                                utt = None
+                        elif etype == "ack":
+                            print(f"chirp cartesia call_id={event.get('call_id')}", flush=True)
+                        elif etype in ("error", "call_ended", "end_call"):
+                            print(f"chirp cartesia {etype}: {raw[:300]}", flush=True)
+                            break
+                finally:
+                    end_speech_span(agent_span)
+                    agent_span = None
+                    end.set()
+                    with contextlib.suppress(Exception):
+                        await ws.close(1000)
+
+            tasks = [asyncio.create_task(inbound()), asyncio.create_task(outbound())]
+            done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            for t in pending:
+                t.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+            print(f"chirp audio bytes in={audio['in']} out={audio['out']}", flush=True)
+            for t in done:
+                exc = None if t.cancelled() else t.exception()
+                if exc is not None and not type(exc).__name__.startswith(
+                    ("ConnectionClosed", "WebSocketDisconnect")
+                ):
+                    raise exc
+
+
+def _record_native_tools(calls: list[dict[str, Any]], seen: set[str]) -> None:
+    """Line-native tools (handoff, end_call) run inside Cartesia and never hit the
+    webhook, so their only trace is the turn they were reported on. A handoff is
+    reported again on the target agent's first turn — dedupe on the call id."""
+    for call in calls:
+        name = call.get("name") or call.get("tool_name")
+        if not name or name not in STATE["native_tools"]:
+            continue
+        key = str(call.get("id") or name)
+        if key in seen:
+            continue
+        seen.add(key)
+        args = call.get("arguments") or call.get("args") or {}
+        print(f"chirp line tool {name} {args}", flush=True)
+        with tool_span(name, args, call_id=call.get("id")) as span:
+            finish_tool_span(span, {"success": True, "source": "line"}, ok=True)
+
+
+def main(model: str | None = None) -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--model", default=model or os.environ.get("CARTESIA_LINE_MODEL", "line"))
+    p.add_argument("--industry", default=os.environ.get("INDUSTRY", "control-industry"))
+    p.add_argument("--host", default=os.environ.get("CHIRP_HOST", "0.0.0.0"))
+    p.add_argument("--port", type=int, default=int(os.environ.get("CHIRP_PORT", "8773")))
+    a = p.parse_args()
+    if not os.environ.get("CARTESIA_API_KEY"):
+        raise SystemExit("need CARTESIA_API_KEY")
+    if not os.environ.get("PUBLIC_URL"):
+        raise SystemExit("need PUBLIC_URL — the Line agent's tools POST to {PUBLIC_URL}/tool/<name>")
+
+    bp = load_blueprint(a.industry)
+    STATE.update(
+        industry=a.industry,
+        model=a.model,
+        agent_id=ensure_agent(a.industry),
+        native_tools={
+            t["name"]
+            for agent in bp["agents"].values()
+            for t in agent["tools"]
+            if t.get("handoff") or t.get("session")
+        },
+    )
+    print(
+        f"ws↔Cartesia Line {STATE['agent_id']} × {a.industry} :{a.port} "
+        f"tools→{os.environ['PUBLIC_URL']}/tool/",
+        flush=True,
+    )
+    uvicorn.run(app, host=a.host, port=a.port, log_level="warning")
+
+
+if __name__ == "__main__":
+    main()

--- a/voice-agent-harnesses/cartesia/harness.py
+++ b/voice-agent-harnesses/cartesia/harness.py
@@ -1,0 +1,172 @@
+"""Blueprint → Cartesia Line agent (deployed), plus the harness-side tool runner.
+
+Line is code-first, so the "provider-side agent config" is `line_agent/main.py`
+plus a generated `line_agent/blueprint.json` (the deployed runtime has no repo).
+`ensure_agent()` deploys that directory with the `cartesia` CLI and caches the
+resulting agent id in `.agents.json`.
+
+Tools run provider-side: `schedule_appointment` is an `http_server_tool` inside
+the Line agent that POSTs to `{TOOL_BASE_URL}/tool/schedule_appointment`, i.e.
+back into `adapters/chirp.py`. That webhook is what emits the `execute_tool`
+span and forwards to the industry tool server, so `run_tool` here is the
+webhook's body — nothing calls it from the audio path.
+
+The tunnel URL is ephemeral, so `ensure_agent()` re-pushes `TOOL_BASE_URL` with
+`cartesia env set` on every chirp boot; `get_agent` reads it per call, so a new
+tunnel needs no redeploy.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HARNESS_DIR = Path(__file__).resolve().parent
+AGENT_DIR = HARNESS_DIR / "line_agent"
+AGENT_CACHE_PATH = HARNESS_DIR / ".agents.json"
+TOOL_SERVER_URL = os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
+CLI = os.environ.get("CARTESIA_CLI", str(Path.home() / ".cartesia" / "bin" / "cartesia"))
+
+
+def industry_path(name: str | Path) -> Path:
+    path = Path(name)
+    if path.is_dir():
+        return path.resolve()
+    env_dir = os.environ.get("INDUSTRY_DIR", "").strip()
+    if env_dir and Path(env_dir).is_dir():
+        return Path(env_dir).resolve()
+    return (REPO_ROOT / "industries" / name).resolve()
+
+
+def load_blueprint(industry_dir: str | Path) -> dict[str, Any]:
+    industry_dir = industry_path(industry_dir)
+    blueprint = json.loads((industry_dir / "agent_blueprint.json").read_text())
+    catalog = {t["name"]: t for t in json.loads((industry_dir / "tools.json").read_text())["tools"]}
+    agents = {}
+    for entry in blueprint["agents"]:
+        agents[entry["name"]] = {
+            "name": entry["name"],
+            "instructions": (industry_dir / entry["system_prompt"]).read_text(),
+            "tools": entry["tools"],
+        }
+    return {
+        "industry_dir": industry_dir,
+        "start": blueprint["agents"][0]["name"],
+        "agents": agents,
+        "catalog": catalog,
+    }
+
+
+def _cli(*args: str) -> str:
+    proc = subprocess.run([CLI, *args], capture_output=True, text=True)
+    out = (proc.stdout + proc.stderr).strip()
+    if proc.returncode != 0:
+        raise SystemExit(f"cartesia {' '.join(args)} failed:\n{out}")
+    return out
+
+
+def _cache() -> dict[str, Any]:
+    if not AGENT_CACHE_PATH.exists():
+        return {}
+    try:
+        return json.loads(AGENT_CACHE_PATH.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def export_blueprint(industry_dir: str | Path) -> str:
+    """Bake the industry prompts + tool schemas into the deployable directory."""
+    bp = load_blueprint(industry_dir)
+    name = Path(bp["industry_dir"]).name
+    (AGENT_DIR / "blueprint.json").write_text(
+        json.dumps({k: v for k, v in bp.items() if k != "industry_dir"}, indent=2) + "\n"
+    )
+    return name
+
+
+def ensure_agent(industry_dir: str | Path, *, public_url: str | None = None) -> str:
+    """Deploy (once per industry) and refresh the deployed agent's environment.
+
+    CARTESIA_AGENT_ID skips the cache; a cached id skips the deploy. `env set`
+    runs every boot because TOOL_BASE_URL follows the cloudflared tunnel.
+    """
+    name = export_blueprint(industry_dir)
+    cache = _cache()
+    agent_id = os.environ.get("CARTESIA_AGENT_ID", "").strip() or cache.get(name, {}).get("agent_id")
+
+    if not agent_id:
+        _cli("init", "--new", f"mivas-{name}", str(AGENT_DIR))
+        # `init --new` writes .cartesia/config.toml: agent-id = 'agent_…'
+        agent_id = (AGENT_DIR / ".cartesia" / "config.toml").read_text().split("'")[1]
+
+    env = {"TOOL_BASE_URL": public_url or os.environ.get("PUBLIC_URL", "")}
+    for key in ("OPENAI_API_KEY", "MIVAS_MODEL", "MIVAS_GREETING"):
+        if os.environ.get(key):
+            env[key] = os.environ[key]
+    env = {k: v for k, v in env.items() if v}
+    # `env set` rolls a new deployment version (~2 min), so only push on change —
+    # by digest, so the cache file never holds the API key it carries.
+    digest = hashlib.sha256(json.dumps(env, sort_keys=True).encode()).hexdigest()[:16]
+    if cache.get(name, {}).get("env_digest") != digest:
+        _cli("env", "set", "--agent-id", agent_id, *[f"{k}={v}" for k, v in env.items()])
+        cache.setdefault(name, {}).update(agent_id=agent_id, env_digest=digest)
+        AGENT_CACHE_PATH.write_text(json.dumps(cache, indent=2) + "\n")
+
+    if cache.get(name, {}).get("agent_id") != agent_id or os.environ.get("CARTESIA_REDEPLOY"):
+        print(f"cartesia deploy {agent_id} …", flush=True)
+        print(_cli("deploy", "--agent-id", agent_id, str(AGENT_DIR)), flush=True)
+        cache.setdefault(name, {})["agent_id"] = agent_id
+        AGENT_CACHE_PATH.write_text(json.dumps(cache, indent=2) + "\n")
+
+    # `env set` and `deploy` both roll a new version; calls hit the old one (or
+    # fail) until it builds, so block rather than start the bridge on stale env.
+    deadline = time.monotonic() + float(os.environ.get("CARTESIA_DEPLOY_TIMEOUT", "420"))
+    while time.monotonic() < deadline:
+        status = _cli("status", agent_id)
+        if re.search(r"Status\s+Ready", status):
+            return agent_id
+        if re.search(r"Status\s+Failed", status):
+            raise SystemExit(status)
+        print("cartesia deployment building …", flush=True)
+        time.sleep(10)
+    raise SystemExit(f"cartesia deployment for {agent_id} never became Ready")
+
+
+async def _post_appointment(date: str) -> dict[str, Any]:
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(f"{TOOL_SERVER_URL}/appointments", json={"date": date})
+        resp.raise_for_status()
+        body = resp.json()
+    return {"success": True, "date": body["date"]}
+
+
+async def _execute_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
+    if name == "schedule_appointment":
+        return await _post_appointment(args["date"])
+    return {"success": False, "error": f"unknown tool {name}"}
+
+
+async def run_tool(name: str, args: dict[str, Any], *, call_id: str | None = None) -> dict[str, Any]:
+    """Run an industry tool under an execute_tool span. Never raises — a failed
+    tool must not take down the bridge before OTel flushes."""
+    from report import call_offset_ms, finish_tool_span, tool_span
+
+    offset = call_offset_ms()
+    with tool_span(name, args, call_id=call_id) as span:
+        try:
+            result = await _execute_tool(name, args)
+            finish_tool_span(span, result, ok=True, name=name, parameters=args, start_offset_ms=offset)
+            return result
+        except Exception as e:
+            err = {"success": False, "error": f"{type(e).__name__}: {e}"}
+            finish_tool_span(span, err, ok=False, name=name, parameters=args, start_offset_ms=offset)
+            return err

--- a/voice-agent-harnesses/cartesia/harness.py
+++ b/voice-agent-harnesses/cartesia/harness.py
@@ -101,7 +101,8 @@ def ensure_agent(industry_dir: str | Path, *, public_url: str | None = None) -> 
     """
     name = export_blueprint(industry_dir)
     cache = _cache()
-    cached_agent_id = cache.get(name, {}).get("agent_id")
+    cached_entry = cache.get(name, {})
+    cached_agent_id = cached_entry.get("agent_id")
     agent_id = os.environ.get("CARTESIA_AGENT_ID", "").strip() or cached_agent_id
     agent_changed = bool(cached_agent_id and agent_id != cached_agent_id)
 
@@ -118,12 +119,18 @@ def ensure_agent(industry_dir: str | Path, *, public_url: str | None = None) -> 
     # `env set` rolls a new deployment version (~2 min), so only push on change —
     # by digest, so the cache file never holds the API key it carries.
     digest = hashlib.sha256(json.dumps(env, sort_keys=True).encode()).hexdigest()[:16]
-    if agent_changed or cache.get(name, {}).get("env_digest") != digest:
+    needs_env_set = agent_changed or cached_entry.get("env_digest") != digest
+    needs_deploy = (
+        agent_changed
+        or cached_agent_id != agent_id
+        or os.environ.get("CARTESIA_REDEPLOY")
+    )
+    if needs_env_set:
         _cli("env", "set", "--agent-id", agent_id, *[f"{k}={v}" for k, v in env.items()])
         cache.setdefault(name, {}).update(agent_id=agent_id, env_digest=digest)
         AGENT_CACHE_PATH.write_text(json.dumps(cache, indent=2) + "\n")
 
-    if cache.get(name, {}).get("agent_id") != agent_id or os.environ.get("CARTESIA_REDEPLOY"):
+    if needs_deploy:
         print(f"cartesia deploy {agent_id} …", flush=True)
         print(_cli("deploy", "--agent-id", agent_id, str(AGENT_DIR)), flush=True)
         cache.setdefault(name, {})["agent_id"] = agent_id

--- a/voice-agent-harnesses/cartesia/harness.py
+++ b/voice-agent-harnesses/cartesia/harness.py
@@ -159,14 +159,12 @@ async def run_tool(name: str, args: dict[str, Any], *, call_id: str | None = Non
     """Run an industry tool under an execute_tool span. Never raises — a failed
     tool must not take down the bridge before OTel flushes."""
     from report import call_offset_ms, finish_tool_span, tool_span
-
-    offset = call_offset_ms()
     with tool_span(name, args, call_id=call_id) as span:
         try:
             result = await _execute_tool(name, args)
-            finish_tool_span(span, result, ok=True, name=name, parameters=args, start_offset_ms=offset)
+            finish_tool_span(span, result, ok=True)
             return result
         except Exception as e:
             err = {"success": False, "error": f"{type(e).__name__}: {e}"}
-            finish_tool_span(span, err, ok=False, name=name, parameters=args, start_offset_ms=offset)
+            finish_tool_span(span, err, ok=False)
             return err

--- a/voice-agent-harnesses/cartesia/harness.py
+++ b/voice-agent-harnesses/cartesia/harness.py
@@ -101,7 +101,9 @@ def ensure_agent(industry_dir: str | Path, *, public_url: str | None = None) -> 
     """
     name = export_blueprint(industry_dir)
     cache = _cache()
-    agent_id = os.environ.get("CARTESIA_AGENT_ID", "").strip() or cache.get(name, {}).get("agent_id")
+    cached_agent_id = cache.get(name, {}).get("agent_id")
+    agent_id = os.environ.get("CARTESIA_AGENT_ID", "").strip() or cached_agent_id
+    agent_changed = bool(cached_agent_id and agent_id != cached_agent_id)
 
     if not agent_id:
         _cli("init", "--new", f"mivas-{name}", str(AGENT_DIR))
@@ -116,7 +118,7 @@ def ensure_agent(industry_dir: str | Path, *, public_url: str | None = None) -> 
     # `env set` rolls a new deployment version (~2 min), so only push on change —
     # by digest, so the cache file never holds the API key it carries.
     digest = hashlib.sha256(json.dumps(env, sort_keys=True).encode()).hexdigest()[:16]
-    if cache.get(name, {}).get("env_digest") != digest:
+    if agent_changed or cache.get(name, {}).get("env_digest") != digest:
         _cli("env", "set", "--agent-id", agent_id, *[f"{k}={v}" for k, v in env.items()])
         cache.setdefault(name, {}).update(agent_id=agent_id, env_digest=digest)
         AGENT_CACHE_PATH.write_text(json.dumps(cache, indent=2) + "\n")
@@ -158,7 +160,7 @@ async def _execute_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
 async def run_tool(name: str, args: dict[str, Any], *, call_id: str | None = None) -> dict[str, Any]:
     """Run an industry tool under an execute_tool span. Never raises — a failed
     tool must not take down the bridge before OTel flushes."""
-    from report import call_offset_ms, finish_tool_span, tool_span
+    from report import finish_tool_span, tool_span
     with tool_span(name, args, call_id=call_id) as span:
         try:
             result = await _execute_tool(name, args)

--- a/voice-agent-harnesses/cartesia/line/adapters/chirp.py
+++ b/voice-agent-harnesses/cartesia/line/adapters/chirp.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from adapters.chirp import main  # noqa: E402
+
+if __name__ == "__main__":
+    main(model="line")

--- a/voice-agent-harnesses/cartesia/line/agent.py
+++ b/voice-agent-harnesses/cartesia/line/agent.py
@@ -42,9 +42,11 @@ async def smoke(industry: str, seconds: float = 20.0) -> None:
 
         task = asyncio.create_task(feed())
         audio, first, last, t0 = 0, None, None, time.monotonic()
+        deadline = t0 + seconds
         try:
-            while time.monotonic() - t0 < seconds:
-                event = json.loads(await asyncio.wait_for(ws.recv(), timeout=seconds))
+            while time.monotonic() < deadline:
+                remaining = deadline - time.monotonic()
+                event = json.loads(await asyncio.wait_for(ws.recv(), timeout=remaining))
                 if event.get("event") == "media_output":
                     first = first or time.monotonic()
                     last = time.monotonic()

--- a/voice-agent-harnesses/cartesia/line/agent.py
+++ b/voice-agent-harnesses/cartesia/line/agent.py
@@ -1,0 +1,68 @@
+"""Local smoke for the deployed Line agent — no Bluejay, no tunnel.
+
+Deploys (or reuses) the Cartesia agent, opens the same stream websocket the
+chirp bridge uses, feeds silence, and prints the turn events + audio byte rate.
+A passing run proves: the blueprint reached the deployed runtime, the LLM key
+works, the greeting is the industry greeting, and output really is pcm_16000.
+
+    uv run python voice-agent-harnesses/cartesia/line/agent.py control-industry
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import websockets
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from adapters.chirp import CARTESIA_VERSION, STREAM_URL, _start_config  # noqa: E402
+from harness import ensure_agent  # noqa: E402
+
+SILENCE = base64.b64encode(b"\x00" * 640).decode()  # 20 ms @ 16 kHz
+
+
+async def smoke(industry: str, seconds: float = 20.0) -> None:
+    agent_id = ensure_agent(industry)
+    url = STREAM_URL.format(agent_id=agent_id, version=CARTESIA_VERSION)
+    async with websockets.connect(
+        url, additional_headers={"Authorization": f"Bearer {os.environ['CARTESIA_API_KEY']}"}
+    ) as ws:
+        await ws.send(json.dumps({"event": "start", "config": _start_config()}))
+
+        async def feed() -> None:
+            while True:
+                await ws.send(json.dumps({"event": "media_input", "media": {"payload": SILENCE}}))
+                await asyncio.sleep(0.02)
+
+        task = asyncio.create_task(feed())
+        audio, first, last, t0 = 0, None, None, time.monotonic()
+        try:
+            while time.monotonic() - t0 < seconds:
+                event = json.loads(await asyncio.wait_for(ws.recv(), timeout=seconds))
+                if event.get("event") == "media_output":
+                    first = first or time.monotonic()
+                    last = time.monotonic()
+                    audio += len(base64.b64decode(event["media"]["payload"]))
+                elif event.get("event") == "turn_ended":
+                    turn = event["turn_ended"]
+                    print(f"{turn['role']}: {turn['text']!r} tools={turn.get('tool_calls')}")
+                    if turn["role"] == "assistant":
+                        break
+                elif event.get("event") in ("ack", "error"):
+                    print(event.get("event"), json.dumps(event)[:300])
+        finally:
+            task.cancel()
+    rate = audio / max((last or 0) - (first or 0), 1e-9)
+    print(f"agent audio {audio} bytes @ {rate:.0f} B/s (pcm_16000 = 32000 B/s)")
+    assert audio > 10_000, "deployed agent produced no audio"
+    assert 28_000 < rate < 36_000, f"unexpected output sample rate: {rate:.0f} B/s"
+
+
+if __name__ == "__main__":
+    asyncio.run(smoke(sys.argv[1] if len(sys.argv) > 1 else "control-industry"))

--- a/voice-agent-harnesses/cartesia/line_agent/blueprint.json
+++ b/voice-agent-harnesses/cartesia/line_agent/blueprint.json
@@ -1,0 +1,113 @@
+{
+  "start": "receptionist",
+  "agents": {
+    "receptionist": {
+      "name": "receptionist",
+      "instructions": "# Receptionist\n\nYou are the receptionist at Bluejay's Repair Services.\n\n## Greeting\n\nWhen the call starts, say: \"Welcome to Bluejay's Repair Services!\" Then greet the customer and ask whether they'd like to schedule an appointment.\n\n## Scheduling handoff\n\nIf the customer asks to schedule a repair appointment, do not continue the conversation. Immediately call `handoff_to_scheduler` and let the scheduler handle the rest. Do not confirm the handoff or explain what happens next.\n\n## Tools\n\nYou only have access to `handoff_to_scheduler`.\n",
+      "tools": [
+        {
+          "name": "handoff_to_scheduler",
+          "handoff": true,
+          "handoff_to": "scheduler"
+        },
+        {
+          "name": "end_call",
+          "session": true
+        }
+      ]
+    },
+    "scheduler": {
+      "name": "scheduler",
+      "instructions": "# Scheduler\n\nYou are the scheduler at Bluejay's Repair Services. Your only job is to book a repair appointment.\n\n## Flow\n\n1. Ask: \"Hey, when do you want to schedule your repair appointment?\"\n2. Get to a concrete calendar date (`MM/DD/YYYY`) before booking:\n   - If the customer gives an actual date (for example, \"March 15th\" or \"03/15/2026\"), use that.\n   - If they give something vague (for example, \"next week\", \"soon\", or \"whenever\"), do not schedule yet. Propose a specific date and only proceed once you both agree on one.\n3. Only call `schedule_appointment` after a concrete date has been given or agreed upon. Never invent or guess a date.\n4. Confirm that the repair appointment is scheduled for that date.\n\nKeep the conversation short. Do not ask for anything else.\n\n## Tools\n\nYou have `schedule_appointment` and `end_call`. Use `end_call` after the booking is confirmed (or if the caller is done / wrong number).\n",
+      "tools": [
+        {
+          "name": "schedule_appointment"
+        },
+        {
+          "name": "end_call",
+          "session": true
+        }
+      ]
+    }
+  },
+  "catalog": {
+    "handoff_to_scheduler": {
+      "name": "handoff_to_scheduler",
+      "description": "Hand off the caller to the Bluejay's Repair Services scheduler agent",
+      "inputSchema": {
+        "type": "object",
+        "additionalProperties": false
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "success"
+        ]
+      }
+    },
+    "schedule_appointment": {
+      "name": "schedule_appointment",
+      "description": "Schedule a repair appointment and store it in the database",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "date": {
+            "type": "string",
+            "description": "Repair appointment date in MM/DD/YYYY format"
+          }
+        },
+        "required": [
+          "date"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "date": {
+            "type": "string",
+            "description": "Scheduled repair appointment date in MM/DD/YYYY format"
+          }
+        },
+        "required": [
+          "success",
+          "date"
+        ]
+      }
+    },
+    "end_call": {
+      "name": "end_call",
+      "description": "End the call once the caller is done, or immediately if it is spam or a wrong number. Say goodbye first.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "Why the call is ending"
+          }
+        },
+        "required": [
+          "reason"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "success"
+        ]
+      }
+    }
+  }
+}

--- a/voice-agent-harnesses/cartesia/line_agent/cartesia.toml
+++ b/voice-agent-harnesses/cartesia/line_agent/cartesia.toml
@@ -1,0 +1,8 @@
+[app]
+name = "line_agent"
+
+[build]
+cmd = "echo 'No build cmd specified'"
+
+[run]
+cmd = "echo 'No run cmd specified'"

--- a/voice-agent-harnesses/cartesia/line_agent/main.py
+++ b/voice-agent-harnesses/cartesia/line_agent/main.py
@@ -1,0 +1,95 @@
+"""Line agent deployed to Cartesia (`cartesia deploy`) — the provider-side agent.
+
+Line is code-first: this file *is* the agent config, so the industry blueprint
+has to travel with it. `harness.export_blueprint()` writes `blueprint.json` into
+this directory right before every deploy; the deployed runtime has no repo.
+
+Multi-agent is native: the receptionist's `handoff_to_scheduler` is a Line
+handoff tool (`agent_as_handoff`), so the scheduler takes over inside Line with
+no bridge-side routing. `end_call` is Line's built-in.
+
+`schedule_appointment` is an `http_server_tool` pointed at the harness webhook
+(`$TOOL_BASE_URL/tool/schedule_appointment`) rather than a local function: that
+webhook is what emits the `execute_tool` span and forwards to the industry tool
+server. TOOL_BASE_URL is the ephemeral cloudflared URL, re-pushed with
+`cartesia env set` on every chirp boot, and read per call (get_agent runs per
+call) so a new tunnel needs no redeploy.
+"""
+
+import json
+import os
+from pathlib import Path
+
+from line.llm_agent import (
+    LlmAgent,
+    LlmConfig,
+    agent_as_handoff,
+    end_call,
+    http_server_tool,
+)
+from line.voice_agent_app import AgentEnv, CallRequest, VoiceAgentApp
+
+BLUEPRINT = json.loads((Path(__file__).parent / "blueprint.json").read_text())
+MODEL = os.getenv("MIVAS_MODEL", "gpt-4.1")
+GREETING = os.getenv("MIVAS_GREETING", "Welcome to Bluejay's Repair Services!")
+# A handoff target is started with CallStarted, so it only speaks if it has an
+# introduction — this is the scheduler prompt's own step 1, verbatim.
+HANDOFF_INTRO = "Hey, when do you want to schedule your repair appointment?"
+
+
+def _tool_url(name: str) -> str:
+    base = os.environ.get("TOOL_BASE_URL", "").rstrip("/")
+    if not base:
+        raise RuntimeError("TOOL_BASE_URL unset — run `cartesia env set --agent-id … TOOL_BASE_URL=…`")
+    return f"{base}/tool/{name}"
+
+
+def _http_tool(name: str) -> object:
+    spec = BLUEPRINT["catalog"][name]
+    schema = dict(spec.get("inputSchema") or {"type": "object"})
+    schema.pop("additionalProperties", None)
+    return http_server_tool(
+        name=name,
+        description=spec.get("description", name),
+        url=_tool_url(name),
+        method="POST",
+        request_body_schema=schema,
+    )
+
+
+def _build(agent_name: str) -> LlmAgent:
+    entry = BLUEPRINT["agents"][agent_name]
+    tools = []
+    for t in entry["tools"]:
+        if t.get("handoff"):
+            target = _build(t["handoff_to"])
+            tools.append(
+                agent_as_handoff(
+                    target,
+                    name=t["name"],
+                    description=BLUEPRINT["catalog"][t["name"]]["description"],
+                )
+            )
+        elif t.get("session") or t["name"] == "end_call":
+            tools.append(end_call)
+        else:
+            tools.append(_http_tool(t["name"]))
+    return LlmAgent(
+        model=MODEL,
+        api_key=os.environ["OPENAI_API_KEY"],
+        tools=tools,
+        config=LlmConfig(
+            system_prompt=entry["instructions"],
+            introduction=GREETING if agent_name == BLUEPRINT["start"] else HANDOFF_INTRO,
+        ),
+    )
+
+
+async def get_agent(env: AgentEnv, call_request: CallRequest) -> LlmAgent:
+    return _build(BLUEPRINT["start"])
+
+
+app = VoiceAgentApp(get_agent=get_agent)
+
+if __name__ == "__main__":
+    app.run()

--- a/voice-agent-harnesses/cartesia/line_agent/pyproject.toml
+++ b/voice-agent-harnesses/cartesia/line_agent/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "mivas-line-agent"
+version = "0.1.0"
+description = "MIVAS control-industry agent on Cartesia Line"
+requires-python = ">=3.11"
+dependencies = [
+    "cartesia-line>=0.2.16",
+]
+
+[tool.setuptools]
+py-modules = ["main"]

--- a/voice-agent-harnesses/cartesia/report.py
+++ b/voice-agent-harnesses/cartesia/report.py
@@ -52,20 +52,15 @@ FINAL_STATUSES = {
     "CANCELLED",
     "NO_CONNECTION",
 }
-EARLY_UPSERT_STATUSES = {"EVALUATING", "EVALUATED", "CONVERSATION_ENDED"}
 PROVIDER = "cartesia"
 TRACER_NAME = "mivas.cartesia"
 
 _provider: TracerProvider | None = None
 _root_span: ContextVar[Span | None] = ContextVar("mivas_cartesia_otel_root", default=None)
 _call_t0: ContextVar[float | None] = ContextVar("mivas_cartesia_otel_t0", default=None)
-_reported_tools: ContextVar[list[dict[str, Any]] | None] = ContextVar(
-    "mivas_cartesia_reported_tools", default=None
-)
 # module fallbacks when asyncio tasks don't inherit ContextVars
 _active_root: Span | None = None
 _active_t0: float | None = None
-_active_tools: list[dict[str, Any]] | None = None
 
 
 def _log(msg: str) -> None:
@@ -157,31 +152,6 @@ def _parent_span() -> Span | None:
     return None
 
 
-def record_tool_call(
-    name: str,
-    parameters: Any,
-    output: Any,
-    *,
-    start_offset_ms: int | None = None,
-) -> None:
-    """Buffer a tool call for the end-of-call update-simulation-result POST."""
-    tools = _reported_tools.get()
-    if tools is None:
-        tools = _active_tools
-    if tools is None:
-        return
-    tools.append(
-        {
-            "name": str(name),
-            "parameters": parameters if isinstance(parameters, dict) else {"raw": parameters},
-            "output": output,
-            "start_offset_ms": int(
-                start_offset_ms if start_offset_ms is not None else call_offset_ms()
-            ),
-        }
-    )
-
-
 @contextmanager
 def tool_span(
     name: str,
@@ -227,13 +197,7 @@ def finish_tool_span(
     output: Any,
     *,
     ok: bool = True,
-    name: str | None = None,
-    parameters: Any = None,
-    start_offset_ms: int | None = None,
 ) -> None:
-    # name/parameters/start_offset_ms kept for call-site compat; conversation
-    # placement comes from the OTel span timeline, not a tool_calls POST.
-    del name, parameters, start_offset_ms
     if span is None:
         return
     span.set_attribute("gen_ai.tool.call.result", _json_attr(output))
@@ -287,11 +251,11 @@ async def _await_terminal_upsert(
     300 s, not 150 s: eval needs ~175 s to settle and anything shorter forces the
     early-post + relink path below, which double-counts every tool.
 
-    Posting during EVALUATING works, but eval then wipes trace_ids and the relink
-    POST re-extracts the execute_tool spans on top of the ones the first POST
-    already produced — every tool lands on the timeline twice. One POST after the
-    sim settles gives a surviving link and one row per tool; `_relink_after_final`
-    stays as the safety net for when this wait times out.
+    Posting during EVALUATING works, but eval then wipes trace_ids, and re-posting
+    makes Bluejay re-extract the execute_tool spans on top of the ones the first
+    POST already produced — every tool lands on the timeline twice. One POST after
+    the sim settles gives a surviving link and one row per tool. On timeout we post
+    anyway and log it; we never re-post, because that is the double-count.
     """
     deadline = time.monotonic() + timeout
     key = _api_key()
@@ -319,10 +283,8 @@ async def post_simulation_enrichment(
     simulation_result_id: str,
     *,
     trace_id: str | None,
-    tool_calls: list[dict[str, Any]] | None = None,
 ) -> None:
-    """Link OTel trace_ids to the sim result. tool_calls arg ignored (use OTel spans)."""
-    del tool_calls  # conversation tools come from execute_tool spans
+    """Link OTel trace_ids; conversation tools come from execute_tool spans."""
     key = _api_key()
     if not key or not simulation_result_id or not trace_id:
         _log(
@@ -373,9 +335,12 @@ async def post_simulation_enrichment(
                         f"update-simulation-result ok trace={trace_id} "
                         f"sim={simulation_result_id} terminal={st} attempt={attempt}"
                     )
-                    if (st is None or st in EARLY_UPSERT_STATUSES) and trace_id:
-                        await _relink_after_final(
-                            client, simulation_result_id, body, key, trace_id, st
+                    if st is None:
+                        logger.warning(
+                            "linked without a final status — sim=%s may still be "
+                            "EVALUATING; if eval wipes trace_ids the link is lost "
+                            "(we do not re-post: a second POST double-counts tools)",
+                            simulation_result_id,
                         )
                     return
         except Exception as e:
@@ -386,70 +351,6 @@ async def post_simulation_enrichment(
 
 
 
-async def _relink_after_final(
-    client: httpx.AsyncClient,
-    simulation_result_id: str,
-    body: dict[str, Any],
-    key: str,
-    trace_id: str,
-    early_status: str | None,
-) -> None:
-    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link).
-
-    Only if it actually got wiped: each POST re-extracts the execute_tool spans and
-    appends them, so a redundant relink double-counts every tool on the timeline.
-    """
-    final: str | None = None
-    linked = False
-    deadline = time.monotonic() + 120.0
-    while time.monotonic() < deadline:
-        try:
-            r = await client.get(
-                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
-                headers={"X-API-Key": key},
-            )
-            if r.status_code == 200:
-                result = (r.json() or {}).get("simulation_result") or {}
-                st = str(result.get("status"))
-                if st in FINAL_STATUSES:
-                    final = st
-                    linked = trace_id in (result.get("trace_ids") or [])
-                    break
-        except Exception:
-            pass
-        await asyncio.sleep(2.0)
-    if final is not None and linked:
-        _log(
-            f"relink not needed after {early_status} — trace={trace_id} still "
-            f"linked sim={simulation_result_id} final={final}"
-        )
-        return
-    if final is None:
-        _log(
-            f"relink skipped — still not final after early upsert terminal={early_status} "
-            f"sim={simulation_result_id}"
-        )
-        return
-    r = await client.post(
-        f"{_api_url()}/update-simulation-result",
-        json=body,
-        headers={"X-API-Key": key, "Content-Type": "application/json"},
-    )
-    if r.status_code >= 400:
-        _log(
-            f"relink after {early_status} FAILED sim={simulation_result_id} "
-            f"{r.status_code} {r.text[:300]}"
-        )
-    else:
-        _log(
-            f"relink after {early_status} ok trace={trace_id} "
-            f"sim={simulation_result_id} final={final}"
-        )
-
-async def post_trace_ids(simulation_result_id: str, trace_id: str) -> None:
-    await post_simulation_enrichment(simulation_result_id, trace_id=trace_id)
-
-
 @asynccontextmanager
 async def traced_run(
     workflow_name: str,
@@ -458,7 +359,7 @@ async def traced_run(
     model: str | None = None,
 ) -> AsyncIterator[None]:
     """OTel voice.call root; flush + link trace_ids/tool_calls on exit."""
-    global _active_root, _active_t0, _active_tools
+    global _active_root, _active_t0
 
     provider = setup_otel()
     if provider is None:
@@ -479,13 +380,10 @@ async def traced_run(
 
     otel_tid: str | None = None
     root_token = None
-    tools_token = None
     t0 = time.monotonic()
     t0_token = _call_t0.set(t0)
-    tool_buf: list[dict[str, Any]] = []
     prev_active = _active_root
     prev_t0 = _active_t0
-    prev_tools = _active_tools
     try:
         with tracer.start_as_current_span(
             "voice.call",
@@ -493,10 +391,8 @@ async def traced_run(
             attributes=attrs,
         ) as root:
             root_token = _root_span.set(root)
-            tools_token = _reported_tools.set(tool_buf)
             _active_root = root
             _active_t0 = t0
-            _active_tools = tool_buf
             ctx = root.get_span_context()
             if ctx.is_valid:
                 otel_tid = format(ctx.trace_id, "032x")
@@ -520,11 +416,8 @@ async def traced_run(
     finally:
         _active_root = prev_active
         _active_t0 = prev_t0
-        _active_tools = prev_tools
         if root_token is not None:
             _root_span.reset(root_token)
-        if tools_token is not None:
-            _reported_tools.reset(tools_token)
         _call_t0.reset(t0_token)
         flush()
         if simulation_result_id and otel_tid:

--- a/voice-agent-harnesses/cartesia/report.py
+++ b/voice-agent-harnesses/cartesia/report.py
@@ -1,0 +1,538 @@
+"""OpenTelemetry → Bluejay OTLP for the Cartesia Line harness.
+
+The Line agent runs on Cartesia's infrastructure and its stream API exposes only
+audio, so every span is emitted bridge-side:
+
+  voice.call (root) — gen_ai.provider.name=cartesia
+    ├── agent.speech          (bracketed by Cartesia turn_started/turn_ended)
+    ├── customer.speech       (inbound Bluejay speech.started/completed)
+    └── execute_tool <name>   (the Line agent's http tool calling our webhook)
+
+After the call we POST {simulation_result_id, trace_ids} so the flamegraph links.
+Bluejay places execute_tool spans onto the conversation timeline from OTel
+(span start relative to voice.call) — we do not also POST tool_calls (that
+duplicates). Chirp supplies simulation_result_id via X-Simulation-Result-Id.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+from contextlib import asynccontextmanager, contextmanager
+from contextvars import ContextVar
+from typing import Any, AsyncIterator, Iterator
+
+import httpx
+from opentelemetry import trace as otel_trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.trace import Span, SpanKind, Status, StatusCode
+
+logger = logging.getLogger("mivas.otel.cartesia")
+if not logger.handlers:
+    _h = logging.StreamHandler(sys.stdout)
+    _h.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+    logger.addHandler(_h)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+DEFAULT_OTLP_ENDPOINT = "https://otlp.getbluejay.ai/v1/traces"
+DEFAULT_API_URL = "https://api.getbluejay.ai/v1"
+FINAL_STATUSES = {
+    "COMPLETED",
+    "FAILED",
+    "SYSTEM_ERROR",
+    "NO_ANSWER",
+    "CANCELLED",
+    "NO_CONNECTION",
+}
+EARLY_UPSERT_STATUSES = {"EVALUATING", "EVALUATED", "CONVERSATION_ENDED"}
+PROVIDER = "cartesia"
+TRACER_NAME = "mivas.cartesia"
+
+_provider: TracerProvider | None = None
+_root_span: ContextVar[Span | None] = ContextVar("mivas_cartesia_otel_root", default=None)
+_call_t0: ContextVar[float | None] = ContextVar("mivas_cartesia_otel_t0", default=None)
+_reported_tools: ContextVar[list[dict[str, Any]] | None] = ContextVar(
+    "mivas_cartesia_reported_tools", default=None
+)
+# module fallbacks when asyncio tasks don't inherit ContextVars
+_active_root: Span | None = None
+_active_t0: float | None = None
+_active_tools: list[dict[str, Any]] | None = None
+
+
+def _log(msg: str) -> None:
+    print(f"[otel.cartesia] {msg}", flush=True)
+    logger.info("%s", msg)
+
+
+def _api_url() -> str:
+    base = os.environ.get("BLUEJAY_API_URL", DEFAULT_API_URL).rstrip("/")
+    if base.endswith("/v1"):
+        return base
+    return f"{base}/v1"
+
+
+def _otlp_endpoint() -> str:
+    return os.environ.get("BLUEJAY_OTLP_ENDPOINT", DEFAULT_OTLP_ENDPOINT)
+
+
+def _service_name() -> str:
+    return os.environ.get("BLUEJAY_SERVICE_NAME", "mivas-cartesia")
+
+
+def _api_key() -> str | None:
+    return os.environ.get("BLUEJAY_API_KEY") or None
+
+
+def _json_attr(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, default=str)
+    except Exception:
+        return str(value)
+
+
+def call_offset_ms() -> int:
+    t0 = _call_t0.get()
+    if t0 is None:
+        t0 = _active_t0
+    if t0 is None:
+        return 0
+    return max(0, int((time.monotonic() - t0) * 1000))
+
+
+def setup_otel() -> TracerProvider | None:
+    """Install global OTel exporter to Bluejay OTLP. No-op without BLUEJAY_API_KEY."""
+    global _provider
+
+    api_key = _api_key()
+    if not api_key:
+        _log("otel disabled — BLUEJAY_API_KEY unset")
+        return None
+
+    if _provider is not None:
+        return _provider
+
+    endpoint = _otlp_endpoint()
+    resource = Resource.create({SERVICE_NAME: _service_name()})
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(
+        SimpleSpanProcessor(
+            OTLPSpanExporter(endpoint, headers={"X-API-KEY": api_key})
+        )
+    )
+    otel_trace.set_tracer_provider(provider)
+    _provider = provider
+    _log(f"otel → {endpoint} service={_service_name()}")
+    return provider
+
+
+def flush() -> None:
+    if _provider is not None:
+        try:
+            ok = _provider.force_flush(timeout_millis=10_000)
+            _log(f"otel flush ok={ok}")
+        except Exception as e:
+            _log(f"otel flush failed: {e}")
+
+
+def _parent_span() -> Span | None:
+    parent = _root_span.get()
+    if parent is not None and parent.get_span_context().is_valid:
+        return parent
+    if _active_root is not None and _active_root.get_span_context().is_valid:
+        return _active_root
+    cur = otel_trace.get_current_span()
+    if cur is not None and cur.get_span_context().is_valid:
+        return cur
+    return None
+
+
+def record_tool_call(
+    name: str,
+    parameters: Any,
+    output: Any,
+    *,
+    start_offset_ms: int | None = None,
+) -> None:
+    """Buffer a tool call for the end-of-call update-simulation-result POST."""
+    tools = _reported_tools.get()
+    if tools is None:
+        tools = _active_tools
+    if tools is None:
+        return
+    tools.append(
+        {
+            "name": str(name),
+            "parameters": parameters if isinstance(parameters, dict) else {"raw": parameters},
+            "output": output,
+            "start_offset_ms": int(
+                start_offset_ms if start_offset_ms is not None else call_offset_ms()
+            ),
+        }
+    )
+
+
+@contextmanager
+def tool_span(
+    name: str,
+    parameters: Any = None,
+    *,
+    call_id: str | None = None,
+) -> Iterator[Span | None]:
+    """Child span under the active voice.call root. No-op outside traced_run."""
+    parent = _parent_span()
+    if parent is None:
+        yield None
+        return
+
+    tracer = otel_trace.get_tracer(TRACER_NAME)
+    parent_ctx = otel_trace.set_span_in_context(parent)
+    attrs: dict[str, Any] = {
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.provider.name": PROVIDER,
+        "gen_ai.tool.name": name,
+        "gen_ai.tool.call.arguments": _json_attr(parameters if parameters is not None else {}),
+        # conversation timestamps go via tool_calls POST (not this attr) to avoid
+        # Bluejay double-counting OTel extraction + update-simulation-result
+    }
+    if call_id:
+        attrs["gen_ai.tool.call.id"] = str(call_id)
+
+    with tracer.start_as_current_span(
+        f"execute_tool {name}",
+        context=parent_ctx,
+        kind=SpanKind.CLIENT,
+        attributes=attrs,
+    ) as span:
+        try:
+            yield span
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)[:400]))
+            raise
+
+
+def finish_tool_span(
+    span: Span | None,
+    output: Any,
+    *,
+    ok: bool = True,
+    name: str | None = None,
+    parameters: Any = None,
+    start_offset_ms: int | None = None,
+) -> None:
+    # name/parameters/start_offset_ms kept for call-site compat; conversation
+    # placement comes from the OTel span timeline, not a tool_calls POST.
+    del name, parameters, start_offset_ms
+    if span is None:
+        return
+    span.set_attribute("gen_ai.tool.call.result", _json_attr(output))
+    if ok:
+        span.set_status(Status(StatusCode.OK))
+    else:
+        span.set_status(Status(StatusCode.ERROR, _json_attr(output)[:400]))
+
+
+def start_speech_span(
+    utterance_id: str, *, speaker: str = "agent"
+) -> Span | None:
+    """Begin agent.speech or customer.speech under voice.call."""
+    parent = _parent_span()
+    if parent is None:
+        return None
+    tracer = otel_trace.get_tracer(TRACER_NAME)
+    parent_ctx = otel_trace.set_span_in_context(parent)
+    is_customer = speaker in ("customer", "user", "digital_human")
+    span_name = "customer.speech" if is_customer else "agent.speech"
+    attrs: dict[str, Any] = {
+        "gen_ai.operation.name": (
+            "speech_to_text" if is_customer else "text_to_speech"
+        ),
+        "gen_ai.provider.name": PROVIDER,
+        "mivas.utterance_id": str(utterance_id),
+        "mivas.speech.speaker": "customer" if is_customer else "agent",
+        "bluejay.speech.start_offset_ms": call_offset_ms(),
+    }
+    span = tracer.start_span(
+        span_name,
+        context=parent_ctx,
+        kind=SpanKind.INTERNAL,
+        attributes=attrs,
+    )
+    return span
+
+def end_speech_span(span: Span | None) -> None:
+    if span is None:
+        return
+    span.set_attribute("bluejay.speech.end_offset_ms", call_offset_ms())
+    span.set_status(Status(StatusCode.OK))
+    span.end()
+
+
+async def _await_terminal_upsert(
+    client: httpx.AsyncClient, simulation_result_id: str, timeout: float = 300.0
+) -> str | None:
+    """Wait for a *final* status before the upsert.
+
+    300 s, not 150 s: eval needs ~175 s to settle and anything shorter forces the
+    early-post + relink path below, which double-counts every tool.
+
+    Posting during EVALUATING works, but eval then wipes trace_ids and the relink
+    POST re-extracts the execute_tool spans on top of the ones the first POST
+    already produced — every tool lands on the timeline twice. One POST after the
+    sim settles gives a surviving link and one row per tool; `_relink_after_final`
+    stays as the safety net for when this wait times out.
+    """
+    deadline = time.monotonic() + timeout
+    key = _api_key()
+    if not key:
+        return None
+    while time.monotonic() < deadline:
+        try:
+            r = await client.get(
+                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                headers={"X-API-Key": key},
+            )
+            if r.status_code == 200:
+                st = str(
+                    ((r.json() or {}).get("simulation_result") or {}).get("status")
+                )
+                if st in FINAL_STATUSES:
+                    return st
+        except Exception:
+            pass
+        await asyncio.sleep(1.0)
+    return None
+
+
+async def post_simulation_enrichment(
+    simulation_result_id: str,
+    *,
+    trace_id: str | None,
+    tool_calls: list[dict[str, Any]] | None = None,
+) -> None:
+    """Link OTel trace_ids to the sim result. tool_calls arg ignored (use OTel spans)."""
+    del tool_calls  # conversation tools come from execute_tool spans
+    key = _api_key()
+    if not key or not simulation_result_id or not trace_id:
+        _log(
+            f"skip update-simulation-result — "
+            f"simulation_result_id={simulation_result_id} "
+            f"trace_id={trace_id} key={bool(key)}"
+        )
+        return
+    if not str(simulation_result_id).isdigit():
+        _log(f"skip update-simulation-result — non-numeric sim id={simulation_result_id}")
+        return
+
+    body: dict[str, Any] = {
+        "simulation_result_id": str(simulation_result_id),
+        "trace_ids": [trace_id],
+    }
+
+    await asyncio.sleep(0.5)
+
+    last_err: str | None = None
+    for attempt in range(1, 4):
+        try:
+            async with httpx.AsyncClient(timeout=20) as client:
+                st = await _await_terminal_upsert(client, simulation_result_id)
+                if st is None:
+                    check = await client.get(
+                        f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                        headers={"X-API-Key": key},
+                    )
+                    if check.status_code == 404:
+                        _log(
+                            f"skip update-simulation-result — "
+                            f"sim={simulation_result_id} not found"
+                        )
+                        return
+                r = await client.post(
+                    f"{_api_url()}/update-simulation-result",
+                    json=body,
+                    headers={"X-API-Key": key, "Content-Type": "application/json"},
+                )
+                if r.status_code >= 400:
+                    last_err = f"{r.status_code} {r.text[:300]} (status={st})"
+                    _log(f"update-simulation-result FAILED attempt={attempt} {last_err}")
+                    if r.status_code == 404:
+                        return
+                else:
+                    _log(
+                        f"update-simulation-result ok trace={trace_id} "
+                        f"sim={simulation_result_id} terminal={st} attempt={attempt}"
+                    )
+                    if (st is None or st in EARLY_UPSERT_STATUSES) and trace_id:
+                        await _relink_after_final(
+                            client, simulation_result_id, body, key, trace_id, st
+                        )
+                    return
+        except Exception as e:
+            last_err = f"{type(e).__name__}: {e}"
+            _log(f"update-simulation-result error attempt={attempt} {last_err}")
+        await asyncio.sleep(1.0 * attempt)
+    _log(f"update-simulation-result gave up: {last_err}")
+
+
+
+async def _relink_after_final(
+    client: httpx.AsyncClient,
+    simulation_result_id: str,
+    body: dict[str, Any],
+    key: str,
+    trace_id: str,
+    early_status: str | None,
+) -> None:
+    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link).
+
+    Only if it actually got wiped: each POST re-extracts the execute_tool spans and
+    appends them, so a redundant relink double-counts every tool on the timeline.
+    """
+    final: str | None = None
+    linked = False
+    deadline = time.monotonic() + 120.0
+    while time.monotonic() < deadline:
+        try:
+            r = await client.get(
+                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                headers={"X-API-Key": key},
+            )
+            if r.status_code == 200:
+                result = (r.json() or {}).get("simulation_result") or {}
+                st = str(result.get("status"))
+                if st in FINAL_STATUSES:
+                    final = st
+                    linked = trace_id in (result.get("trace_ids") or [])
+                    break
+        except Exception:
+            pass
+        await asyncio.sleep(2.0)
+    if final is not None and linked:
+        _log(
+            f"relink not needed after {early_status} — trace={trace_id} still "
+            f"linked sim={simulation_result_id} final={final}"
+        )
+        return
+    if final is None:
+        _log(
+            f"relink skipped — still not final after early upsert terminal={early_status} "
+            f"sim={simulation_result_id}"
+        )
+        return
+    r = await client.post(
+        f"{_api_url()}/update-simulation-result",
+        json=body,
+        headers={"X-API-Key": key, "Content-Type": "application/json"},
+    )
+    if r.status_code >= 400:
+        _log(
+            f"relink after {early_status} FAILED sim={simulation_result_id} "
+            f"{r.status_code} {r.text[:300]}"
+        )
+    else:
+        _log(
+            f"relink after {early_status} ok trace={trace_id} "
+            f"sim={simulation_result_id} final={final}"
+        )
+
+async def post_trace_ids(simulation_result_id: str, trace_id: str) -> None:
+    await post_simulation_enrichment(simulation_result_id, trace_id=trace_id)
+
+
+@asynccontextmanager
+async def traced_run(
+    workflow_name: str,
+    *,
+    simulation_result_id: str | None = None,
+    model: str | None = None,
+) -> AsyncIterator[None]:
+    """OTel voice.call root; flush + link trace_ids/tool_calls on exit."""
+    global _active_root, _active_t0, _active_tools
+
+    provider = setup_otel()
+    if provider is None:
+        yield
+        return
+
+    tracer = otel_trace.get_tracer(TRACER_NAME)
+    attrs: dict[str, Any] = {
+        "gen_ai.system": PROVIDER,
+        "gen_ai.provider.name": PROVIDER,
+        "gen_ai.operation.name": "invoke_agent",
+        "mivas.workflow.name": workflow_name,
+    }
+    if model:
+        attrs["gen_ai.request.model"] = model
+    if simulation_result_id:
+        attrs["bluejay.simulation_result_id"] = str(simulation_result_id)
+
+    otel_tid: str | None = None
+    root_token = None
+    tools_token = None
+    t0 = time.monotonic()
+    t0_token = _call_t0.set(t0)
+    tool_buf: list[dict[str, Any]] = []
+    prev_active = _active_root
+    prev_t0 = _active_t0
+    prev_tools = _active_tools
+    try:
+        with tracer.start_as_current_span(
+            "voice.call",
+            kind=SpanKind.SERVER,
+            attributes=attrs,
+        ) as root:
+            root_token = _root_span.set(root)
+            tools_token = _reported_tools.set(tool_buf)
+            _active_root = root
+            _active_t0 = t0
+            _active_tools = tool_buf
+            ctx = root.get_span_context()
+            if ctx.is_valid:
+                otel_tid = format(ctx.trace_id, "032x")
+                _log(
+                    f"otel trace_id={otel_tid} sim={simulation_result_id} "
+                    f"workflow={workflow_name} model={model}"
+                )
+            try:
+                yield
+            except Exception as e:
+                name = type(e).__name__
+                if name.startswith("ConnectionClosed") or name in {
+                    "ConnectionResetError",
+                    "BrokenPipeError",
+                }:
+                    root.set_status(Status(StatusCode.OK))
+                else:
+                    root.record_exception(e)
+                    root.set_status(Status(StatusCode.OK))
+                    _log(f"voice.call swallowed {name}: {e}")
+    finally:
+        _active_root = prev_active
+        _active_t0 = prev_t0
+        _active_tools = prev_tools
+        if root_token is not None:
+            _root_span.reset(root_token)
+        if tools_token is not None:
+            _reported_tools.reset(tools_token)
+        _call_t0.reset(t0_token)
+        flush()
+        if simulation_result_id and otel_tid:
+            try:
+                await post_simulation_enrichment(
+                    simulation_result_id, trace_id=otel_tid
+                )
+            except Exception as e:
+                _log(f"post_simulation_enrichment crashed: {type(e).__name__}: {e}")
+        elif simulation_result_id and not otel_tid:
+            _log(f"have simulation_result_id={simulation_result_id} but no otel trace id")

--- a/voice-agent-harnesses/cartesia/report.py
+++ b/voice-agent-harnesses/cartesia/report.py
@@ -411,8 +411,9 @@ async def traced_run(
                     root.set_status(Status(StatusCode.OK))
                 else:
                     root.record_exception(e)
-                    root.set_status(Status(StatusCode.OK))
+                    root.set_status(Status(StatusCode.ERROR, str(e)[:400]))
                     _log(f"voice.call swallowed {name}: {e}")
+                    raise
     finally:
         _active_root = prev_active
         _active_t0 = prev_t0

--- a/voice-agent-harnesses/cartesia/report.py
+++ b/voice-agent-harnesses/cartesia/report.py
@@ -413,7 +413,6 @@ async def traced_run(
                     root.record_exception(e)
                     root.set_status(Status(StatusCode.ERROR, str(e)[:400]))
                     _log(f"voice.call swallowed {name}: {e}")
-                    raise
     finally:
         _active_root = prev_active
         _active_t0 = prev_t0

--- a/voice-agent-harnesses/cartesia/requirements.txt
+++ b/voice-agent-harnesses/cartesia/requirements.txt
@@ -1,0 +1,9 @@
+# Bridge side only — the Line agent itself runs on Cartesia (see line_agent/pyproject.toml).
+# The cartesia CLI is a separate binary: curl -fsSL https://cartesia.sh | sh
+fastapi>=0.115.0
+uvicorn>=0.32.0
+websockets>=14.0
+httpx>=0.27.0
+opentelemetry-api>=1.27.0
+opentelemetry-sdk>=1.27.0
+opentelemetry-exporter-otlp-proto-http>=1.27.0

--- a/voice-agent-harnesses/livekit/.env.example
+++ b/voice-agent-harnesses/livekit/.env.example
@@ -1,0 +1,20 @@
+# LiveKit Cloud project — MUST be the project stored on the Bluejay org's LiveKit
+# integration, otherwise Bluejay dispatches into a room this worker never sees.
+LIVEKIT_URL=
+LIVEKIT_API_KEY=
+LIVEKIT_API_SECRET=
+
+# Bluejay trace linking
+BLUEJAY_API_URL=https://api.getbluejay.ai/v1
+BLUEJAY_OTLP_ENDPOINT=https://otlp.getbluejay.ai/v1/traces
+BLUEJAY_API_KEY=
+BLUEJAY_SERVICE_NAME=mivas-livekit
+
+INDUSTRY=control-industry
+TOOL_SERVER_URL=http://127.0.0.1:8000
+
+OPENAI_API_KEY=
+GOOGLE_API_KEY=
+DEEPGRAM_API_KEY=
+# the livekit elevenlabs plugin reads ELEVEN_API_KEY, not ELEVENLABS_API_KEY
+ELEVEN_API_KEY=

--- a/voice-agent-harnesses/livekit/README.md
+++ b/voice-agent-harnesses/livekit/README.md
@@ -18,7 +18,7 @@ the framework is the only variable.
 ## Layout
 
 ```
-harness.py     blueprint load, Receptionist/Scheduler/Combined agents, run_tool, serve()
+harness.py     blueprint load, Receptionist/Scheduler agents, run_tool, serve()
 report.py      OTel → Bluejay OTLP + the single post-final update-simulation-result
 <runtime>/agent.py   plugin wiring for one stack; everything else comes from harness.py
 ```
@@ -67,20 +67,25 @@ The exporter is attached to a **private** `TracerProvider` rather than the globa
 one. livekit-agents resolves its own tracer off the global provider, and setting it
 would ship the framework's entire internal span tree to Bluejay as unrelated traces.
 
-`_await_terminal_upsert` waits **300 s** here, not the 150 s the CHIRP harnesses
+`_await_terminal_upsert` waits **600 s** here, not the 150 s the CHIRP harnesses
 use. Result 710911 proved why: its evaluation took longer than 150 s, the wait
 fell through to `_relink_after_final`, the link had by then been wiped, and the
 relink POST appended a second copy of every tool (`handoff_to_scheduler` actual=2,
-`end_call` actual=2). The relink net still double-counts whenever it actually
-fires — the fix is to make the wait long enough that it does not.
+`end_call` actual=2). Since we never re-post, a fall-through is now simply a lost
+link: result 712617 hit the old 300 s ceiling, POSTed during `EVALUATING`, and
+evaluation wiped its `trace_ids`. The clock to beat is our hangup → `COMPLETED`,
+which includes the ~2 min the simulation can linger after we hang up.
 
 ## Proof runs (control-industry)
 
+All three `COMPLETED` with `goal_success: true`, a linked `trace_ids`, and exactly one
+actual per expected tool (`handoff_to_scheduler`, `schedule_appointment`).
+
 | runtime | agent | sim | run | result | link |
 | --- | --- | --- | --- | --- | --- |
-| cascaded | 30519 | 30223 | 224783 | 710922 | https://app.getbluejay.ai/simulations/30223/runs/224783 |
-| openai-realtime-2.1 | 30520 | 30224 | 224784 | 710923 | https://app.getbluejay.ai/simulations/30224/runs/224784 |
-| gemini-flash-live-3.1 | 30521 | 30225 | 224785 | 710924 | https://app.getbluejay.ai/simulations/30225/runs/224785 |
+| cascaded | 30519 | 30223 | 225189 | 712620 | https://app.getbluejay.ai/simulations/30223/runs/225189 |
+| openai-realtime-2.1 | 30520 | 30224 | 225198 | 712629 | https://app.getbluejay.ai/simulations/30224/runs/225198 |
+| gemini-flash-live-3.1 | 30521 | 30225 | 225188 | 712619 | https://app.getbluejay.ai/simulations/30225/runs/225188 |
 
 ## Runtime notes
 
@@ -90,13 +95,30 @@ fires — the fix is to make the wait long enough that it does not.
   waiting for a final status can take ~1 min and the entrypoint gets
   `session_end_timeout` (300 s) versus a shutdown callback's
   `shutdown_process_timeout` (10 s).
-* **Gemini 3.1 Live is degraded by plugin design.**
+* **All three runtimes do a real two-agent handoff.** `handoff_to_scheduler` is a
+  `@function_tool` on `Receptionist` that returns a `Scheduler` *instance*, so
+  LiveKit swaps the active `Agent`. The two agents never share a prompt or a tool
+  set: the receptionist is physically unable to call `schedule_appointment` and the
+  scheduler is unable to call `handoff_to_scheduler` (asserted by
+  `test_harness.test_real_handoff`).
+* **Gemini 3.1 Live gets one model instance per agent.**
   `livekit/plugins/google/realtime/realtime_api.py` sets
-  `mutable = "3.1" not in model`, which turns off `mutable_instructions`,
-  `mutable_chat_context` and `mutable_tools`. Consequences:
-  * no in-framework Agent handoff (a swapped Agent's prompt and tools would never
-    reach the session) — this runtime uses `harness.Combined`: one agent, both
-    blueprint prompts, `handoff_to_scheduler` still runs and still gets a span;
-  * `generate_reply()` is rejected, so the agent cannot open the call from the
-    model. An ElevenLabs TTS is attached purely so `session.say()` can deliver the
-    scripted greeting; every later turn is native Gemini audio.
+  `mutable = "3.1" not in model`, turning off `mutable_instructions` and
+  `mutable_chat_context` (`mutable_tools` is off for every Gemini Live model).
+  Those flags only forbid *mutating a live session*, not running two of them:
+  * `AgentActivity._detach_reusable_resources` carries the realtime session across
+    a handoff only when `self.llm is new_activity.llm`. This runtime gives the
+    `Receptionist` and the `Scheduler` their own `RealtimeModel`, so the handoff
+    falls through to `llm.session()` and a second Gemini Live socket is opened with
+    the scheduler's `system_instruction` and only the scheduler's `tools`
+    (`_build_connect_config`). The debug log shows *two* "created new realtime
+    session for activity" lines and no "reusing realtime session";
+  * `generate_reply()` is still rejected, so the model cannot open a turn on its
+    own. An ElevenLabs TTS is attached so `session.say()` can deliver the two
+    scripted lines (the call greeting and `harness.SCHEDULER_OPENER`, which is step
+    1 of `scheduler.md` verbatim); every other turn is native Gemini audio.
+* **OpenAI Realtime reuses the socket, by design.** Its capabilities are all
+  mutable, so LiveKit keeps the WebSocket and re-pushes the scheduler's
+  instructions and tool list with a `session.update` (`_start_session`, `rt_reused`
+  branch). Still a real agent switch — the model is handed a different prompt and a
+  different tool set — just without a reconnect.

--- a/voice-agent-harnesses/livekit/README.md
+++ b/voice-agent-harnesses/livekit/README.md
@@ -1,3 +1,102 @@
-# livekit
+# LiveKit Agents harness
 
-Benchmarks and evaluation assets for livekit voice agents.
+Three LiveKit Agents runtimes over the shared `control-industry` blueprint, reached
+by **native Bluejay `LIVEKIT` dispatch** — Bluejay creates the room and dispatches
+our `agent_name` into it. There is **no CHIRP bridge, no tool webhook and no
+cloudflared tunnel**: LiveKit runs our code, so every tool body executes in this
+process and is wrapped directly in an `execute_tool` span.
+
+| runtime | stack | LiveKit `agent_name` |
+| --- | --- | --- |
+| `cascaded/` | Deepgram Flux `flux-general-en` STT + OpenAI `gpt-4.1` + ElevenLabs `eleven_flash_v2_5` | `mivas-livekit-cascaded` |
+| `openai-realtime-2.1/` | OpenAI Realtime `gpt-realtime-2.1` (S2S) | `mivas-livekit-openai-realtime` |
+| `gemini-flash-live-3.1/` | Google `gemini-3.1-flash-live-preview` (S2S) | `mivas-livekit-gemini-live` |
+
+`cascaded` is STT/LLM/TTS-matched to the Vapi and Cartesia cascaded harnesses, so
+the framework is the only variable.
+
+## Layout
+
+```
+harness.py     blueprint load, Receptionist/Scheduler/Combined agents, run_tool, serve()
+report.py      OTel → Bluejay OTLP + the single post-final update-simulation-result
+<runtime>/agent.py   plugin wiring for one stack; everything else comes from harness.py
+```
+
+## Run
+
+The worker registers with LiveKit Cloud and waits for Bluejay to dispatch it, so it
+can run locally — which is also how it reaches the industry tool server on
+`127.0.0.1:8000`.
+
+```bash
+cd voice-agent-harnesses/livekit
+uv venv --python 3.12 .venv && uv pip install --python .venv/bin/python -r requirements.txt
+cp .env.example .env      # fill in; LIVEKIT_* must be the project on the Bluejay org's LiveKit integration
+
+# terminal A — shared industry tool server (do not restart if another harness is using it)
+uv run python industries/control-industry/tool_server.py
+
+# terminal B/C/D — one worker per runtime
+.venv/bin/python cascaded/agent.py dev
+.venv/bin/python openai-realtime-2.1/agent.py dev
+.venv/bin/python gemini-flash-live-3.1/agent.py dev
+```
+
+Then queue a Bluejay run against an agent whose `connection_type=LIVEKIT` and
+`livekit_agent_name` matches (or pass `livekit_agent_name` to
+`queue-simulation-run`). **Do not** pass `livekit_metadata` at queue time: a
+simulation-run-level metadata dict *replaces* the test-case one, and the test-case
+one is where Bluejay injects `X-Simulation-Result-Id`.
+
+## Telemetry
+
+```
+voice.call                      root, attr bluejay.simulation_result_id
+  ├── agent.speech              AgentSession agent_state_changed → speaking
+  ├── customer.speech           AgentSession user_state_changed → speaking
+  └── execute_tool <name>       handoff_to_scheduler / schedule_appointment / end_call
+```
+
+All three tools are ours, so all three produce real spans — there is no
+provider-internal step to leave untimed. Only `trace_ids` is POSTed
+(`tool_calls` would double-count against the OTel-extracted tools), and only once,
+after the simulation reaches a final status.
+
+The exporter is attached to a **private** `TracerProvider` rather than the global
+one. livekit-agents resolves its own tracer off the global provider, and setting it
+would ship the framework's entire internal span tree to Bluejay as unrelated traces.
+
+`_await_terminal_upsert` waits **300 s** here, not the 150 s the CHIRP harnesses
+use. Result 710911 proved why: its evaluation took longer than 150 s, the wait
+fell through to `_relink_after_final`, the link had by then been wiped, and the
+relink POST appended a second copy of every tool (`handoff_to_scheduler` actual=2,
+`end_call` actual=2). The relink net still double-counts whenever it actually
+fires — the fix is to make the wait long enough that it does not.
+
+## Proof runs (control-industry)
+
+| runtime | agent | sim | run | result | link |
+| --- | --- | --- | --- | --- | --- |
+| cascaded | 30519 | 30223 | 224783 | 710922 | https://app.getbluejay.ai/simulations/30223/runs/224783 |
+| openai-realtime-2.1 | 30520 | 30224 | 224784 | 710923 | https://app.getbluejay.ai/simulations/30224/runs/224784 |
+| gemini-flash-live-3.1 | 30521 | 30225 | 224785 | 710924 | https://app.getbluejay.ai/simulations/30225/runs/224785 |
+
+## Runtime notes
+
+* **Job executor is THREAD, not PROCESS.** `spawn` pickles the entrypoint by
+  reference and ours is a closure over the runtime's session/agent factories.
+* **The trace-linking POST lives in the entrypoint**, not a shutdown callback:
+  waiting for a final status can take ~1 min and the entrypoint gets
+  `session_end_timeout` (300 s) versus a shutdown callback's
+  `shutdown_process_timeout` (10 s).
+* **Gemini 3.1 Live is degraded by plugin design.**
+  `livekit/plugins/google/realtime/realtime_api.py` sets
+  `mutable = "3.1" not in model`, which turns off `mutable_instructions`,
+  `mutable_chat_context` and `mutable_tools`. Consequences:
+  * no in-framework Agent handoff (a swapped Agent's prompt and tools would never
+    reach the session) — this runtime uses `harness.Combined`: one agent, both
+    blueprint prompts, `handoff_to_scheduler` still runs and still gets a span;
+  * `generate_reply()` is rejected, so the agent cannot open the call from the
+    model. An ElevenLabs TTS is attached purely so `session.say()` can deliver the
+    scripted greeting; every later turn is native Gemini audio.

--- a/voice-agent-harnesses/livekit/cascaded/agent.py
+++ b/voice-agent-harnesses/livekit/cascaded/agent.py
@@ -1,0 +1,47 @@
+"""MIVAS LiveKit runtime — cascaded: Deepgram Flux + GPT-4.1 + ElevenLabs Flash v2.5.
+
+Same STT/LLM/TTS as the Vapi/Cartesia cascaded harnesses, so the stack is the
+control variable and the framework is what changes.
+
+    python cascaded/agent.py dev      # local worker, picks up Bluejay dispatch
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[3] / ".env")
+load_dotenv(Path(__file__).resolve().parents[1] / ".env", override=True)
+
+from livekit.agents import AgentSession, TurnHandlingOptions  # noqa: E402
+from livekit.plugins import deepgram, elevenlabs, openai, silero  # noqa: E402
+
+import harness  # noqa: E402
+
+AGENT_NAME = "mivas-livekit-cascaded"
+MODEL = "gpt-4.1"
+
+
+def build_session(_bp):
+    return AgentSession(
+        turn_handling=TurnHandlingOptions(turn_detection="stt"),
+        stt=deepgram.STTv2(model="flux-general-en"),
+        llm=openai.LLM(model=MODEL),
+        tts=elevenlabs.TTS(model="eleven_flash_v2_5", voice_id="21m00Tcm4TlvDq8ikWAM"),
+        vad=silero.VAD.load(),
+        max_tool_steps=8,
+    )
+
+
+if __name__ == "__main__":
+    harness.serve(
+        AGENT_NAME,
+        build_session=build_session,
+        build_agent=lambda bp, hangup: harness.Receptionist(bp, hangup),
+        model=MODEL,
+    )

--- a/voice-agent-harnesses/livekit/gemini-flash-live-3.1/agent.py
+++ b/voice-agent-harnesses/livekit/gemini-flash-live-3.1/agent.py
@@ -1,23 +1,30 @@
 """MIVAS LiveKit runtime — Gemini `gemini-3.1-flash-live-preview` (speech-to-speech).
 
-Two constraints the plugin imposes on any "3.1" Live model
-(`livekit/plugins/google/realtime/realtime_api.py`: `mutable = "3.1" not in model`):
+`livekit/plugins/google/realtime/realtime_api.py` sets `mutable = "3.1" not in model`,
+so `mutable_instructions` / `mutable_chat_context` are False (and `mutable_tools` is
+False for every Gemini Live model). Those flags only forbid *mutating a live session*,
+not running two of them, so this runtime does a real agent handoff by giving each
+`Agent` its own `RealtimeModel`:
 
-* `mutable_instructions` / `mutable_chat_context` / `mutable_tools` are False, so
-  the system prompt MUST go to the `RealtimeModel` constructor and the agent may
-  not be swapped mid-session — this runtime uses `harness.Combined`
-  (one agent, both blueprint prompts, soft handoff) instead of a real Agent handoff.
-* `generate_reply()` is rejected, so the agent cannot open the call from the model.
-  A TTS is attached purely so `session.say()` can deliver the scripted greeting;
-  every later turn is native Gemini audio.
+* `AgentActivity._detach_reusable_resources` reuses the realtime session only when
+  `self.llm is new_activity.llm`. Two instances => no reuse => `_start_session` calls
+  `llm.session()` and logs "created new realtime session for activity".
+* the fresh session has no active socket yet, so `update_instructions`/`update_tools`
+  land on `_opts`/`_tools` and `_build_connect_config` sends them as the connect-time
+  `system_instruction` and `tools` — the scheduler prompt and *only* the scheduler's
+  tools reach the model.
+* `generate_reply()` is still rejected, so the ElevenLabs TTS delivers the two
+  scripted lines (call greeting, scheduler opener); every other turn is Gemini audio.
 
     python gemini-flash-live-3.1/agent.py dev
 """
 
 from __future__ import annotations
 
+import asyncio
 import sys
 from pathlib import Path
+from typing import Any
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
@@ -36,16 +43,32 @@ AGENT_NAME = "mivas-livekit-gemini-live"
 MODEL = "gemini-3.1-flash-live-preview"
 
 
-def build_session(bp):
+def _model(instructions: str) -> lk_google.realtime.RealtimeModel:
+    return lk_google.realtime.RealtimeModel(
+        model=MODEL, voice="Puck", language="en-US", instructions=instructions
+    )
+
+
+def build_session(_bp: dict[str, Any]) -> AgentSession:
+    # no session-level llm on purpose: each agent brings its own, which is what makes
+    # the handoff open a second Gemini Live session instead of reusing the first.
     return AgentSession(
-        llm=lk_google.realtime.RealtimeModel(
-            model=MODEL,
-            voice="Puck",
-            language="en-US",
-            instructions=harness.combined_instructions(bp),
-        ),
         tts=elevenlabs.TTS(model="eleven_flash_v2_5", voice_id="21m00Tcm4TlvDq8ikWAM"),
         max_tool_steps=8,
+    )
+
+
+def build_agent(bp: dict[str, Any], hangup: asyncio.Event) -> harness.Receptionist:
+    return harness.Receptionist(
+        bp,
+        hangup,
+        llm=_model(bp["agents"]["receptionist"]["instructions"]),
+        make_scheduler=lambda: harness.Scheduler(
+            bp,
+            hangup,
+            llm=_model(bp["agents"]["scheduler"]["instructions"]),
+            opener=harness.SCHEDULER_OPENER,
+        ),
     )
 
 
@@ -53,7 +76,7 @@ if __name__ == "__main__":
     harness.serve(
         AGENT_NAME,
         build_session=build_session,
-        build_agent=lambda bp, hangup: harness.Combined(bp, hangup),
+        build_agent=build_agent,
         model=MODEL,
         greet="say",
     )

--- a/voice-agent-harnesses/livekit/gemini-flash-live-3.1/agent.py
+++ b/voice-agent-harnesses/livekit/gemini-flash-live-3.1/agent.py
@@ -1,0 +1,59 @@
+"""MIVAS LiveKit runtime — Gemini `gemini-3.1-flash-live-preview` (speech-to-speech).
+
+Two constraints the plugin imposes on any "3.1" Live model
+(`livekit/plugins/google/realtime/realtime_api.py`: `mutable = "3.1" not in model`):
+
+* `mutable_instructions` / `mutable_chat_context` / `mutable_tools` are False, so
+  the system prompt MUST go to the `RealtimeModel` constructor and the agent may
+  not be swapped mid-session — this runtime uses `harness.Combined`
+  (one agent, both blueprint prompts, soft handoff) instead of a real Agent handoff.
+* `generate_reply()` is rejected, so the agent cannot open the call from the model.
+  A TTS is attached purely so `session.say()` can deliver the scripted greeting;
+  every later turn is native Gemini audio.
+
+    python gemini-flash-live-3.1/agent.py dev
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[3] / ".env")
+load_dotenv(Path(__file__).resolve().parents[1] / ".env", override=True)
+
+from livekit.agents import AgentSession  # noqa: E402
+from livekit.plugins import elevenlabs  # noqa: E402
+from livekit.plugins import google as lk_google  # noqa: E402
+
+import harness  # noqa: E402
+
+AGENT_NAME = "mivas-livekit-gemini-live"
+MODEL = "gemini-3.1-flash-live-preview"
+
+
+def build_session(bp):
+    return AgentSession(
+        llm=lk_google.realtime.RealtimeModel(
+            model=MODEL,
+            voice="Puck",
+            language="en-US",
+            instructions=harness.combined_instructions(bp),
+        ),
+        tts=elevenlabs.TTS(model="eleven_flash_v2_5", voice_id="21m00Tcm4TlvDq8ikWAM"),
+        max_tool_steps=8,
+    )
+
+
+if __name__ == "__main__":
+    harness.serve(
+        AGENT_NAME,
+        build_session=build_session,
+        build_agent=lambda bp, hangup: harness.Combined(bp, hangup),
+        model=MODEL,
+        greet="say",
+    )

--- a/voice-agent-harnesses/livekit/harness.py
+++ b/voice-agent-harnesses/livekit/harness.py
@@ -11,11 +11,13 @@ token with a `RoomAgentDispatch` for our `agent_name`, and puts
 `X-Simulation-Result-Id` on the job metadata (see livekit_agent
 `src/agent_bootstrap/hydration.py`). There is no CHIRP bridge.
 
-Gemini 3.1 Live is the one runtime that cannot use the in-framework handoff:
-`livekit.plugins.google` sets `mutable_chat_context/instructions/tools = False`
-for any "3.1" model, so swapping the active `Agent` would silently keep the old
-prompt and tools. That runtime uses `Combined` (one agent, both prompts, soft
-handoff) — the tool still runs and still gets its span.
+All three runtimes use the same handoff, including the speech-to-speech ones. The
+`mutable_*` capability flags only gate *mutating an existing* realtime session, so
+a runtime whose model cannot be mutated (Gemini 3.1 Live) gives each `Agent` its
+own `llm=` instead: `AgentActivity._detach_reusable_resources` only reuses the
+realtime session when `self.llm is new_activity.llm`, so a distinct model instance
+forces `llm.session()` — a second, independently configured provider session with
+the new agent's prompt and only the new agent's tools.
 """
 
 from __future__ import annotations
@@ -29,11 +31,13 @@ from typing import Any, Callable
 
 import httpx
 from livekit.agents import (
+    NOT_GIVEN,
     Agent,
     AgentServer,
     AgentSession,
     JobContext,
     JobExecutorType,
+    NotGivenOr,
     RunContext,
     cli,
     function_tool,
@@ -47,6 +51,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 TOOL_SERVER_URL = os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
 INDUSTRY = os.environ.get("INDUSTRY", "control-industry")
 GREETING = "Welcome to Bluejay's Repair Services!"
+# step 1 of system-prompts/scheduler.md, verbatim. Only used by runtimes whose model
+# rejects generate_reply() (see Scheduler.on_enter); every other turn is model-generated.
+SCHEDULER_OPENER = "Hey, when do you want to schedule your repair appointment?"
 # the caller hangs up too; this is just long enough for the goodbye to play out
 HANGUP_GRACE_S = 4.0
 
@@ -125,15 +132,34 @@ async def _end_call(reason: str, hangup: asyncio.Event) -> dict[str, Any]:
 
 
 class Scheduler(Agent):
-    """Books the appointment. Reached by handoff (or is the whole agent, gemini)."""
+    """Books the appointment. Reached by handoff from the receptionist.
 
-    def __init__(self, bp: dict[str, Any], hangup: asyncio.Event, *, greet_on_enter: bool = True):
-        super().__init__(instructions=bp["agents"]["scheduler"]["instructions"])
+    `llm` is the per-agent model override. Passing a distinct instance is what makes
+    the handoff a real switch on models that cannot be mutated mid-session: LiveKit
+    only carries the realtime session across a handoff when the two activities share
+    the *same* model object, so a fresh instance means a fresh provider session
+    configured with this agent's prompt and this agent's tools.
+    """
+
+    def __init__(
+        self,
+        bp: dict[str, Any],
+        hangup: asyncio.Event,
+        *,
+        llm: NotGivenOr[Any] = NOT_GIVEN,
+        opener: str | None = None,
+    ):
+        super().__init__(instructions=bp["agents"]["scheduler"]["instructions"], llm=llm)
         self._hangup = hangup
-        self._greet_on_enter = greet_on_enter
+        self._opener = opener
 
     async def on_enter(self) -> None:
-        if self._greet_on_enter:
+        # generate_reply() is rejected by realtime models with mutable_chat_context=False
+        # (google plugin, any "3.1" model); those runtimes pass `opener` and the session
+        # TTS speaks the scheduler's scripted first line instead.
+        if self._opener:
+            self.session.say(self._opener)
+        else:
             self.session.generate_reply()
 
     @function_tool
@@ -159,10 +185,19 @@ class Scheduler(Agent):
 class Receptionist(Agent):
     """Greets, then hands off in-framework by returning the Scheduler instance."""
 
-    def __init__(self, bp: dict[str, Any], hangup: asyncio.Event):
-        super().__init__(instructions=bp["agents"]["receptionist"]["instructions"])
-        self._bp = bp
+    def __init__(
+        self,
+        bp: dict[str, Any],
+        hangup: asyncio.Event,
+        *,
+        llm: NotGivenOr[Any] = NOT_GIVEN,
+        make_scheduler: Callable[[], Agent] | None = None,
+    ):
+        super().__init__(instructions=bp["agents"]["receptionist"]["instructions"], llm=llm)
         self._hangup = hangup
+        # runtimes whose model can't be mutated mid-session pass a factory that gives the
+        # Scheduler its own model instance; everyone else shares the session's.
+        self._make_scheduler = make_scheduler or (lambda: Scheduler(bp, hangup))
 
     @function_tool
     async def handoff_to_scheduler(self, context: RunContext) -> Agent:
@@ -174,7 +209,7 @@ class Receptionist(Agent):
         # opener. The blueprint forbids that, and the two overlapping turns let the
         # caller's "okay, thank you" land on the scheduler as "I'm done" -> end_call
         # before anything is booked.
-        return Scheduler(self._bp, self._hangup)
+        return self._make_scheduler()
 
     @function_tool
     async def end_call(self, context: RunContext, reason: str) -> dict[str, Any]:
@@ -185,36 +220,6 @@ class Receptionist(Agent):
             reason: Why the call is ending
         """
         return await _end_call(reason, self._hangup)
-
-
-class Combined(Scheduler):
-    """Single-agent variant for models that cannot swap prompt/tools mid-session.
-
-    Both blueprint prompts live in one instruction block and `handoff_to_scheduler`
-    returns a string instead of an Agent, so the tool call is still real and timed
-    but nothing has to mutate on the realtime session.
-    """
-
-    def __init__(self, bp: dict[str, Any], hangup: asyncio.Event):
-        Agent.__init__(self, instructions=combined_instructions(bp))
-        self._hangup = hangup
-        self._greet_on_enter = False
-
-    @function_tool
-    async def handoff_to_scheduler(self, context: RunContext) -> dict[str, Any]:
-        """Hand off the caller to the Bluejay's Repair Services scheduler agent."""
-        return await run_tool("handoff_to_scheduler", {})
-
-
-def combined_instructions(bp: dict[str, Any]) -> str:
-    return (
-        bp["agents"]["receptionist"]["instructions"]
-        + "\n\n---\n\n"
-        + bp["agents"]["scheduler"]["instructions"]
-        + "\n\n# Handoff\n\nYou play both roles in one session. After you call "
-        "`handoff_to_scheduler`, continue as the scheduler above and book the "
-        "appointment yourself.\n"
-    )
 
 
 # ── job plumbing ─────────────────────────────────────────────────────────────

--- a/voice-agent-harnesses/livekit/harness.py
+++ b/voice-agent-harnesses/livekit/harness.py
@@ -110,9 +110,7 @@ async def run_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
             ok = True
         except Exception as e:  # soft-fail: the call (and its trace) must still finish
             result, ok = {"success": False, "error": f"{type(e).__name__}: {e}"}, False
-        report.finish_tool_span(
-            span, result, ok=ok, name=name, parameters=args, start_offset_ms=offset
-        )
+        report.finish_tool_span(span, result, ok=ok)
     logger.info("tool %s args=%s -> %s (+%dms)", name, args, result, offset)
     return result
 

--- a/voice-agent-harnesses/livekit/harness.py
+++ b/voice-agent-harnesses/livekit/harness.py
@@ -1,0 +1,365 @@
+"""control-industry blueprint → LiveKit Agents, shared by all three runtimes.
+
+LiveKit runs our code, so unlike the Vapi/Retell/Bland/Cartesia harnesses there is
+no tool webhook and no tunnel: every tool body runs in this process and is wrapped
+directly in an `execute_tool` span. Multi-agent handoff is in-framework — the
+receptionist's `handoff_to_scheduler` returns the `Scheduler` agent instance — so
+the handoff is a real, timed tool call rather than a provider-internal jump.
+
+Transport is native Bluejay `LIVEKIT` dispatch: Bluejay creates the room, mints a
+token with a `RoomAgentDispatch` for our `agent_name`, and puts
+`X-Simulation-Result-Id` on the job metadata (see livekit_agent
+`src/agent_bootstrap/hydration.py`). There is no CHIRP bridge.
+
+Gemini 3.1 Live is the one runtime that cannot use the in-framework handoff:
+`livekit.plugins.google` sets `mutable_chat_context/instructions/tools = False`
+for any "3.1" model, so swapping the active `Agent` would silently keep the old
+prompt and tools. That runtime uses `Combined` (one agent, both prompts, soft
+handoff) — the tool still runs and still gets its span.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Callable
+
+import httpx
+from livekit.agents import (
+    Agent,
+    AgentServer,
+    AgentSession,
+    JobContext,
+    JobExecutorType,
+    RunContext,
+    cli,
+    function_tool,
+)
+
+import report
+
+logger = logging.getLogger("mivas.livekit")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+TOOL_SERVER_URL = os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
+INDUSTRY = os.environ.get("INDUSTRY", "control-industry")
+GREETING = "Welcome to Bluejay's Repair Services!"
+# the caller hangs up too; this is just long enough for the goodbye to play out
+HANGUP_GRACE_S = 4.0
+
+
+# ── blueprint ────────────────────────────────────────────────────────────────
+
+
+def industry_path(name: str | Path) -> Path:
+    path = Path(name)
+    if path.is_dir():
+        return path.resolve()
+    env_dir = os.environ.get("INDUSTRY_DIR", "").strip()
+    if env_dir and Path(env_dir).is_dir():
+        return Path(env_dir).resolve()
+    return (REPO_ROOT / "industries" / name).resolve()
+
+
+def load_blueprint(industry_dir: str | Path = INDUSTRY) -> dict[str, Any]:
+    industry_dir = industry_path(industry_dir)
+    blueprint = json.loads((industry_dir / "agent_blueprint.json").read_text())
+    catalog = {
+        t["name"]: t for t in json.loads((industry_dir / "tools.json").read_text())["tools"]
+    }
+    agents = {
+        entry["name"]: {
+            "name": entry["name"],
+            "instructions": (industry_dir / entry["system_prompt"]).read_text(),
+            "tools": entry["tools"],
+        }
+        for entry in blueprint["agents"]
+    }
+    return {
+        "industry_dir": industry_dir,
+        "start": blueprint["agents"][0]["name"],
+        "agents": agents,
+        "catalog": catalog,
+    }
+
+
+# ── tools (in-process, each under an execute_tool span) ──────────────────────
+
+
+async def _execute(name: str, args: dict[str, Any]) -> dict[str, Any]:
+    if name == "schedule_appointment":
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            r = await client.post(f"{TOOL_SERVER_URL}/appointments", json={"date": args["date"]})
+            r.raise_for_status()
+            return {"success": True, "date": r.json()["date"]}
+    if name in ("handoff_to_scheduler", "end_call"):
+        # harness-local: no industry state to mutate, the span is the artifact
+        return {"success": True}
+    return {"success": False, "error": f"unknown tool {name}"}
+
+
+async def run_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Run one blueprint tool under an `execute_tool` span. Never raises."""
+    offset = report.call_offset_ms()
+    with report.tool_span(name, args) as span:
+        try:
+            result = await _execute(name, args)
+            ok = True
+        except Exception as e:  # soft-fail: the call (and its trace) must still finish
+            result, ok = {"success": False, "error": f"{type(e).__name__}: {e}"}, False
+        report.finish_tool_span(
+            span, result, ok=ok, name=name, parameters=args, start_offset_ms=offset
+        )
+    logger.info("tool %s args=%s -> %s (+%dms)", name, args, result, offset)
+    return result
+
+
+async def _end_call(reason: str, hangup: asyncio.Event) -> dict[str, Any]:
+    result = await run_tool("end_call", {"reason": reason})
+    hangup.set()
+    return result
+
+
+# ── agents ───────────────────────────────────────────────────────────────────
+
+
+class Scheduler(Agent):
+    """Books the appointment. Reached by handoff (or is the whole agent, gemini)."""
+
+    def __init__(self, bp: dict[str, Any], hangup: asyncio.Event, *, greet_on_enter: bool = True):
+        super().__init__(instructions=bp["agents"]["scheduler"]["instructions"])
+        self._hangup = hangup
+        self._greet_on_enter = greet_on_enter
+
+    async def on_enter(self) -> None:
+        if self._greet_on_enter:
+            self.session.generate_reply()
+
+    @function_tool
+    async def schedule_appointment(self, context: RunContext, date: str) -> dict[str, Any]:
+        """Schedule a repair appointment and store it in the database.
+
+        Args:
+            date: Repair appointment date in MM/DD/YYYY format
+        """
+        return await run_tool("schedule_appointment", {"date": date})
+
+    @function_tool
+    async def end_call(self, context: RunContext, reason: str) -> dict[str, Any]:
+        """End the call once the caller is done, or immediately if it is spam or a
+        wrong number. Say goodbye first.
+
+        Args:
+            reason: Why the call is ending
+        """
+        return await _end_call(reason, self._hangup)
+
+
+class Receptionist(Agent):
+    """Greets, then hands off in-framework by returning the Scheduler instance."""
+
+    def __init__(self, bp: dict[str, Any], hangup: asyncio.Event):
+        super().__init__(instructions=bp["agents"]["receptionist"]["instructions"])
+        self._bp = bp
+        self._hangup = hangup
+
+    @function_tool
+    async def handoff_to_scheduler(self, context: RunContext) -> Agent:
+        """Hand off the caller to the Bluejay's Repair Services scheduler agent."""
+        await run_tool("handoff_to_scheduler", {})
+        # return the Agent and nothing else: any non-Agent output sets
+        # reply_required, which makes the receptionist announce the transfer
+        # ("I'll connect you with our scheduler") on top of the scheduler's own
+        # opener. The blueprint forbids that, and the two overlapping turns let the
+        # caller's "okay, thank you" land on the scheduler as "I'm done" -> end_call
+        # before anything is booked.
+        return Scheduler(self._bp, self._hangup)
+
+    @function_tool
+    async def end_call(self, context: RunContext, reason: str) -> dict[str, Any]:
+        """End the call once the caller is done, or immediately if it is spam or a
+        wrong number. Say goodbye first.
+
+        Args:
+            reason: Why the call is ending
+        """
+        return await _end_call(reason, self._hangup)
+
+
+class Combined(Scheduler):
+    """Single-agent variant for models that cannot swap prompt/tools mid-session.
+
+    Both blueprint prompts live in one instruction block and `handoff_to_scheduler`
+    returns a string instead of an Agent, so the tool call is still real and timed
+    but nothing has to mutate on the realtime session.
+    """
+
+    def __init__(self, bp: dict[str, Any], hangup: asyncio.Event):
+        Agent.__init__(self, instructions=combined_instructions(bp))
+        self._hangup = hangup
+        self._greet_on_enter = False
+
+    @function_tool
+    async def handoff_to_scheduler(self, context: RunContext) -> dict[str, Any]:
+        """Hand off the caller to the Bluejay's Repair Services scheduler agent."""
+        return await run_tool("handoff_to_scheduler", {})
+
+
+def combined_instructions(bp: dict[str, Any]) -> str:
+    return (
+        bp["agents"]["receptionist"]["instructions"]
+        + "\n\n---\n\n"
+        + bp["agents"]["scheduler"]["instructions"]
+        + "\n\n# Handoff\n\nYou play both roles in one session. After you call "
+        "`handoff_to_scheduler`, continue as the scheduler above and book the "
+        "appointment yourself.\n"
+    )
+
+
+# ── job plumbing ─────────────────────────────────────────────────────────────
+
+
+def sim_result_id_from_job_metadata(raw: Any) -> str | None:
+    """Bluejay puts X-Simulation-Result-Id on the LiveKit job metadata JSON."""
+    if not raw:
+        return None
+    meta = raw if isinstance(raw, dict) else None
+    if meta is None:
+        try:
+            meta = json.loads(str(raw))
+        except Exception:
+            logger.warning("job.metadata is not valid JSON: %s", raw)
+            return None
+    if not isinstance(meta, dict):
+        return None
+    for key in (
+        "X-Simulation-Result-Id",
+        "x-simulation-result-id",
+        "simulation_result_id",
+        "simulationResultId",
+    ):
+        val = meta.get(key)
+        if val is not None and str(val).strip():
+            return str(val).strip()
+    return None
+
+
+def wire_speech_spans(session: AgentSession) -> None:
+    """agent.speech / customer.speech from real turn events (no silence heuristic)."""
+    spans: dict[str, Any] = {"agent": None, "customer": None}
+    counter = {"n": 0}
+
+    def toggle(who: str, speaking: bool) -> None:
+        if speaking and spans[who] is None:
+            counter["n"] += 1
+            spans[who] = report.start_speech_span(f"{who}-{counter['n']}", speaker=who)
+        elif not speaking and spans[who] is not None:
+            report.end_speech_span(spans[who])
+            spans[who] = None
+
+    @session.on("agent_state_changed")
+    def _agent(ev: Any) -> None:
+        toggle("agent", str(ev.new_state) == "speaking")
+
+    @session.on("user_state_changed")
+    def _user(ev: Any) -> None:
+        toggle("customer", str(ev.new_state) == "speaking")
+
+    @session.on("close")
+    def _close(_ev: Any) -> None:
+        toggle("agent", False)
+        toggle("customer", False)
+
+
+async def run_call(
+    ctx: JobContext,
+    *,
+    build_session: Callable[[dict[str, Any]], AgentSession],
+    build_agent: Callable[[dict[str, Any], asyncio.Event], Agent],
+    model: str,
+    greet: str = "generate_reply",
+) -> None:
+    """Shared entrypoint body: trace the call, run it, then link the trace.
+
+    The POST lives here rather than in a shutdown callback: `traced_run` waits for
+    a *final* simulation status before its single POST (posting during EVALUATING
+    and relinking double-counts every tool), and the entrypoint gets
+    `AgentServer.session_end_timeout` (300 s) to finish while shutdown callbacks
+    only get `shutdown_process_timeout` (10 s).
+    """
+    sim_result_id = sim_result_id_from_job_metadata(ctx.job.metadata)
+    logger.info("job start room=%s sim_result_id=%s model=%s", ctx.room.name, sim_result_id, model)
+
+    bp = load_blueprint()
+    async with report.traced_run(
+        f"mivas-{Path(bp['industry_dir']).name}",
+        simulation_result_id=sim_result_id,
+        model=model,
+    ):
+        hangup = asyncio.Event()
+        disconnected = asyncio.Event()
+
+        @ctx.room.on("disconnected")
+        def _on_disconnect(*_: Any) -> None:
+            disconnected.set()
+
+        session = build_session(bp)
+        wire_speech_spans(session)
+        await session.start(room=ctx.room, agent=build_agent(bp, hangup))
+
+        if greet == "say":
+            # realtime models with mutable_chat_context=False reject generate_reply;
+            # a TTS on the session lets say() deliver the scripted opener instead.
+            session.say(GREETING)
+        elif greet == "generate_reply":
+            session.generate_reply(instructions=f"Greet the caller with: '{GREETING}'")
+
+        done = [asyncio.create_task(hangup.wait()), asyncio.create_task(disconnected.wait())]
+        await asyncio.wait(done, return_when=asyncio.FIRST_COMPLETED)
+        for t in done:
+            t.cancel()
+
+        if hangup.is_set() and not disconnected.is_set():
+            await asyncio.sleep(HANGUP_GRACE_S)
+            try:
+                await ctx.delete_room()
+            except Exception as e:
+                logger.warning("delete_room failed: %s", e)
+        logger.info("call finished room=%s hangup=%s", ctx.room.name, hangup.is_set())
+
+
+def serve(
+    agent_name: str,
+    *,
+    build_session: Callable[[dict[str, Any]], AgentSession],
+    build_agent: Callable[[dict[str, Any], asyncio.Event], Agent],
+    model: str,
+    greet: str = "generate_reply",
+) -> None:
+    """Register one runtime with LiveKit and hand control to the agents CLI."""
+
+    async def entrypoint(ctx: JobContext) -> None:
+        await run_call(
+            ctx,
+            build_session=build_session,
+            build_agent=build_agent,
+            model=model,
+            greet=greet,
+        )
+
+    # THREAD, not the default PROCESS: spawn pickles the entrypoint by reference and
+    # this one is a closure over the runtime's session/agent factories. Threads also
+    # keep the trace-linking POST on a loop that outlives the individual job.
+    server = AgentServer(job_executor_type=JobExecutorType.THREAD)
+    server.rtc_session(agent_name=agent_name)(entrypoint)
+
+    # the agents CLI installs the root handler; just keep the noisy libs down
+    for noisy in ("urllib3", "httpx", "httpcore", "asyncio"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+    logging.getLogger("livekit.plugins.silero").setLevel(logging.ERROR)
+    logger.setLevel(logging.INFO)
+
+    cli.run_app(server)

--- a/voice-agent-harnesses/livekit/openai-realtime-2.1/agent.py
+++ b/voice-agent-harnesses/livekit/openai-realtime-2.1/agent.py
@@ -1,0 +1,40 @@
+"""MIVAS LiveKit runtime — OpenAI Realtime `gpt-realtime-2.1` (speech-to-speech).
+
+    python openai-realtime-2.1/agent.py dev
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from dotenv import load_dotenv
+
+load_dotenv(Path(__file__).resolve().parents[3] / ".env")
+load_dotenv(Path(__file__).resolve().parents[1] / ".env", override=True)
+
+from livekit.agents import AgentSession  # noqa: E402
+from livekit.plugins import openai  # noqa: E402
+
+import harness  # noqa: E402
+
+AGENT_NAME = "mivas-livekit-openai-realtime"
+MODEL = "gpt-realtime-2.1"
+
+
+def build_session(_bp):
+    return AgentSession(
+        llm=openai.realtime.RealtimeModel(model=MODEL, voice="marin"),
+        max_tool_steps=8,
+    )
+
+
+if __name__ == "__main__":
+    harness.serve(
+        AGENT_NAME,
+        build_session=build_session,
+        build_agent=lambda bp, hangup: harness.Receptionist(bp, hangup),
+        model=MODEL,
+    )

--- a/voice-agent-harnesses/livekit/report.py
+++ b/voice-agent-harnesses/livekit/report.py
@@ -1,0 +1,577 @@
+"""OpenTelemetry → Bluejay OTLP for the LiveKit harness.
+
+Cloned from `vapi/report.py` (the corrected single-POST-after-final version).
+Two LiveKit-specific changes:
+
+* the exporter is attached to a **private** TracerProvider instead of the global
+  one, so livekit-agents' own instrumentation does not dump its internal span
+  tree into Bluejay alongside ours;
+* `execute_tool` spans come from the in-process `@function_tool` bodies, and
+  speech spans from real `agent_state_changed` / `user_state_changed` events.
+
+Span tree:
+
+  voice.call (root) — gen_ai.provider.name=livekit
+    ├── agent.speech          (AgentSession agent_state_changed → speaking)
+    ├── customer.speech       (AgentSession user_state_changed → speaking)
+    └── execute_tool <name>   (gen_ai.tool.*; emitted by harness.run_tool)
+
+After the call we POST to update-simulation-result with:
+  - trace_ids  → waterfall flamegraph
+  Conversation tool markers come from execute_tool OTel spans (not a tool_calls POST).
+
+Bluejay supplies simulation_result_id via X-Simulation-Result-Id on the LiveKit
+job metadata (native LIVEKIT dispatch — there is no CHIRP bridge here).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+import threading
+import time
+from contextlib import asynccontextmanager, contextmanager
+from contextvars import ContextVar
+from typing import Any, AsyncIterator, Iterator
+
+import httpx
+from opentelemetry import trace as otel_trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.trace import Span, SpanKind, Status, StatusCode
+
+logger = logging.getLogger("mivas.otel.livekit")
+if not logger.handlers:
+    _h = logging.StreamHandler(sys.stdout)
+    _h.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+    logger.addHandler(_h)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+DEFAULT_OTLP_ENDPOINT = "https://otlp.getbluejay.ai/v1/traces"
+DEFAULT_API_URL = "https://api.getbluejay.ai/v1"
+FINAL_STATUSES = {
+    "COMPLETED",
+    "FAILED",
+    "SYSTEM_ERROR",
+    "NO_ANSWER",
+    "CANCELLED",
+    "NO_CONNECTION",
+}
+EARLY_UPSERT_STATUSES = {"EVALUATING", "EVALUATED", "CONVERSATION_ENDED"}
+PROVIDER = "livekit"
+TRACER_NAME = "mivas.livekit"
+
+_provider: TracerProvider | None = None
+_root_span: ContextVar[Span | None] = ContextVar("mivas_livekit_otel_root", default=None)
+_call_t0: ContextVar[float | None] = ContextVar("mivas_livekit_otel_t0", default=None)
+_reported_tools: ContextVar[list[dict[str, Any]] | None] = ContextVar(
+    "mivas_livekit_reported_tools", default=None
+)
+# module fallbacks when asyncio tasks don't inherit ContextVars
+_active_root: Span | None = None
+_active_t0: float | None = None
+_active_tools: list[dict[str, Any]] | None = None
+
+
+def _api_url() -> str:
+    return os.environ.get("BLUEJAY_API_URL", DEFAULT_API_URL).rstrip("/")
+
+
+def _otlp_endpoint() -> str:
+    return os.environ.get("BLUEJAY_OTLP_ENDPOINT", DEFAULT_OTLP_ENDPOINT)
+
+
+def _service_name() -> str:
+    return os.environ.get("BLUEJAY_SERVICE_NAME", "mivas-livekit")
+
+
+def _api_key() -> str | None:
+    return os.environ.get("BLUEJAY_API_KEY") or None
+
+
+def _json_attr(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, default=str)
+    except Exception:
+        return str(value)
+
+
+def call_offset_ms() -> int:
+    t0 = _call_t0.get()
+    if t0 is None:
+        t0 = _active_t0
+    if t0 is None:
+        return 0
+    return max(0, int((time.monotonic() - t0) * 1000))
+
+
+def setup_otel() -> TracerProvider | None:
+    """Install global OTel exporter to Bluejay OTLP. No-op without BLUEJAY_API_KEY."""
+    global _provider
+
+    api_key = _api_key()
+    if not api_key:
+        return None
+
+    if _provider is not None:
+        return _provider
+
+    endpoint = _otlp_endpoint()
+    resource = Resource.create({SERVICE_NAME: _service_name()})
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(
+        SimpleSpanProcessor(
+            OTLPSpanExporter(endpoint, headers={"X-API-KEY": api_key})
+        )
+    )
+    # deliberately NOT otel_trace.set_tracer_provider(): livekit-agents resolves
+    # its own tracer off the global provider and would export its whole internal
+    # span tree to Bluejay as unrelated traces.
+    _provider = provider
+    logger.info("otel → %s service=%s", endpoint, _service_name())
+    return provider
+
+
+def flush() -> None:
+    if _provider is not None:
+        try:
+            _provider.force_flush()
+        except Exception as e:
+            logger.error("otel flush failed: %s", e)
+
+
+def _tracer():
+    return (_provider or otel_trace.get_tracer_provider()).get_tracer(TRACER_NAME)
+
+
+def _parent_span() -> Span | None:
+    parent = _root_span.get()
+    if parent is not None and parent.get_span_context().is_valid:
+        return parent
+    if _active_root is not None and _active_root.get_span_context().is_valid:
+        return _active_root
+    cur = otel_trace.get_current_span()
+    if cur is not None and cur.get_span_context().is_valid:
+        return cur
+    return None
+
+
+def record_tool_call(
+    name: str,
+    parameters: Any,
+    output: Any,
+    *,
+    start_offset_ms: int | None = None,
+) -> None:
+    """Buffer a tool call for the end-of-call update-simulation-result POST."""
+    tools = _reported_tools.get()
+    if tools is None:
+        tools = _active_tools
+    if tools is None:
+        return
+    tools.append(
+        {
+            "name": str(name),
+            "parameters": parameters if isinstance(parameters, dict) else {"raw": parameters},
+            "output": output,
+            "start_offset_ms": int(
+                start_offset_ms if start_offset_ms is not None else call_offset_ms()
+            ),
+        }
+    )
+
+
+@contextmanager
+def tool_span(
+    name: str,
+    parameters: Any = None,
+    *,
+    call_id: str | None = None,
+) -> Iterator[Span | None]:
+    """Child span under the active voice.call root. No-op outside traced_run."""
+    parent = _parent_span()
+    if parent is None:
+        yield None
+        return
+
+    tracer = _tracer()
+    parent_ctx = otel_trace.set_span_in_context(parent)
+    attrs: dict[str, Any] = {
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.provider.name": PROVIDER,
+        "gen_ai.tool.name": name,
+        "gen_ai.tool.call.arguments": _json_attr(parameters if parameters is not None else {}),
+        # conversation timestamps come from span start vs voice.call (OTel extraction)
+    }
+    if call_id:
+        attrs["gen_ai.tool.call.id"] = str(call_id)
+
+    with tracer.start_as_current_span(
+        f"execute_tool {name}",
+        context=parent_ctx,
+        kind=SpanKind.CLIENT,
+        attributes=attrs,
+    ) as span:
+        try:
+            yield span
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)[:400]))
+            raise
+
+
+def finish_tool_span(
+    span: Span | None,
+    output: Any,
+    *,
+    ok: bool = True,
+    name: str | None = None,
+    parameters: Any = None,
+    start_offset_ms: int | None = None,
+) -> None:
+    if span is not None:
+        span.set_attribute("gen_ai.tool.call.result", _json_attr(output))
+        if ok:
+            span.set_status(Status(StatusCode.OK))
+        else:
+            span.set_status(Status(StatusCode.ERROR, _json_attr(output)[:400]))
+
+
+def start_speech_span(
+    utterance_id: str, *, speaker: str = "agent"
+) -> Span | None:
+    """Begin agent.speech or customer.speech under voice.call."""
+    parent = _parent_span()
+    if parent is None:
+        return None
+    tracer = _tracer()
+    parent_ctx = otel_trace.set_span_in_context(parent)
+    is_customer = speaker in ("customer", "user", "digital_human")
+    span_name = "customer.speech" if is_customer else "agent.speech"
+    attrs: dict[str, Any] = {
+        "gen_ai.operation.name": (
+            "speech_to_text" if is_customer else "text_to_speech"
+        ),
+        "gen_ai.provider.name": PROVIDER,
+        "mivas.utterance_id": str(utterance_id),
+        "mivas.speech.speaker": "customer" if is_customer else "agent",
+        "bluejay.speech.start_offset_ms": call_offset_ms(),
+    }
+    span = tracer.start_span(
+        span_name,
+        context=parent_ctx,
+        kind=SpanKind.INTERNAL,
+        attributes=attrs,
+    )
+    return span
+
+def end_speech_span(span: Span | None) -> None:
+    if span is None:
+        return
+    span.set_attribute("bluejay.speech.end_offset_ms", call_offset_ms())
+    span.set_status(Status(StatusCode.OK))
+    span.end()
+
+
+async def _await_terminal_upsert(
+    client: httpx.AsyncClient, simulation_result_id: str, timeout: float = 300.0
+) -> str | None:
+    """Wait for a *final* status before the upsert.
+
+    300 s, not the 150 s the CHIRP harnesses use: this runs on a detached thread
+    with no job deadline, and Bluejay evaluation has been observed taking >150 s —
+    every timeout falls back to the relink path, which is the one that can
+    double-count.
+
+    Posting during EVALUATING works, but eval then wipes trace_ids and the relink
+    POST re-extracts the execute_tool spans on top of the ones the first POST
+    already produced — every tool lands on the timeline twice. One POST after the
+    sim settles gives a surviving link and one row per tool; `_relink_after_final`
+    stays as the safety net for when this wait times out.
+    """
+    deadline = time.monotonic() + timeout
+    key = _api_key()
+    if not key:
+        return None
+    while time.monotonic() < deadline:
+        try:
+            r = await client.get(
+                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                headers={"X-API-Key": key},
+            )
+            if r.status_code == 200:
+                st = str(
+                    ((r.json() or {}).get("simulation_result") or {}).get("status")
+                )
+                if st in FINAL_STATUSES:
+                    return st
+        except Exception:
+            pass
+        await asyncio.sleep(1.0)
+    return None
+
+
+async def post_simulation_enrichment(
+    simulation_result_id: str,
+    *,
+    trace_id: str | None,
+    tool_calls: list[dict[str, Any]] | None = None,
+) -> None:
+    """Link OTel trace_ids. tool_calls ignored — use execute_tool spans."""
+    del tool_calls
+    key = _api_key()
+    if not key or not simulation_result_id:
+        logger.warning(
+            "skip update-simulation-result — "
+            "simulation_result_id=%s key=%s",
+            simulation_result_id,
+            bool(key),
+        )
+        return
+    if not str(simulation_result_id).isdigit():
+        logger.warning(
+            "skip update-simulation-result — non-numeric sim id=%s",
+            simulation_result_id,
+        )
+        return
+
+    body: dict[str, Any] = {"simulation_result_id": str(simulation_result_id)}
+    if trace_id:
+        body["trace_ids"] = [trace_id]
+    if "trace_ids" not in body and "tool_calls" not in body:
+        logger.warning("skip update-simulation-result — nothing to post")
+        return
+
+    await asyncio.sleep(0.5)
+
+    last_err: str | None = None
+    for attempt in range(1, 4):
+        try:
+            async with httpx.AsyncClient(timeout=20) as client:
+                st = await _await_terminal_upsert(client, simulation_result_id)
+                if st is None:
+                    check = await client.get(
+                        f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                        headers={"X-API-Key": key},
+                    )
+                    if check.status_code == 404:
+                        logger.warning(
+                            "skip update-simulation-result — sim=%s not found",
+                            simulation_result_id,
+                        )
+                        return
+                r = await client.post(
+                    f"{_api_url()}/update-simulation-result",
+                    json=body,
+                    headers={"X-API-Key": key, "Content-Type": "application/json"},
+                )
+                if r.status_code >= 400:
+                    last_err = f"{r.status_code} {r.text[:300]} (status={st})"
+                    logger.error(
+                        "update-simulation-result FAILED attempt=%s %s",
+                        attempt,
+                        last_err,
+                    )
+                    if r.status_code == 404:
+                        return
+                else:
+                    logger.info(
+                        "update-simulation-result ok trace=%s sim=%s terminal=%s attempt=%s",
+                        trace_id,
+                        simulation_result_id,
+                        st,
+                        attempt,
+                    )
+                    if (st is None or st in EARLY_UPSERT_STATUSES) and trace_id:
+                        await _relink_after_final(
+                            client, simulation_result_id, body, key, trace_id, st
+                        )
+                    return
+        except Exception as e:
+            last_err = f"{type(e).__name__}: {e}"
+            logger.error(
+                "update-simulation-result error attempt=%s %s", attempt, last_err
+            )
+        await asyncio.sleep(1.0 * attempt)
+    logger.error("update-simulation-result gave up: %s", last_err)
+
+
+
+async def _relink_after_final(
+    client: httpx.AsyncClient,
+    simulation_result_id: str,
+    body: dict[str, Any],
+    key: str,
+    trace_id: str,
+    early_status: str | None,
+) -> None:
+    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link).
+
+    Only if it actually got wiped: each POST re-extracts the execute_tool spans and
+    appends them, so a redundant relink double-counts every tool on the timeline.
+    """
+    final: str | None = None
+    linked = False
+    deadline = time.monotonic() + 120.0
+    while time.monotonic() < deadline:
+        try:
+            r = await client.get(
+                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                headers={"X-API-Key": key},
+            )
+            if r.status_code == 200:
+                result = (r.json() or {}).get("simulation_result") or {}
+                st = str(result.get("status"))
+                if st in FINAL_STATUSES:
+                    final = st
+                    linked = trace_id in (result.get("trace_ids") or [])
+                    break
+        except Exception:
+            pass
+        await asyncio.sleep(2.0)
+    if final is not None and linked:
+        logger.info(
+            "relink not needed after %s — trace=%s still linked sim=%s final=%s",
+            early_status,
+            trace_id,
+            simulation_result_id,
+            final,
+        )
+        return
+    if final is None:
+        logger.warning(
+            "relink skipped — still not final after early upsert terminal=%s sim=%s",
+            early_status,
+            simulation_result_id,
+        )
+        return
+    r = await client.post(
+        f"{_api_url()}/update-simulation-result",
+        json=body,
+        headers={"X-API-Key": key, "Content-Type": "application/json"},
+    )
+    if r.status_code >= 400:
+        logger.error(
+            "relink after %s FAILED sim=%s %s %s",
+            early_status,
+            simulation_result_id,
+            r.status_code,
+            r.text[:300],
+        )
+    else:
+        logger.info(
+            "relink after %s ok trace=%s sim=%s final=%s",
+            early_status,
+            trace_id,
+            simulation_result_id,
+            final,
+        )
+
+# back-compat alias used by older call sites
+async def post_trace_ids(simulation_result_id: str, trace_id: str) -> None:
+    await post_simulation_enrichment(
+        simulation_result_id, trace_id=trace_id, tool_calls=_reported_tools.get()
+    )
+
+
+@asynccontextmanager
+async def traced_run(
+    workflow_name: str,
+    *,
+    simulation_result_id: str | None = None,
+    model: str | None = None,
+) -> AsyncIterator[None]:
+    """OTel voice.call root; flush + link trace_ids/tool_calls on exit."""
+    global _active_root, _active_t0, _active_tools
+
+    provider = setup_otel()
+    if provider is None:
+        yield
+        return
+
+    tracer = _tracer()
+    attrs: dict[str, Any] = {
+        "gen_ai.system": PROVIDER,
+        "gen_ai.provider.name": PROVIDER,
+        "gen_ai.operation.name": "invoke_agent",
+        "mivas.workflow.name": workflow_name,
+    }
+    if model:
+        attrs["gen_ai.request.model"] = model
+    if simulation_result_id:
+        attrs["bluejay.simulation_result_id"] = str(simulation_result_id)
+
+    otel_tid: str | None = None
+    root_token = None
+    tools_token = None
+    t0 = time.monotonic()
+    t0_token = _call_t0.set(t0)
+    tool_buf: list[dict[str, Any]] = []
+    prev_active = _active_root
+    prev_t0 = _active_t0
+    prev_tools = _active_tools
+    try:
+        with tracer.start_as_current_span(
+            "voice.call",
+            kind=SpanKind.SERVER,
+            attributes=attrs,
+        ) as root:
+            root_token = _root_span.set(root)
+            tools_token = _reported_tools.set(tool_buf)
+            _active_root = root
+            _active_t0 = t0
+            _active_tools = tool_buf
+            ctx = root.get_span_context()
+            if ctx.is_valid:
+                otel_tid = format(ctx.trace_id, "032x")
+                logger.info(
+                    "otel trace_id=%s sim=%s workflow=%s model=%s",
+                    otel_tid,
+                    simulation_result_id,
+                    workflow_name,
+                    model,
+                )
+            try:
+                yield
+            except Exception as e:
+                if type(e).__name__.startswith("ConnectionClosed"):
+                    root.set_status(Status(StatusCode.OK))
+                else:
+                    raise
+    finally:
+        _active_root = prev_active
+        _active_t0 = prev_t0
+        _active_tools = prev_tools
+        if root_token is not None:
+            _root_span.reset(root_token)
+        if tools_token is not None:
+            _reported_tools.reset(tools_token)
+        _call_t0.reset(t0_token)
+        flush()
+        if simulation_result_id and otel_tid:
+            # LiveKit cancels the entrypoint ~15 s after the room closes
+            # ("entrypoint did not exit in time"), which kills any coroutine still
+            # waiting here — and the single POST must not happen until the
+            # simulation reaches a FINAL status. A plain non-daemon thread outlives
+            # the job and keeps the worker process alive until the link lands.
+            threading.Thread(
+                target=asyncio.run,
+                args=(
+                    post_simulation_enrichment(simulation_result_id, trace_id=otel_tid),
+                ),
+                name=f"mivas-link-{simulation_result_id}",
+                daemon=False,
+            ).start()
+        elif simulation_result_id and not otel_tid:
+            logger.error(
+                "have simulation_result_id=%s but no otel trace id to post",
+                simulation_result_id,
+            )

--- a/voice-agent-harnesses/livekit/report.py
+++ b/voice-agent-harnesses/livekit/report.py
@@ -63,20 +63,15 @@ FINAL_STATUSES = {
     "CANCELLED",
     "NO_CONNECTION",
 }
-EARLY_UPSERT_STATUSES = {"EVALUATING", "EVALUATED", "CONVERSATION_ENDED"}
 PROVIDER = "livekit"
 TRACER_NAME = "mivas.livekit"
 
 _provider: TracerProvider | None = None
 _root_span: ContextVar[Span | None] = ContextVar("mivas_livekit_otel_root", default=None)
 _call_t0: ContextVar[float | None] = ContextVar("mivas_livekit_otel_t0", default=None)
-_reported_tools: ContextVar[list[dict[str, Any]] | None] = ContextVar(
-    "mivas_livekit_reported_tools", default=None
-)
 # module fallbacks when asyncio tasks don't inherit ContextVars
 _active_root: Span | None = None
 _active_t0: float | None = None
-_active_tools: list[dict[str, Any]] | None = None
 
 
 def _api_url() -> str:
@@ -164,31 +159,6 @@ def _parent_span() -> Span | None:
     return None
 
 
-def record_tool_call(
-    name: str,
-    parameters: Any,
-    output: Any,
-    *,
-    start_offset_ms: int | None = None,
-) -> None:
-    """Buffer a tool call for the end-of-call update-simulation-result POST."""
-    tools = _reported_tools.get()
-    if tools is None:
-        tools = _active_tools
-    if tools is None:
-        return
-    tools.append(
-        {
-            "name": str(name),
-            "parameters": parameters if isinstance(parameters, dict) else {"raw": parameters},
-            "output": output,
-            "start_offset_ms": int(
-                start_offset_ms if start_offset_ms is not None else call_offset_ms()
-            ),
-        }
-    )
-
-
 @contextmanager
 def tool_span(
     name: str,
@@ -233,9 +203,6 @@ def finish_tool_span(
     output: Any,
     *,
     ok: bool = True,
-    name: str | None = None,
-    parameters: Any = None,
-    start_offset_ms: int | None = None,
 ) -> None:
     if span is not None:
         span.set_attribute("gen_ai.tool.call.result", _json_attr(output))
@@ -291,11 +258,11 @@ async def _await_terminal_upsert(
     every timeout falls back to the relink path, which is the one that can
     double-count.
 
-    Posting during EVALUATING works, but eval then wipes trace_ids and the relink
-    POST re-extracts the execute_tool spans on top of the ones the first POST
-    already produced — every tool lands on the timeline twice. One POST after the
-    sim settles gives a surviving link and one row per tool; `_relink_after_final`
-    stays as the safety net for when this wait times out.
+    Posting during EVALUATING works, but eval then wipes trace_ids, and re-posting
+    makes Bluejay re-extract the execute_tool spans on top of the ones the first
+    POST already produced — every tool lands on the timeline twice. One POST after
+    the sim settles gives a surviving link and one row per tool. On timeout we post
+    anyway and log it; we never re-post, because that is the double-count.
     """
     deadline = time.monotonic() + timeout
     key = _api_key()
@@ -323,10 +290,8 @@ async def post_simulation_enrichment(
     simulation_result_id: str,
     *,
     trace_id: str | None,
-    tool_calls: list[dict[str, Any]] | None = None,
 ) -> None:
-    """Link OTel trace_ids. tool_calls ignored — use execute_tool spans."""
-    del tool_calls
+    """Link OTel trace_ids; conversation tools come from execute_tool spans."""
     key = _api_key()
     if not key or not simulation_result_id:
         logger.warning(
@@ -346,7 +311,7 @@ async def post_simulation_enrichment(
     body: dict[str, Any] = {"simulation_result_id": str(simulation_result_id)}
     if trace_id:
         body["trace_ids"] = [trace_id]
-    if "trace_ids" not in body and "tool_calls" not in body:
+    if "trace_ids" not in body:
         logger.warning("skip update-simulation-result — nothing to post")
         return
 
@@ -390,9 +355,12 @@ async def post_simulation_enrichment(
                         st,
                         attempt,
                     )
-                    if (st is None or st in EARLY_UPSERT_STATUSES) and trace_id:
-                        await _relink_after_final(
-                            client, simulation_result_id, body, key, trace_id, st
+                    if st is None:
+                        logger.warning(
+                            "linked without a final status — sim=%s may still be "
+                            "EVALUATING; if eval wipes trace_ids the link is lost "
+                            "(we do not re-post: a second POST double-counts tools)",
+                            simulation_result_id,
                         )
                     return
         except Exception as e:
@@ -405,83 +373,6 @@ async def post_simulation_enrichment(
 
 
 
-async def _relink_after_final(
-    client: httpx.AsyncClient,
-    simulation_result_id: str,
-    body: dict[str, Any],
-    key: str,
-    trace_id: str,
-    early_status: str | None,
-) -> None:
-    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link).
-
-    Only if it actually got wiped: each POST re-extracts the execute_tool spans and
-    appends them, so a redundant relink double-counts every tool on the timeline.
-    """
-    final: str | None = None
-    linked = False
-    deadline = time.monotonic() + 120.0
-    while time.monotonic() < deadline:
-        try:
-            r = await client.get(
-                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
-                headers={"X-API-Key": key},
-            )
-            if r.status_code == 200:
-                result = (r.json() or {}).get("simulation_result") or {}
-                st = str(result.get("status"))
-                if st in FINAL_STATUSES:
-                    final = st
-                    linked = trace_id in (result.get("trace_ids") or [])
-                    break
-        except Exception:
-            pass
-        await asyncio.sleep(2.0)
-    if final is not None and linked:
-        logger.info(
-            "relink not needed after %s — trace=%s still linked sim=%s final=%s",
-            early_status,
-            trace_id,
-            simulation_result_id,
-            final,
-        )
-        return
-    if final is None:
-        logger.warning(
-            "relink skipped — still not final after early upsert terminal=%s sim=%s",
-            early_status,
-            simulation_result_id,
-        )
-        return
-    r = await client.post(
-        f"{_api_url()}/update-simulation-result",
-        json=body,
-        headers={"X-API-Key": key, "Content-Type": "application/json"},
-    )
-    if r.status_code >= 400:
-        logger.error(
-            "relink after %s FAILED sim=%s %s %s",
-            early_status,
-            simulation_result_id,
-            r.status_code,
-            r.text[:300],
-        )
-    else:
-        logger.info(
-            "relink after %s ok trace=%s sim=%s final=%s",
-            early_status,
-            trace_id,
-            simulation_result_id,
-            final,
-        )
-
-# back-compat alias used by older call sites
-async def post_trace_ids(simulation_result_id: str, trace_id: str) -> None:
-    await post_simulation_enrichment(
-        simulation_result_id, trace_id=trace_id, tool_calls=_reported_tools.get()
-    )
-
-
 @asynccontextmanager
 async def traced_run(
     workflow_name: str,
@@ -490,7 +381,7 @@ async def traced_run(
     model: str | None = None,
 ) -> AsyncIterator[None]:
     """OTel voice.call root; flush + link trace_ids/tool_calls on exit."""
-    global _active_root, _active_t0, _active_tools
+    global _active_root, _active_t0
 
     provider = setup_otel()
     if provider is None:
@@ -511,13 +402,10 @@ async def traced_run(
 
     otel_tid: str | None = None
     root_token = None
-    tools_token = None
     t0 = time.monotonic()
     t0_token = _call_t0.set(t0)
-    tool_buf: list[dict[str, Any]] = []
     prev_active = _active_root
     prev_t0 = _active_t0
-    prev_tools = _active_tools
     try:
         with tracer.start_as_current_span(
             "voice.call",
@@ -525,10 +413,8 @@ async def traced_run(
             attributes=attrs,
         ) as root:
             root_token = _root_span.set(root)
-            tools_token = _reported_tools.set(tool_buf)
             _active_root = root
             _active_t0 = t0
-            _active_tools = tool_buf
             ctx = root.get_span_context()
             if ctx.is_valid:
                 otel_tid = format(ctx.trace_id, "032x")
@@ -549,11 +435,8 @@ async def traced_run(
     finally:
         _active_root = prev_active
         _active_t0 = prev_t0
-        _active_tools = prev_tools
         if root_token is not None:
             _root_span.reset(root_token)
-        if tools_token is not None:
-            _reported_tools.reset(tools_token)
         _call_t0.reset(t0_token)
         flush()
         if simulation_result_id and otel_tid:

--- a/voice-agent-harnesses/livekit/report.py
+++ b/voice-agent-harnesses/livekit/report.py
@@ -249,14 +249,16 @@ def end_speech_span(span: Span | None) -> None:
 
 
 async def _await_terminal_upsert(
-    client: httpx.AsyncClient, simulation_result_id: str, timeout: float = 300.0
+    client: httpx.AsyncClient, simulation_result_id: str, timeout: float = 600.0
 ) -> str | None:
     """Wait for a *final* status before the upsert.
 
-    300 s, not the 150 s the CHIRP harnesses use: this runs on a detached thread
-    with no job deadline, and Bluejay evaluation has been observed taking >150 s —
-    every timeout falls back to the relink path, which is the one that can
-    double-count.
+    600 s, not the 150 s the CHIRP harnesses use: this runs on a detached thread
+    with no job deadline, and the wall clock we have to beat is our own hangup to
+    Bluejay's COMPLETED — which includes the ~2 min the simulation can linger after
+    we hang up, plus evaluation. Result 712617 timed out at 300 s, posted during
+    EVALUATING, and evaluation then wiped its trace_ids: a linked-then-wiped run is
+    unrecoverable, because re-posting is what double-counts every tool.
 
     Posting during EVALUATING works, but eval then wipes trace_ids, and re-posting
     makes Bluejay re-extract the execute_tool spans on top of the ones the first

--- a/voice-agent-harnesses/livekit/requirements.txt
+++ b/voice-agent-harnesses/livekit/requirements.txt
@@ -1,0 +1,6 @@
+livekit-agents[deepgram,openai,elevenlabs,silero,google]>=1.5.14,<2
+python-dotenv>=1.0
+httpx>=0.27
+opentelemetry-api>=1.27.0
+opentelemetry-sdk>=1.27.0
+opentelemetry-exporter-otlp-proto-http>=1.27.0

--- a/voice-agent-harnesses/livekit/test_harness.py
+++ b/voice-agent-harnesses/livekit/test_harness.py
@@ -1,18 +1,22 @@
 """Self-check: `python test_harness.py` (needs the harness venv on sys.path).
 
-Covers the two things that silently break a whole run: the job-metadata parse
-(wrong => no trace ever links to a simulation result) and the blueprint load.
+Covers the three things that silently break a whole run: the job-metadata parse
+(wrong => no trace ever links to a simulation result), the blueprint load, and the
+two-agent split (wrong => a "handoff" that is really one agent holding both prompts).
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-from harness import combined_instructions, load_blueprint, sim_result_id_from_job_metadata
+from livekit.agents import llm as lk_llm
+
+from harness import Receptionist, Scheduler, load_blueprint, sim_result_id_from_job_metadata
 
 
 def test_sim_result_id() -> None:
@@ -33,12 +37,35 @@ def test_blueprint() -> None:
     assert bp["start"] == "receptionist"
     assert set(bp["agents"]) == {"receptionist", "scheduler"}
     assert set(bp["catalog"]) == {"handoff_to_scheduler", "schedule_appointment", "end_call"}
-    combined = combined_instructions(bp)
-    for agent in bp["agents"].values():
-        assert agent["instructions"] in combined
+
+
+def _tool_names(agent) -> set[str]:
+    return set(lk_llm.ToolContext(agent.tools).function_tools)
+
+
+def test_real_handoff() -> None:
+    """The handoff must yield a *different* agent with the scheduler's own prompt and
+    tools — the receptionist must not be able to book, and vice versa."""
+    bp = load_blueprint("control-industry")
+    hangup = asyncio.Event()
+
+    sentinel = object()  # stands in for a per-agent RealtimeModel instance
+    receptionist = Receptionist(
+        bp, hangup, make_scheduler=lambda: Scheduler(bp, hangup, llm=sentinel, opener="hi")
+    )
+    assert _tool_names(receptionist) == {"handoff_to_scheduler", "end_call"}
+    assert receptionist.instructions == bp["agents"]["receptionist"]["instructions"]
+
+    scheduler = asyncio.run(receptionist.handoff_to_scheduler(None))
+    assert isinstance(scheduler, Scheduler)
+    assert _tool_names(scheduler) == {"schedule_appointment", "end_call"}
+    assert scheduler.instructions == bp["agents"]["scheduler"]["instructions"]
+    # each agent carries its own model => LiveKit cannot reuse the realtime session
+    assert scheduler.llm is sentinel and scheduler.llm is not receptionist.llm
 
 
 if __name__ == "__main__":
     test_sim_result_id()
     test_blueprint()
+    test_real_handoff()
     print("ok")

--- a/voice-agent-harnesses/livekit/test_harness.py
+++ b/voice-agent-harnesses/livekit/test_harness.py
@@ -1,0 +1,44 @@
+"""Self-check: `python test_harness.py` (needs the harness venv on sys.path).
+
+Covers the two things that silently break a whole run: the job-metadata parse
+(wrong => no trace ever links to a simulation result) and the blueprint load.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from harness import combined_instructions, load_blueprint, sim_result_id_from_job_metadata
+
+
+def test_sim_result_id() -> None:
+    # what Bluejay actually sends: a JSON string on job.metadata
+    assert (
+        sim_result_id_from_job_metadata(
+            json.dumps({"X-Simulation-Result-Id": "710922", "X-Agent-Id": "30519"})
+        )
+        == "710922"
+    )
+    assert sim_result_id_from_job_metadata({"simulation_result_id": 710922}) == "710922"
+    for empty in (None, "", "{}", "not json", json.dumps({"X-Agent-Id": "1"}), "[]"):
+        assert sim_result_id_from_job_metadata(empty) is None, empty
+
+
+def test_blueprint() -> None:
+    bp = load_blueprint("control-industry")
+    assert bp["start"] == "receptionist"
+    assert set(bp["agents"]) == {"receptionist", "scheduler"}
+    assert set(bp["catalog"]) == {"handoff_to_scheduler", "schedule_appointment", "end_call"}
+    combined = combined_instructions(bp)
+    for agent in bp["agents"].values():
+        assert agent["instructions"] in combined
+
+
+if __name__ == "__main__":
+    test_sim_result_id()
+    test_blueprint()
+    print("ok")

--- a/voice-agent-harnesses/livekit/test_harness.py
+++ b/voice-agent-harnesses/livekit/test_harness.py
@@ -49,9 +49,13 @@ def test_real_handoff() -> None:
     bp = load_blueprint("control-industry")
     hangup = asyncio.Event()
 
-    sentinel = object()  # stands in for a per-agent RealtimeModel instance
+    receptionist_model = object()  # stands in for a per-agent RealtimeModel instance
+    scheduler_model = object()
     receptionist = Receptionist(
-        bp, hangup, make_scheduler=lambda: Scheduler(bp, hangup, llm=sentinel, opener="hi")
+        bp,
+        hangup,
+        llm=receptionist_model,
+        make_scheduler=lambda: Scheduler(bp, hangup, llm=scheduler_model, opener="hi"),
     )
     assert _tool_names(receptionist) == {"handoff_to_scheduler", "end_call"}
     assert receptionist.instructions == bp["agents"]["receptionist"]["instructions"]
@@ -61,7 +65,9 @@ def test_real_handoff() -> None:
     assert _tool_names(scheduler) == {"schedule_appointment", "end_call"}
     assert scheduler.instructions == bp["agents"]["scheduler"]["instructions"]
     # each agent carries its own model => LiveKit cannot reuse the realtime session
-    assert scheduler.llm is sentinel and scheduler.llm is not receptionist.llm
+    assert receptionist.llm is receptionist_model
+    assert scheduler.llm is scheduler_model
+    assert scheduler.llm is not receptionist.llm
 
 
 if __name__ == "__main__":

--- a/voice-agent-harnesses/pipecat/Dockerfile
+++ b/voice-agent-harnesses/pipecat/Dockerfile
@@ -1,0 +1,9 @@
+# Pipecat Cloud agent image. The base image owns the HTTP entrypoint and calls
+# `bot(args)` from /app/bot.py — do not add a CMD.
+FROM dailyco/pipecat-base:latest
+
+COPY requirements.txt requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY *.py ./
+COPY industries ./industries

--- a/voice-agent-harnesses/pipecat/Dockerfile
+++ b/voice-agent-harnesses/pipecat/Dockerfile
@@ -1,6 +1,6 @@
 # Pipecat Cloud agent image. The base image owns the HTTP entrypoint and calls
 # `bot(args)` from /app/bot.py — do not add a CMD.
-FROM dailyco/pipecat-base:latest
+FROM dailyco/pipecat-base:1.7.0
 
 COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt

--- a/voice-agent-harnesses/pipecat/README.md
+++ b/voice-agent-harnesses/pipecat/README.md
@@ -1,3 +1,105 @@
-# pipecat
+# Pipecat harness
 
-Benchmarks and evaluation assets for pipecat voice agents.
+Pipecat runs our code, so this harness is the agent itself — not a bridge to
+someone else's. All three industry tools execute in-process and are wrapped with
+`report.tool_span`, so `handoff_to_scheduler`, `schedule_appointment` and
+`end_call` all produce real `execute_tool` spans with no untimeable gaps.
+
+## Runtimes
+
+| runtime | stack |
+|---|---|
+| `cascaded` | Deepgram Flux `flux-general-en` → OpenAI `gpt-4.1` → ElevenLabs `eleven_flash_v2_5` |
+| `openai-realtime-2.1` | OpenAI Realtime `gpt-realtime-2.1` |
+| `gemini-flash-live-3.1` | Google Gemini Live `gemini-3.1-flash-live-preview` |
+
+One deployed Pipecat Cloud agent serves all three; the runtime is chosen per call
+from the start `body`, i.e. from the Bluejay agent's `pipecat_agent_configuration`.
+The model is a runtime setting, not a deployment property, so three copies of the
+same image would buy nothing.
+
+Handoff is soft (prompt + tool result) rather than Pipecat Flows: Flows does not
+support realtime S2S services, and two of the three runtimes are S2S. Doing it the
+same way in all three keeps the runtimes comparable.
+
+`gemini-flash-live-3.1` additionally carries an ElevenLabs TTS used *only* to speak
+the scripted opener (`harness.GREETING`, verbatim from the receptionist prompt).
+Gemini 3.1 Live will not speak until the caller does, which otherwise burns ~63 s of
+a 180 s call on dead air; the LiveKit harness works around the same plugin limit with
+`session.say(GREETING)`. The model still says everything else itself. The TTS is
+gated by a `FunctionFilter` on both sides — see the comments in `bot.py` — and the
+`LLMRunFrame` is still queued alongside the opener, without which the Gemini service
+answers nothing and the socket closes with `1008`.
+
+## How Bluejay reaches it
+
+`connection_type=PIPECAT` is **not** a CHIRP bridge and not a self-hosted worker.
+Bluejay's LiveKit worker calls Pipecat Cloud:
+
+```
+Bluejay DH ──LiveKit room── bridge ──Daily room── Pipecat Cloud agent (this code)
+                              │
+                              └── POST https://api.pipecat.daily.co/v1/public/<pipecat_agent_name>/start
+                                  Authorization: Bearer <org integrations.pipecat_api_key>
+                                  body = agent.pipecat_agent_configuration
+```
+
+Two consequences that differ from the other harnesses:
+
+- **The bot runs in Pipecat Cloud, so `TOOL_SERVER_URL` must be publicly
+  reachable.** There is no tool webhook, but the industry tool server still needs
+  a tunnel. The URL is passed per-agent in `pipecat_agent_configuration`, so a new
+  cloudflared URL only needs an `update-agent`, not a redeploy.
+- **Bluejay passes no per-run metadata.** LiveKit dispatch injects
+  `X-Simulation-Result-Id` into the job metadata
+  (`livekit_agent/src/agent_bootstrap/hydration.py`); the Pipecat path
+  (`src/agent_bootstrap/connection_handlers.py:handle_pipecat_simulation`) forwards
+  only the *static* `agent.pipecat_agent_configuration` and ignores the run's own
+  `pipecat_agent_configuration`. So the config carries `simulation_id` and
+  `report.resolve_simulation_result_id` looks the live result up over the Bluejay
+  API. That is exact at `max_concurrent: 1`; concurrency needs Bluejay to pass the
+  id through.
+
+The Pipecat Cloud key stored in the org integrations must be a **public** key
+(`pk_...`). `/v1/public/<agent>/start` rejects a private key with
+`PCC-1002 "Attempt to start agent without public api key"`.
+
+## Agent config
+
+```jsonc
+// Bluejay agent: connection_type = PIPECAT, pipecat_agent_name = "mivas-control"
+{
+  "runtime": "cascaded",                                  // or the other two
+  "tool_server_url": "https://<tunnel>.trycloudflare.com",
+  "simulation_id": 30227
+}
+```
+
+## Env
+
+| var | use |
+|---|---|
+| `OPENAI_API_KEY` / `GOOGLE_API_KEY` / `DEEPGRAM_API_KEY` / `ELEVENLABS_API_KEY` | model providers |
+| `BLUEJAY_API_KEY` | OTLP export + `update-simulation-result` + result-id lookup |
+| `BLUEJAY_API_URL`, `BLUEJAY_OTLP_ENDPOINT`, `BLUEJAY_SERVICE_NAME` | defaults are the prod Bluejay endpoints / `mivas-pipecat` |
+| `TOOL_SERVER_URL` | industry tool server; overridden by `body.tool_server_url` |
+| `PIPECAT_PRIVATE_API_KEY` | deploy only (`sk_...`) |
+
+## Commands
+
+```bash
+# tool server (shared, port 8000) + a tunnel the deployed bot can reach
+uv run python industries/control-industry/tool_server.py
+cloudflared tunnel --url http://127.0.0.1:8000 --no-autoupdate
+
+# offline checks
+uv run python voice-agent-harnesses/pipecat/harness.py                       # tools + handoff
+uv run python voice-agent-harnesses/pipecat/cascaded/agent.py                # services + pipeline
+uv run python voice-agent-harnesses/pipecat/openai-realtime-2.1/agent.py
+uv run python voice-agent-harnesses/pipecat/gemini-flash-live-3.1/agent.py
+
+# deploy (REST; no Docker daemon and no interactive CLI login needed)
+set -a && source .env && set +a
+export PIPECAT_PRIVATE_API_KEY=sk_... BLUEJAY_API_KEY=...
+uv run python voice-agent-harnesses/pipecat/deploy.py
+```

--- a/voice-agent-harnesses/pipecat/README.md
+++ b/voice-agent-harnesses/pipecat/README.md
@@ -18,9 +18,35 @@ from the start `body`, i.e. from the Bluejay agent's `pipecat_agent_configuratio
 The model is a runtime setting, not a deployment property, so three copies of the
 same image would buy nothing.
 
-Handoff is soft (prompt + tool result) rather than Pipecat Flows: Flows does not
-support realtime S2S services, and two of the three runtimes are S2S. Doing it the
-same way in all three keeps the runtimes comparable.
+## Handoff
+
+`handoff_to_scheduler` is a real agent switch, not a prompt injection. Each
+blueprint agent gets its own prompt and its own tool set, and the receptionist's
+model is never told `schedule_appointment` exists. Which Pipecat mechanism does
+the switching depends on the runtime, because Pipecat's own machinery does:
+
+| runtime | mechanism |
+|---|---|
+| `cascaded` | **Pipecat Flows** (`pipecat.flows`, now in core; the standalone `pipecat-ai-flows` / `pipecat_flows` is deprecated). One `NodeConfig` per blueprint agent, each with its own `task_messages` and its own `functions`. The consolidated handler returns `(result, next_node)` — `transition_to` / `transition_callback` were removed in Flows 1.0 — and `FlowManager` swaps the context (`ContextStrategy.RESET`) and the advertised tool set (`LLMSetToolsFrame`). |
+| `openai-realtime-2.1`, `gemini-flash-live-3.1` | **`LLMSwitcher`** over one S2S service per blueprint agent. Each service opens its own websocket session with its own `instructions` and its own `tools`; the handoff pushes `ManuallySwitchServiceFrame(service=scheduler_llm)` plus an `LLMRunFrame`, and `ServiceSwitcher`'s per-branch filters wire the call to the other session. |
+
+Flows is not used for the S2S runtimes because it does not support them —
+"Speech-to-speech (realtime) models aren't supported — Gemini Live, OpenAI
+Realtime, Ultravox, and AWS Nova Sonic" — precisely because it transitions by
+mutating one live session's context and tools. Two sessions make that
+unnecessary: nothing is mutated, the call is simply rewired.
+
+Two consequences worth knowing:
+
+- The shared `LLMContext` carries **no tools and no system message**. Context
+  tools would override the S2S services' own (`OpenAIRealtimeLLMService._send_session_update`:
+  "tools given in the context override the tools in the session properties")
+  and hand the receptionist the scheduler's tools. With none set, Pipecat falls
+  back to each service's own tools, including for handler registration
+  (`LLMService._sync_registered_tool_handlers`).
+- Both S2S sessions connect at `StartFrame` (the switcher's filters pass
+  lifecycle frames) and stay connected for the call. The inactive one receives
+  no audio and its output never leaves its branch.
 
 `gemini-flash-live-3.1` additionally carries an ElevenLabs TTS used *only* to speak
 the scripted opener (`harness.GREETING`, verbatim from the receptionist prompt).
@@ -92,7 +118,7 @@ The Pipecat Cloud key stored in the org integrations must be a **public** key
 uv run python industries/control-industry/tool_server.py
 cloudflared tunnel --url http://127.0.0.1:8000 --no-autoupdate
 
-# offline checks
+# offline checks (each asserts the receptionist is never given schedule_appointment)
 uv run python voice-agent-harnesses/pipecat/harness.py                       # tools + handoff
 uv run python voice-agent-harnesses/pipecat/cascaded/agent.py                # services + pipeline
 uv run python voice-agent-harnesses/pipecat/openai-realtime-2.1/agent.py

--- a/voice-agent-harnesses/pipecat/bluejay_setup.py
+++ b/voice-agent-harnesses/pipecat/bluejay_setup.py
@@ -1,0 +1,139 @@
+"""Create/refresh the Bluejay side of the Pipecat proof runs (agent, sim, DH).
+
+Re-run it whenever the cloudflared URL changes: the deployed bot reaches the
+industry tool server through `pipecat_agent_configuration.tool_server_url`, so a
+new tunnel only needs an `update-agent`, never a redeploy.
+
+    export BLUEJAY_API_KEY=...
+    export TOOL_SERVER_URL=https://<tunnel>.trycloudflare.com
+    uv run python voice-agent-harnesses/pipecat/bluejay_setup.py
+
+Ids are cached in `.bluejay-ids.json` next to this file (gitignored).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+HARNESS_DIR = Path(__file__).resolve().parent
+STATE = HARNESS_DIR / ".bluejay-ids.json"
+API = os.environ.get("BLUEJAY_API_URL", "https://api.getbluejay.ai/v1").rstrip("/")
+PIPECAT_AGENT = os.environ.get("PIPECAT_AGENT_NAME", "mivas-control")
+
+RUNTIMES = {
+    "cascaded": "Deepgram Flux flux-general-en + gpt-4.1 + ElevenLabs eleven_flash_v2_5",
+    "openai-realtime-2.1": "OpenAI Realtime gpt-realtime-2.1",
+    "gemini-flash-live-3.1": "Gemini gemini-3.1-flash-live-preview",
+}
+GOALS = [
+    "Hand off to scheduler when the caller wants an appointment",
+    "Schedule a concrete repair appointment date",
+    "End the call when done",
+]
+INTENT = (
+    "Call Bluejay's Repair Services and schedule a repair appointment for next "
+    "Tuesday afternoon."
+)
+SUCCESS = "Appointment is scheduled for a concrete date."
+
+
+def call(path: str, data: dict | None = None) -> dict:
+    key = os.environ.get("BLUEJAY_API_KEY")
+    if not key:
+        sys.exit("BLUEJAY_API_KEY is required")
+    req = urllib.request.Request(
+        API + path,
+        data=json.dumps(data).encode() if data is not None else None,
+        headers={"X-API-Key": key, "Content-Type": "application/json"},
+        method="POST" if data is not None else "GET",
+    )
+    try:
+        with urllib.request.urlopen(req) as r:
+            return json.loads(r.read() or b"{}")
+    except urllib.error.HTTPError as e:
+        raise SystemExit(f"{path} -> {e.code} {e.read().decode()[:600]}") from e
+
+
+def main() -> None:
+    tool_url = os.environ.get("TOOL_SERVER_URL")
+    if not tool_url:
+        sys.exit("TOOL_SERVER_URL must be a PUBLIC url — the bot runs in Pipecat Cloud")
+    industry = HARNESS_DIR.parents[1] / "industries" / "control-industry"
+    prompt = (industry / "system-prompts" / "receptionist.md").read_text()
+
+    state = json.loads(STATE.read_text()) if STATE.exists() else {}
+    by_name = {a["name"]: a["id"] for a in call("/all-agents")}
+
+    for runtime, desc in RUNTIMES.items():
+        st = state.setdefault(runtime, {})
+        name = f"control-industry:pipecat {runtime}"
+        st.setdefault("agent_id", by_name.get(name))
+        if not st["agent_id"]:
+            st["agent_id"] = call("/add-agent", {
+                "name": name,
+                "system_prompt": prompt,
+                "goals": GOALS,
+                "connection_type": "PIPECAT",
+                "mode": "VOICE",
+                "type": "INBOUND",
+                "external_agent_id": f"pipecat/{runtime}",
+                "folder": "MIVAS",
+                "pipecat_agent_name": PIPECAT_AGENT,
+                "pipecat_agent_configuration": {"runtime": runtime},
+            })["agent_id"]
+
+        if not st.get("simulation_id"):
+            st["simulation_id"] = call("/create-simulation", {
+                "agent_id": str(st["agent_id"]),
+                "name": f"MIVAS control — pipecat {runtime}",
+                "description": desc,
+                "max_concurrent": 1,
+                "max_call_duration": 180,
+                "max_call_duration_units": "seconds",
+            })["simulation_id"]
+
+        # the config is the bot's only channel: runtime, tool server, and the
+        # simulation id it resolves the live simulation_result_id from
+        cfg = {
+            "runtime": runtime,
+            "tool_server_url": tool_url.rstrip("/"),
+            "simulation_id": st["simulation_id"],
+        }
+        call("/update-agent", {
+            "agent_id": str(st["agent_id"]),
+            "pipecat_agent_name": PIPECAT_AGENT,
+            "pipecat_agent_configuration": cfg,
+        })
+
+        if not st.get("digital_human_id"):
+            call("/create-digital-humans", {
+                "simulation_ids": [st["simulation_id"]],
+                "digital_humans": [{
+                    "name": f"pipecat {runtime} scheduler caller",
+                    "test_name": f"pipecat {runtime} — schedule next Tuesday afternoon",
+                    "intent": INTENT,
+                    "success_criteria": SUCCESS,
+                    "expected_tool_calls": [
+                        {"name": "handoff_to_scheduler"},
+                        {"name": "schedule_appointment"},
+                    ],
+                    "speaks_first_config": {"speaks_first": False},
+                    "language": "en",
+                    "accent": "american",
+                }],
+            })
+            dhs = call(f"/digital-humans-by-simulation/{st['simulation_id']}")
+            st["digital_human_id"] = (dhs.get("digital_humans") or dhs)[0]["id"]
+
+        print(runtime, st, cfg["tool_server_url"])
+
+    STATE.write_text(json.dumps(state, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/voice-agent-harnesses/pipecat/bluejay_setup.py
+++ b/voice-agent-harnesses/pipecat/bluejay_setup.py
@@ -69,6 +69,9 @@ def main() -> None:
     state = json.loads(STATE.read_text()) if STATE.exists() else {}
     by_name = {a["name"]: a["id"] for a in call("/all-agents")}
 
+    def checkpoint() -> None:
+        STATE.write_text(json.dumps(state, indent=2) + "\n")
+
     for runtime, desc in RUNTIMES.items():
         st = state.setdefault(runtime, {})
         name = f"control-industry:pipecat {runtime}"
@@ -86,6 +89,7 @@ def main() -> None:
                 "pipecat_agent_name": PIPECAT_AGENT,
                 "pipecat_agent_configuration": {"runtime": runtime},
             })["agent_id"]
+            checkpoint()
 
         if not st.get("simulation_id"):
             st["simulation_id"] = call("/create-simulation", {
@@ -96,6 +100,7 @@ def main() -> None:
                 "max_call_duration": 180,
                 "max_call_duration_units": "seconds",
             })["simulation_id"]
+            checkpoint()
 
         # the config is the bot's only channel: runtime, tool server, and the
         # simulation id it resolves the live simulation_result_id from
@@ -129,10 +134,11 @@ def main() -> None:
             })
             dhs = call(f"/digital-humans-by-simulation/{st['simulation_id']}")
             st["digital_human_id"] = (dhs.get("digital_humans") or dhs)[0]["id"]
+            checkpoint()
 
         print(runtime, st, cfg["tool_server_url"])
 
-    STATE.write_text(json.dumps(state, indent=2))
+    checkpoint()
 
 
 if __name__ == "__main__":

--- a/voice-agent-harnesses/pipecat/bot.py
+++ b/voice-agent-harnesses/pipecat/bot.py
@@ -197,6 +197,13 @@ async def run_bot(transport, runtime: str) -> None:
         ending = True
         end_task = asyncio.create_task(_end_call())  # noqa: RUF006 — held on `end_task`
 
+    async def cancel_end_task() -> None:
+        nonlocal end_task
+        if end_task is not None and not end_task.done():
+            end_task.cancel()
+            await asyncio.gather(end_task, return_exceptions=True)
+        end_task = None
+
     if s2s:
         # Each blueprint agent is its own speech-to-speech session, opened with
         # that agent's prompt and that agent's tools. Handing off swaps which
@@ -336,6 +343,7 @@ async def run_bot(transport, runtime: str) -> None:
     @transport.event_handler("on_client_disconnected")
     async def _disconnected(_transport, _client):
         logger.info("client disconnected")
+        await cancel_end_task()
         await worker.cancel()
 
     runner = WorkerRunner(handle_sigint=False)
@@ -343,6 +351,7 @@ async def run_bot(transport, runtime: str) -> None:
     try:
         await runner.run()
     finally:
+        await cancel_end_task()
         observer.close()
 
 

--- a/voice-agent-harnesses/pipecat/bot.py
+++ b/voice-agent-harnesses/pipecat/bot.py
@@ -11,6 +11,9 @@ read from the start `body`, i.e. from the Bluejay agent's
 `simulation_id` is there because Bluejay's Pipecat dispatch passes no per-run
 metadata — `report.resolve_simulation_result_id` turns it into the live
 simulation_result_id.
+
+The receptionist → scheduler handoff is a real agent switch in all three
+runtimes; see `harness` for which Pipecat mechanism each one uses and why.
 """
 
 from __future__ import annotations
@@ -18,6 +21,7 @@ from __future__ import annotations
 import asyncio
 import os
 import sys
+import time
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -29,7 +33,9 @@ from pipecat.frames.frames import (
     BotStoppedSpeakingFrame,
     EndTaskFrame,
     Frame,
+    FunctionCallResultProperties,
     LLMRunFrame,
+    ManuallySwitchServiceFrame,
     TextFrame,
     TTSSpeakFrame,
     UserStartedSpeakingFrame,
@@ -37,6 +43,7 @@ from pipecat.frames.frames import (
 )
 from pipecat.processors.filters.function_filter import FunctionFilter
 from pipecat.observers.base_observer import BaseObserver, FramePushed
+from pipecat.pipeline.llm_switcher import LLMSwitcher
 from pipecat.pipeline.pipeline import Pipeline
 from pipecat.pipeline.runner import WorkerRunner
 from pipecat.pipeline.worker import PipelineParams, PipelineWorker
@@ -157,38 +164,113 @@ class SpeechSpanObserver(BaseObserver):
 async def run_bot(transport, runtime: str) -> None:
     bp = harness.load_blueprint(INDUSTRY)
     state = {"agent": bp["start"]}
-    instructions = harness.system_prompt(bp)
+    s2s = runtime in harness.S2S_RUNTIMES
 
+    observer = SpeechSpanObserver()
+    worker: PipelineWorker | None = None
+    llm = None            # the pipeline's LLM stage: one service, or an LLMSwitcher
+    agent_llms: dict = {}  # S2S only: one model session per blueprint agent
     ending = False
+    end_task: asyncio.Task | None = None
 
-    async def on_tool(params) -> None:
-        nonlocal ending
-        result, stop = await harness.run_tool(
-            params.function_name,
-            dict(params.arguments or {}),
-            bp,
-            state,
-            call_id=params.tool_call_id,
-        )
-        await params.result_callback(result)
-        # The farewell wait leaves the model free to call `end_call` again while we
-        # hold the pipeline open; honour only the first one (run 712222 hung up twice,
-        # 61915 ms and 83421 ms, and ran 90 s instead of ~70 s).
-        if stop and not ending:
-            ending = True
-            await _await_farewell(observer)
-            await params.llm.push_frame(EndTaskFrame(), FrameDirection.UPSTREAM)
+    async def _end_call() -> None:
+        await _await_farewell(observer)
+        # Push from the service that is actually speaking; behind a switcher the
+        # inactive branch's filter would swallow it.
+        src = llm.active_llm if isinstance(llm, LLMSwitcher) else llm
+        await src.push_frame(EndTaskFrame(), FrameDirection.UPSTREAM)
 
-    tools = harness.function_schemas(bp, on_tool)
-    llm = harness.build_llm(runtime, instructions, tools)
+    def schedule_end(stop: bool) -> None:
+        """Hang up once the farewell has played.
+
+        The wait runs off to the side rather than inside the tool handler: Flows
+        does not deliver a function result until its handler returns, so blocking
+        here would stop the model ever generating the farewell we are waiting for.
+
+        The wait also leaves the model free to call `end_call` again while we hold
+        the pipeline open; honour only the first one (run 712222 hung up twice,
+        61915 ms and 83421 ms, and ran 90 s instead of ~70 s).
+        """
+        nonlocal ending, end_task
+        if not stop or ending:
+            return
+        ending = True
+        end_task = asyncio.create_task(_end_call())  # noqa: RUF006 — held on `end_task`
+
+    if s2s:
+        # Each blueprint agent is its own speech-to-speech session, opened with
+        # that agent's prompt and that agent's tools. Handing off swaps which
+        # session the call is wired to — the receptionist's session is never told
+        # `schedule_appointment` exists.
+        async def on_tool(params) -> None:
+            result, stop = await harness.run_tool(
+                params.function_name,
+                dict(params.arguments or {}),
+                bp,
+                state,
+                call_id=params.tool_call_id,
+            )
+            target = result.get("role")
+            if target not in agent_llms:
+                await params.result_callback(result)
+                schedule_end(stop)
+                return
+
+            async def _switch() -> None:
+                logger.info(
+                    "handoff → {} ({} session, tools={})",
+                    target, harness.RUNTIMES[runtime], harness.tool_names(bp, target),
+                )
+                await worker.queue_frames(
+                    [ManuallySwitchServiceFrame(service=agent_llms[target]), LLMRunFrame()]
+                )
+
+            # Switch from `on_context_updated`, not inline: the handoff call and
+            # its result have to be in the shared context *before* the incoming
+            # agent first sees that context. Otherwise the result lands after,
+            # looks newly-completed to a session that never made the call, and
+            # OpenAI Realtime kills it with
+            # `invalid_tool_call_id: Tool call ID '...' not found in conversation`
+            # — which takes the receive loop down with it (run 712652).
+            # run_llm=False also keeps the outgoing agent from answering a tool
+            # result meant for its replacement.
+            await params.result_callback(
+                result,
+                properties=FunctionCallResultProperties(
+                    run_llm=False, on_context_updated=_switch
+                ),
+            )
+            schedule_end(stop)
+
+        agent_llms = harness.build_agent_llms(runtime, bp, on_tool)
+        # Order matters: ServiceSwitcher starts on services[0], the receptionist.
+        llm = LLMSwitcher(llms=list(agent_llms.values()))
+    else:
+        # Cascaded is a text LLM with function calling, which is exactly what
+        # Pipecat Flows is for. One node per blueprint agent, each with its own
+        # task_messages and its own functions; the consolidated handler returns
+        # (result, next_node) and FlowManager swaps context and advertised tools.
+        async def on_tool(name, args, _flow_manager):
+            result, stop = await harness.run_tool(name, dict(args or {}), bp, state)
+            schedule_end(stop)
+            target = result.get("role")
+            if target in bp["agents"]:
+                logger.info(
+                    "handoff → {} node (tools={})", target, harness.tool_names(bp, target)
+                )
+                return result, harness.flows_node(bp, target, on_tool)
+            return result, None
+
+        llm = harness.build_llm(runtime, "", None)
+
     stt, tts = harness.build_stt_tts(runtime)
 
-    # Gemini Live takes the prompt on the constructor; the others take it in context.
-    messages = (
-        [] if runtime == "gemini-flash-live-3.1"
-        else [{"role": "system", "content": instructions}]
-    )
-    context = LLMContext(messages=messages, tools=tools)
+    # No system message and no tools on the shared context: prompts and tool sets
+    # are per-agent, carried by the Flows node or by the S2S session itself. A
+    # context tool set would override the S2S services' own (see
+    # `OpenAIRealtimeLLMService._send_session_update`) and hand the receptionist
+    # the scheduler's tools.
+    context = LLMContext()
     aggregators = LLMContextAggregatorPair(
         context, user_params=LLMUserAggregatorParams(vad_analyzer=SileroVADAnalyzer())
     )
@@ -219,7 +301,6 @@ async def run_bot(transport, runtime: str) -> None:
     else:
         stages += [transport.output(), aggregators.assistant()]
 
-    observer = SpeechSpanObserver()
     worker = PipelineWorker(
         Pipeline(stages),
         params=PipelineParams(enable_metrics=True),
@@ -228,10 +309,22 @@ async def run_bot(transport, runtime: str) -> None:
         observers=[observer],
     )
 
+    flow_manager = None
+    if not s2s:
+        from pipecat.flows import FlowManager
+
+        flow_manager = FlowManager(
+            worker=worker, llm=llm, context_aggregator=aggregators, transport=transport
+        )
+
     @transport.event_handler("on_client_connected")
     async def _connected(_transport, _client):
         logger.info("client connected — kicking off greeting")
-        # Every runtime still gets the LLMRunFrame: Gemini will not speak first
+        if flow_manager is not None:
+            # initialize() sets the receptionist node — prompt, tools, LLMRunFrame.
+            await flow_manager.initialize(harness.flows_node(bp, bp["start"], on_tool))
+            return
+        # Every S2S runtime still gets the LLMRunFrame: Gemini will not speak first
         # regardless, but the frame is what primes its turn handling — without it
         # the service answers no user turn at all and the socket eventually closes
         # with 1008. The scripted opener rides behind it on the greeting TTS.

--- a/voice-agent-harnesses/pipecat/bot.py
+++ b/voice-agent-harnesses/pipecat/bot.py
@@ -1,0 +1,294 @@
+"""Pipecat Cloud entrypoint for the MIVAS control-industry agent.
+
+One deployed Pipecat Cloud service serves all three runtimes; which one runs is
+read from the start `body`, i.e. from the Bluejay agent's
+`pipecat_agent_configuration`:
+
+    {"runtime": "cascaded" | "openai-realtime-2.1" | "gemini-flash-live-3.1",
+     "tool_server_url": "https://<tunnel>",
+     "simulation_id": 30xxx}
+
+`simulation_id` is there because Bluejay's Pipecat dispatch passes no per-run
+metadata — `report.resolve_simulation_result_id` turns it into the live
+simulation_result_id.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from loguru import logger
+
+from pipecat.frames.frames import (
+    BotStartedSpeakingFrame,
+    BotStoppedSpeakingFrame,
+    EndTaskFrame,
+    Frame,
+    LLMRunFrame,
+    TextFrame,
+    TTSSpeakFrame,
+    UserStartedSpeakingFrame,
+    UserStoppedSpeakingFrame,
+)
+from pipecat.processors.filters.function_filter import FunctionFilter
+from pipecat.observers.base_observer import BaseObserver, FramePushed
+from pipecat.pipeline.pipeline import Pipeline
+from pipecat.pipeline.runner import WorkerRunner
+from pipecat.pipeline.worker import PipelineParams, PipelineWorker
+from pipecat.processors.aggregators.llm_context import LLMContext
+from pipecat.processors.aggregators.llm_response_universal import (
+    LLMContextAggregatorPair,
+    LLMUserAggregatorParams,
+)
+from pipecat.processors.frame_processor import FrameDirection
+from pipecat.audio.vad.silero import SileroVADAnalyzer
+from pipecat.runner.utils import create_transport
+from pipecat.transports.daily.transport import DailyParams
+
+import harness
+import report
+
+INDUSTRY = os.environ.get("INDUSTRY", "control-industry")
+
+
+async def _not_text_frame(frame: Frame) -> bool:
+    """Gate for the greeting-only TTS: everything except text it would re-speak."""
+    return not isinstance(frame, TextFrame)
+
+
+async def _not_greeting_text(frame: Frame) -> bool:
+    """Keep the injected opener out of the LLM context.
+
+    The greeting TTS emits a TTSTextFrame with `append_to_context` left true, so
+    `LLMAssistantAggregator` appends it as an assistant message before the caller
+    has said anything — and Gemini Live then answers nothing and closes the socket
+    with 1008. Gemini's own speech frames must still reach the aggregator exactly
+    as they did before the TTS existed, so match only the line we injected.
+
+    ponytail: exact-text match, fine for a fixed one-sentence opener; revisit if
+    the greeting ever becomes multi-sentence and the TTS splits it.
+    """
+    return not (
+        isinstance(frame, TextFrame) and frame.text.strip() == harness.GREETING
+    )
+
+
+# `end_call` must not tear the pipeline down the instant the tool returns. A
+# cascaded LLM has already generated its farewell by then, so the EndFrame drain
+# plays it out; a realtime model only generates that audio *after* it sees the
+# tool result, so an immediate EndTaskFrame cuts it off mid-thought and the caller
+# hears silence (pipecat 711945 vs livekit 710923, same gpt-realtime-2.1). LiveKit
+# solves this with a flat `HANGUP_GRACE_S = 4.0`; here we can do better and wait
+# for the farewell to actually finish, with the flat delay as the lead-in.
+END_CALL_LEAD_IN_S = float(os.environ.get("MIVAS_END_CALL_CLOSE_DELAY_S", "4.0"))
+END_CALL_MAX_WAIT_S = float(os.environ.get("MIVAS_END_CALL_MAX_WAIT_S", "20.0"))
+
+
+async def _await_farewell(observer: "SpeechSpanObserver") -> None:
+    """Give the model room to say goodbye, then wait for it to stop speaking."""
+    await asyncio.sleep(END_CALL_LEAD_IN_S)
+    deadline = time.monotonic() + END_CALL_MAX_WAIT_S
+    # ponytail: 200 ms poll on an asyncio.Event, not an edge-triggered wait —
+    # the farewell may start during the lead-in, and polling cannot miss that.
+    while not observer.agent_idle.is_set() and time.monotonic() < deadline:
+        await asyncio.sleep(0.2)
+
+
+class SpeechSpanObserver(BaseObserver):
+    """Bracket agent.speech / customer.speech on real turn frames.
+
+    Frames are pushed by several processors, so each start/stop pair is
+    deduplicated on frame id and by "a span is already open".
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._seen: set[int] = set()
+        self._spans: dict[str, object] = {}
+        self._n = 0
+        # set whenever the agent is not mid-utterance; `_await_farewell` waits on it
+        self.agent_idle = asyncio.Event()
+        self.agent_idle.set()
+
+    async def on_push_frame(self, data: FramePushed) -> None:
+        frame = data.frame
+        if isinstance(
+            frame,
+            (
+                BotStartedSpeakingFrame,
+                BotStoppedSpeakingFrame,
+                UserStartedSpeakingFrame,
+                UserStoppedSpeakingFrame,
+            ),
+        ):
+            if frame.id in self._seen:
+                return
+            self._seen.add(frame.id)
+        else:
+            return
+
+        if isinstance(frame, (BotStartedSpeakingFrame, UserStartedSpeakingFrame)):
+            speaker = "agent" if isinstance(frame, BotStartedSpeakingFrame) else "customer"
+            if speaker == "agent":
+                self.agent_idle.clear()
+            if self._spans.get(speaker) is not None:
+                return
+            self._n += 1
+            self._spans[speaker] = report.start_speech_span(
+                f"{speaker}-{self._n}", speaker=speaker
+            )
+        else:
+            speaker = "agent" if isinstance(frame, BotStoppedSpeakingFrame) else "customer"
+            if speaker == "agent":
+                self.agent_idle.set()
+            report.end_speech_span(self._spans.pop(speaker, None))
+
+    def close(self) -> None:
+        for span in self._spans.values():
+            report.end_speech_span(span)
+        self._spans.clear()
+
+
+async def run_bot(transport, runtime: str) -> None:
+    bp = harness.load_blueprint(INDUSTRY)
+    state = {"agent": bp["start"]}
+    instructions = harness.system_prompt(bp)
+
+    ending = False
+
+    async def on_tool(params) -> None:
+        nonlocal ending
+        result, stop = await harness.run_tool(
+            params.function_name,
+            dict(params.arguments or {}),
+            bp,
+            state,
+            call_id=params.tool_call_id,
+        )
+        await params.result_callback(result)
+        # The farewell wait leaves the model free to call `end_call` again while we
+        # hold the pipeline open; honour only the first one (run 712222 hung up twice,
+        # 61915 ms and 83421 ms, and ran 90 s instead of ~70 s).
+        if stop and not ending:
+            ending = True
+            await _await_farewell(observer)
+            await params.llm.push_frame(EndTaskFrame(), FrameDirection.UPSTREAM)
+
+    tools = harness.function_schemas(bp, on_tool)
+    llm = harness.build_llm(runtime, instructions, tools)
+    stt, tts = harness.build_stt_tts(runtime)
+
+    # Gemini Live takes the prompt on the constructor; the others take it in context.
+    messages = (
+        [] if runtime == "gemini-flash-live-3.1"
+        else [{"role": "system", "content": instructions}]
+    )
+    context = LLMContext(messages=messages, tools=tools)
+    aggregators = LLMContextAggregatorPair(
+        context, user_params=LLMUserAggregatorParams(vad_analyzer=SileroVADAnalyzer())
+    )
+
+    stages = [transport.input()]
+    if stt:
+        stages.append(stt)
+    stages.append(aggregators.user())
+    stages.append(llm)
+    if tts:
+        stages.append(tts)
+        stages += [transport.output(), aggregators.assistant()]
+    elif runtime in harness.GREETING_TTS_RUNTIMES:
+        # Greeting-only TTS, gated on both sides. Ahead of it: the S2S model
+        # narrates its own speech as LLMTextFrame + TTSTextFrame and this TTS would
+        # happily say all of it a second time (TTSSpeakFrame is not a TextFrame, so
+        # the opener still gets through). Behind it: the opener's own text frame
+        # must not reach the assistant aggregator, or it lands in the context as an
+        # assistant message before the caller has spoken and Gemini drops the
+        # session with 1008.
+        stages.append(FunctionFilter(_not_text_frame))
+        stages.append(harness.build_tts())
+        stages += [
+            transport.output(),
+            FunctionFilter(_not_greeting_text),
+            aggregators.assistant(),
+        ]
+    else:
+        stages += [transport.output(), aggregators.assistant()]
+
+    observer = SpeechSpanObserver()
+    worker = PipelineWorker(
+        Pipeline(stages),
+        params=PipelineParams(enable_metrics=True),
+        # observers is a PipelineWorker kwarg — PipelineParams silently drops it,
+        # which is how the speech spans went missing from the first proof runs.
+        observers=[observer],
+    )
+
+    @transport.event_handler("on_client_connected")
+    async def _connected(_transport, _client):
+        logger.info("client connected — kicking off greeting")
+        # Every runtime still gets the LLMRunFrame: Gemini will not speak first
+        # regardless, but the frame is what primes its turn handling — without it
+        # the service answers no user turn at all and the socket eventually closes
+        # with 1008. The scripted opener rides behind it on the greeting TTS.
+        frames = [LLMRunFrame()]
+        if runtime in harness.GREETING_TTS_RUNTIMES:
+            frames.append(TTSSpeakFrame(harness.GREETING))
+        await worker.queue_frames(frames)
+
+    @transport.event_handler("on_client_disconnected")
+    async def _disconnected(_transport, _client):
+        logger.info("client disconnected")
+        await worker.cancel()
+
+    runner = WorkerRunner(handle_sigint=False)
+    await runner.add_workers(worker)
+    try:
+        await runner.run()
+    finally:
+        observer.close()
+
+
+async def bot(args) -> None:
+    """Pipecat Cloud entrypoint."""
+    body = dict(getattr(args, "body", None) or {})
+    runtime = body.get("runtime") or harness.DEFAULT_RUNTIME
+    if runtime not in harness.RUNTIMES:
+        logger.warning("unknown runtime %r — falling back to %s", runtime, harness.DEFAULT_RUNTIME)
+        runtime = harness.DEFAULT_RUNTIME
+    if body.get("tool_server_url"):
+        os.environ["TOOL_SERVER_URL"] = str(body["tool_server_url"])
+
+    sim_result_id = await report.resolve_simulation_result_id(body.get("simulation_id"))
+    logger.info(
+        "pipecat bot runtime={} model={} sim_result_id={} tool_server={}",
+        runtime, harness.RUNTIMES[runtime], sim_result_id, harness.tool_server_url(),
+    )
+
+    transport = await create_transport(
+        args,
+        {
+            "daily": lambda: DailyParams(
+                audio_in_enabled=True,
+                audio_out_enabled=True,
+                vad_analyzer=SileroVADAnalyzer(),
+            ),
+        },
+    )
+
+    async with report.traced_run(
+        f"mivas-{INDUSTRY}-{runtime}",
+        simulation_result_id=sim_result_id,
+        model=harness.RUNTIMES[runtime],
+    ):
+        await run_bot(transport, runtime)
+
+
+if __name__ == "__main__":
+    from pipecat.runner.run import main
+
+    main()

--- a/voice-agent-harnesses/pipecat/cascaded/agent.py
+++ b/voice-agent-harnesses/pipecat/cascaded/agent.py
@@ -1,0 +1,14 @@
+"""Local smoke for the `cascaded` runtime — builds the real services and pipeline
+without a transport, so a bad service kwarg fails here instead of mid-call.
+
+    uv run python voice-agent-harnesses/pipecat/cascaded/agent.py control-industry
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from check import check_runtime
+
+if __name__ == "__main__":
+    check_runtime("cascaded", sys.argv[1] if len(sys.argv) > 1 else "control-industry")

--- a/voice-agent-harnesses/pipecat/check.py
+++ b/voice-agent-harnesses/pipecat/check.py
@@ -1,5 +1,10 @@
 """Offline construction check for one runtime: blueprint → services → pipeline.
 
+Also the proof that the handoff is a real agent switch and not a prompt trick:
+for every runtime it asserts the receptionist's model is never given
+`schedule_appointment`, at the level the model actually sees (the S2S session's
+own tool set, or the Flows node's `functions`).
+
 Needs the runtime's API keys in the environment (nothing is dialled — the
 services only open sockets once the pipeline starts).
 """
@@ -7,6 +12,11 @@ services only open sockets once the pipeline starts).
 from __future__ import annotations
 
 import harness
+
+EXPECTED = {
+    "receptionist": ["handoff_to_scheduler", "end_call"],
+    "scheduler": ["schedule_appointment", "end_call"],
+}
 
 
 def check_greeting_gate() -> None:
@@ -35,22 +45,54 @@ def check_greeting_gate() -> None:
 
 
 def check_runtime(runtime: str, industry: str = "control-industry") -> None:
+    from pipecat.pipeline.llm_switcher import LLMSwitcher
     from pipecat.pipeline.pipeline import Pipeline
 
     bp = harness.load_blueprint(industry)
     assert runtime in harness.RUNTIMES, runtime
+    assert {a: harness.tool_names(bp, a) for a in bp["agents"]} == EXPECTED
 
-    async def _noop(params):  # pragma: no cover - never called here
+    async def _noop(*_a, **_k):  # pragma: no cover - never called here
         raise AssertionError("tool handler must not run during the build check")
 
-    tools = harness.function_schemas(bp, _noop)
-    assert [t.name for t in tools] == harness.tool_names(bp)
-
-    llm = harness.build_llm(runtime, harness.system_prompt(bp), tools)
     stt, tts = harness.build_stt_tts(runtime)
     assert (stt is None) == (runtime != "cascaded")
 
-    stages = [s for s in (stt, llm, tts) if s is not None]
-    Pipeline(stages)
-    print(f"{runtime}: model={harness.RUNTIMES[runtime]} "
-          f"stages={[type(s).__name__ for s in stages]} tools={[t.name for t in tools]} ok")
+    if runtime in harness.S2S_RUNTIMES:
+        agent_llms = harness.build_agent_llms(runtime, bp, _noop)
+        assert list(agent_llms) == harness.agent_order(bp)
+        switcher = LLMSwitcher(llms=list(agent_llms.values()))
+        # ServiceSwitcher starts on services[0]; that must be the receptionist.
+        assert switcher.active_llm is agent_llms[bp["start"]]
+
+        for agent, llm in agent_llms.items():
+            # what the session advertises to the model...
+            advertised = [t.name for t in llm._service_tools().standard_tools]
+            assert advertised == EXPECTED[agent], (agent, advertised)
+            # ...and what Pipecat will route a call for. `None` (context tools
+            # unset) is how the live pipeline calls this: the service falls back
+            # to its own tools, which is what keeps the two sessions distinct.
+            llm._sync_registered_tool_handlers(None)
+            for name in ("handoff_to_scheduler", "schedule_appointment", "end_call"):
+                assert llm.has_function(name) == (name in EXPECTED[agent]), (agent, name)
+
+        assert not agent_llms["receptionist"].has_function("schedule_appointment")
+        assert agent_llms["receptionist"] is not agent_llms["scheduler"]
+        stages = [switcher]
+    else:
+        for agent in bp["agents"]:
+            node = harness.flows_node(bp, agent, _noop)
+            assert node["name"] == agent
+            assert [f.name for f in node["functions"]] == EXPECTED[agent], agent
+            assert node["task_messages"][0]["content"] == harness.instructions(bp, agent)
+        assert "schedule_appointment" not in str(
+            harness.instructions(bp, "receptionist")
+        )
+        stages = [harness.build_llm(runtime, "", None)]
+
+    Pipeline([s for s in ([stt] + stages + [tts]) if s is not None])
+    print(
+        f"{runtime}: model={harness.RUNTIMES[runtime]} "
+        f"agents={ {a: harness.tool_names(bp, a) for a in bp['agents']} } "
+        f"stages={[type(s).__name__ for s in stages]} ok"
+    )

--- a/voice-agent-harnesses/pipecat/check.py
+++ b/voice-agent-harnesses/pipecat/check.py
@@ -45,6 +45,7 @@ def check_greeting_gate() -> None:
 
 
 def check_runtime(runtime: str, industry: str = "control-industry") -> None:
+    check_greeting_gate()
     from pipecat.pipeline.llm_switcher import LLMSwitcher
     from pipecat.pipeline.pipeline import Pipeline
 

--- a/voice-agent-harnesses/pipecat/check.py
+++ b/voice-agent-harnesses/pipecat/check.py
@@ -1,0 +1,56 @@
+"""Offline construction check for one runtime: blueprint → services → pipeline.
+
+Needs the runtime's API keys in the environment (nothing is dialled — the
+services only open sockets once the pipeline starts).
+"""
+
+from __future__ import annotations
+
+import harness
+
+
+def check_greeting_gate() -> None:
+    """The greeting-only TTS must say the opener and nothing the S2S model says."""
+    import asyncio
+
+    from pipecat.frames.frames import LLMTextFrame, TTSSpeakFrame, TTSTextFrame
+    from pipecat.utils.text.base_text_aggregator import AggregationType
+
+    from bot import _not_greeting_text, _not_text_frame
+
+    def tts_text(s):
+        return TTSTextFrame(s, aggregated_by=AggregationType.SENTENCE)
+
+    # ahead of the TTS: the opener passes, the model's own text does not
+    assert asyncio.run(_not_text_frame(TTSSpeakFrame(harness.GREETING))) is True
+    assert asyncio.run(_not_text_frame(LLMTextFrame("hi"))) is False
+    assert asyncio.run(_not_text_frame(tts_text("hi"))) is False
+
+    # behind it: the opener is kept out of the context, everything else gets through
+    assert asyncio.run(_not_greeting_text(tts_text(harness.GREETING))) is False
+    assert asyncio.run(_not_greeting_text(tts_text(f" {harness.GREETING} "))) is False
+    assert asyncio.run(_not_greeting_text(tts_text("How can I help?"))) is True
+    assert asyncio.run(_not_greeting_text(LLMTextFrame("How can I help?"))) is True
+    print("greeting gate ok")
+
+
+def check_runtime(runtime: str, industry: str = "control-industry") -> None:
+    from pipecat.pipeline.pipeline import Pipeline
+
+    bp = harness.load_blueprint(industry)
+    assert runtime in harness.RUNTIMES, runtime
+
+    async def _noop(params):  # pragma: no cover - never called here
+        raise AssertionError("tool handler must not run during the build check")
+
+    tools = harness.function_schemas(bp, _noop)
+    assert [t.name for t in tools] == harness.tool_names(bp)
+
+    llm = harness.build_llm(runtime, harness.system_prompt(bp), tools)
+    stt, tts = harness.build_stt_tts(runtime)
+    assert (stt is None) == (runtime != "cascaded")
+
+    stages = [s for s in (stt, llm, tts) if s is not None]
+    Pipeline(stages)
+    print(f"{runtime}: model={harness.RUNTIMES[runtime]} "
+          f"stages={[type(s).__name__ for s in stages]} tools={[t.name for t in tools]} ok")

--- a/voice-agent-harnesses/pipecat/deploy.py
+++ b/voice-agent-harnesses/pipecat/deploy.py
@@ -26,6 +26,8 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+from harness import RUNTIME_SECRET_KEYS
+
 HARNESS_DIR = Path(__file__).resolve().parent
 REPO_ROOT = HARNESS_DIR.parents[1]
 API = "https://api.pipecat.daily.co/v1"
@@ -119,13 +121,16 @@ def upload_and_build(context: bytes) -> str:
     raise SystemExit("build timed out")
 
 
-def main() -> None:
+def main() -> int:
     secrets = [
         {"secretKey": k, "secretValue": os.environ[k]}
         for k in SECRET_KEYS
         if os.environ.get(k)
     ]
-    missing = [k for k in ("OPENAI_API_KEY", "BLUEJAY_API_KEY") if not os.environ.get(k)]
+    required = {"BLUEJAY_API_KEY"}
+    for runtime_keys in RUNTIME_SECRET_KEYS.values():
+        required.update(runtime_keys)
+    missing = sorted(k for k in required if not os.environ.get(k))
     if missing:
         sys.exit(f"missing required env: {missing}")
     api(f"/secrets/{SECRET_SET}", {"secrets": secrets, "region": REGION}, method="PUT")
@@ -155,10 +160,11 @@ def main() -> None:
         details = api(f"/agents/{AGENT_NAME}")
         if details.get("ready") and details.get("activeDeploymentReady"):
             print(f"agent {AGENT_NAME} ready")
-            return
+            return 0
         time.sleep(10)
     print(f"agent {AGENT_NAME} deployed but not reporting ready yet", file=sys.stderr)
+    return 1
 
 
 if __name__ == "__main__":
-    main()
+    raise SystemExit(main() or 0)

--- a/voice-agent-harnesses/pipecat/deploy.py
+++ b/voice-agent-harnesses/pipecat/deploy.py
@@ -1,0 +1,164 @@
+"""Deploy this harness to Pipecat Cloud over the REST API (no Docker, no CLI).
+
+The `pipecat` CLI needs an interactive browser login or a personal access token,
+and a local Docker daemon; the REST API needs neither — it takes a tarball of the
+build context, builds it in-cloud, and deploys the resulting image.
+
+    export PIPECAT_PRIVATE_API_KEY=sk_...        # Pipecat Cloud *private* key
+    set -a && source .env && set +a              # provider keys → secret set
+    export BLUEJAY_API_KEY=...
+    uv run python voice-agent-harnesses/pipecat/deploy.py
+
+Uploads the secret set, builds, then creates or updates the agent. One deployed
+agent serves all three runtimes; the runtime is chosen per call by the Bluejay
+agent's `pipecat_agent_configuration.runtime`.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import tarfile
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+HARNESS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = HARNESS_DIR.parents[1]
+API = "https://api.pipecat.daily.co/v1"
+
+AGENT_NAME = os.environ.get("PIPECAT_AGENT_NAME", "mivas-control")
+SECRET_SET = os.environ.get("PIPECAT_SECRET_SET", "mivas-secrets")
+REGION = os.environ.get("PIPECAT_REGION", "us-west")
+INDUSTRY = os.environ.get("INDUSTRY", "control-industry")
+
+# Provider keys the bot needs at runtime, forwarded from the local environment.
+SECRET_KEYS = (
+    "OPENAI_API_KEY",
+    "GOOGLE_API_KEY",
+    "DEEPGRAM_API_KEY",
+    "ELEVENLABS_API_KEY",
+    "BLUEJAY_API_KEY",
+    "BLUEJAY_API_URL",
+    "BLUEJAY_OTLP_ENDPOINT",
+    "BLUEJAY_SERVICE_NAME",
+)
+# Files copied into the build context (Dockerfile COPYs *.py + industries/).
+CONTEXT_FILES = ("Dockerfile", "requirements.txt", "bot.py", "harness.py", "report.py", "check.py")
+
+
+def api(path: str, data: dict | None = None, method: str | None = None) -> dict:
+    key = os.environ.get("PIPECAT_PRIVATE_API_KEY", "")
+    if not key:
+        sys.exit("PIPECAT_PRIVATE_API_KEY (sk_...) is required")
+    req = urllib.request.Request(
+        API + path,
+        data=json.dumps(data).encode() if data is not None else None,
+        headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"},
+        method=method or ("POST" if data is not None else "GET"),
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read() or b"{}")
+    except urllib.error.HTTPError as e:
+        body = e.read().decode()[:500]
+        raise SystemExit(f"{method or 'POST'} {path} → {e.code} {body}") from e
+
+
+def build_context() -> bytes:
+    """tar.gz of the harness plus the industry it serves."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name in CONTEXT_FILES:
+            tar.add(HARNESS_DIR / name, arcname=name)
+        tar.add(
+            REPO_ROOT / "industries" / INDUSTRY,
+            arcname=f"industries/{INDUSTRY}",
+            filter=lambda ti: None if ti.name.endswith((".db", "__pycache__")) else ti,
+        )
+    return buf.getvalue()
+
+
+def upload_and_build(context: bytes) -> str:
+    import subprocess
+    import tempfile
+
+    up = api("/builds/upload-url", {"region": REGION})
+    with tempfile.NamedTemporaryFile(suffix=".tar.gz") as fh:
+        fh.write(context)
+        fh.flush()
+        cmd = ["curl", "-sS", "-o", "/dev/null", "-w", "%{http_code}", "-X", "POST", up["uploadUrl"]]
+        for k, v in up["uploadFields"].items():
+            cmd += ["-F", f"{k}={v}"]
+        # the presigned policy pins Content-Type but the field is not returned
+        cmd += ["-F", "Content-Type=application/gzip", "-F", f"file=@{fh.name}"]
+        code = subprocess.run(cmd, capture_output=True, text=True).stdout.strip()
+    if code != "204":
+        raise SystemExit(f"context upload failed: HTTP {code}")
+
+    created = api(
+        "/builds",
+        {"uploadId": up["uploadId"], "region": REGION, "dockerfilePath": "Dockerfile"},
+    )
+    build_id = created["build"]["id"]
+    print(f"build {build_id} cached={created.get('cached')}", flush=True)
+
+    deadline = time.time() + 1800
+    while time.time() < deadline:
+        status = api(f"/builds/{build_id}")["build"]["status"]
+        if status in ("success", "succeeded"):
+            return build_id
+        if status in ("failed", "error"):
+            logs = api(f"/builds/{build_id}/logs")
+            raise SystemExit(f"build failed:\n{json.dumps(logs)[-3000:]}")
+        print(f"  build {status}...", flush=True)
+        time.sleep(10)
+    raise SystemExit("build timed out")
+
+
+def main() -> None:
+    secrets = [
+        {"secretKey": k, "secretValue": os.environ[k]}
+        for k in SECRET_KEYS
+        if os.environ.get(k)
+    ]
+    missing = [k for k in ("OPENAI_API_KEY", "BLUEJAY_API_KEY") if not os.environ.get(k)]
+    if missing:
+        sys.exit(f"missing required env: {missing}")
+    api(f"/secrets/{SECRET_SET}", {"secrets": secrets, "region": REGION}, method="PUT")
+    print(f"secret set {SECRET_SET}: {[s['secretKey'] for s in secrets]}", flush=True)
+
+    build_id = upload_and_build(build_context())
+
+    body = {
+        "buildId": build_id,
+        "region": REGION,
+        "secretSet": SECRET_SET,
+        "autoScaling": {"minAgents": 1, "maxAgents": 3},
+        "agentProfile": "agent-1x",
+        "maxSessionDuration": 600,
+    }
+    existing = {s["name"] for s in api("/agents").get("services", [])}
+    if AGENT_NAME in existing:
+        body.pop("region", None)
+        body["forceRedeploy"] = True
+        api(f"/agents/{AGENT_NAME}", body)
+        print(f"updated agent {AGENT_NAME}")
+    else:
+        api("/agents", {"serviceName": AGENT_NAME, **body})
+        print(f"created agent {AGENT_NAME}")
+
+    for _ in range(60):
+        details = api(f"/agents/{AGENT_NAME}")
+        if details.get("ready") and details.get("activeDeploymentReady"):
+            print(f"agent {AGENT_NAME} ready")
+            return
+        time.sleep(10)
+    print(f"agent {AGENT_NAME} deployed but not reporting ready yet", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/voice-agent-harnesses/pipecat/gemini-flash-live-3.1/agent.py
+++ b/voice-agent-harnesses/pipecat/gemini-flash-live-3.1/agent.py
@@ -1,0 +1,14 @@
+"""Local smoke for the `gemini-flash-live-3.1` runtime — builds the real services and pipeline
+without a transport, so a bad service kwarg fails here instead of mid-call.
+
+    uv run python voice-agent-harnesses/pipecat/gemini-flash-live-3.1/agent.py control-industry
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from check import check_runtime
+
+if __name__ == "__main__":
+    check_runtime("gemini-flash-live-3.1", sys.argv[1] if len(sys.argv) > 1 else "control-industry")

--- a/voice-agent-harnesses/pipecat/harness.py
+++ b/voice-agent-harnesses/pipecat/harness.py
@@ -1,0 +1,297 @@
+"""Blueprint → Pipecat services, tools and pipeline, for three runtimes.
+
+Pipecat runs our code, so the industry tools are plain Python coroutines wrapped
+in `report.tool_span` — all three (`handoff_to_scheduler`, `schedule_appointment`,
+`end_call`) produce real `execute_tool` spans, no untimeable gaps.
+
+Handoff is soft (prompt + tool result), not Pipecat Flows: Flows explicitly does
+not support realtime S2S services, and two of the three runtimes are S2S. Doing
+it the same way in all three keeps the runtimes comparable.
+
+Runtimes:
+  cascaded              Deepgram Flux flux-general-en → gpt-4.1 → ElevenLabs eleven_flash_v2_5
+  openai-realtime-2.1   gpt-realtime-2.1
+  gemini-flash-live-3.1 gemini-3.1-flash-live-preview
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+HARNESS_DIR = Path(__file__).resolve().parent
+# In the repo this is mivas-bench/; in the deployed image the harness IS the root.
+REPO_ROOT = HARNESS_DIR.parents[1] if len(HARNESS_DIR.parents) > 1 else HARNESS_DIR
+
+RUNTIMES = {
+    "cascaded": "gpt-4.1",
+    "openai-realtime-2.1": "gpt-realtime-2.1",
+    "gemini-flash-live-3.1": "gemini-3.1-flash-live-preview",
+}
+DEFAULT_RUNTIME = "cascaded"
+
+STT_MODEL = os.environ.get("PIPECAT_STT_MODEL", "flux-general-en")
+TTS_MODEL = os.environ.get("PIPECAT_TTS_MODEL", "eleven_flash_v2_5")
+TTS_VOICE_ID = os.environ.get("PIPECAT_TTS_VOICE_ID", "21m00Tcm4TlvDq8ikWAM")
+
+# Gemini 3.1 Live will not speak until the caller does, so it opens with dead
+# air until the digital human gives up and prompts — ~64 s of a 180 s call. A TTS
+# is attached for that runtime purely so the scripted opener can be spoken; the
+# model still says everything else itself. Same workaround as the LiveKit harness
+# (`session.say(GREETING)`), for the same plugin limitation.
+GREETING = "Welcome to Bluejay's Repair Services!"
+GREETING_TTS_RUNTIMES = frozenset({"gemini-flash-live-3.1"})
+
+HANDOFF_NOTE = (
+    "\n\n# Multi-agent note\n"
+    "Start as the receptionist. Only call schedule_appointment after "
+    "handoff_to_scheduler has succeeded and you have adopted the scheduler role."
+)
+
+
+def industry_path(name: str | Path) -> Path:
+    path = Path(name)
+    if path.is_dir():
+        return path.resolve()
+    env_dir = os.environ.get("INDUSTRY_DIR", "").strip()
+    if env_dir and Path(env_dir).is_dir():
+        return Path(env_dir).resolve()
+    for base in (HARNESS_DIR / "industries", REPO_ROOT / "industries"):
+        if (base / name).is_dir():
+            return (base / name).resolve()
+    return (REPO_ROOT / "industries" / name).resolve()
+
+
+def load_blueprint(industry_dir: str | Path) -> dict[str, Any]:
+    industry_dir = industry_path(industry_dir)
+    blueprint = json.loads((industry_dir / "agent_blueprint.json").read_text())
+    catalog = {
+        t["name"]: t
+        for t in json.loads((industry_dir / "tools.json").read_text())["tools"]
+    }
+    agents = {
+        entry["name"]: {
+            "name": entry["name"],
+            "instructions": (industry_dir / entry["system_prompt"]).read_text(),
+            "tools": entry["tools"],
+        }
+        for entry in blueprint["agents"]
+    }
+    return {
+        "industry_dir": industry_dir,
+        "start": blueprint["agents"][0]["name"],
+        "agents": agents,
+        "catalog": catalog,
+    }
+
+
+def system_prompt(bp: dict[str, Any]) -> str:
+    return bp["agents"][bp["start"]]["instructions"] + HANDOFF_NOTE
+
+
+def tool_names(bp: dict[str, Any]) -> list[str]:
+    seen: list[str] = []
+    for agent in bp["agents"].values():
+        for t in agent["tools"]:
+            if t["name"] not in seen and t["name"] in bp["catalog"]:
+                seen.append(t["name"])
+    return seen
+
+
+# ── tools ────────────────────────────────────────────────────────────────────
+
+
+def tool_server_url() -> str:
+    return os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
+
+
+async def _execute_tool(
+    name: str, args: dict[str, Any], bp: dict[str, Any], state: dict[str, Any]
+) -> tuple[dict[str, Any], bool]:
+    """Run a blueprint tool. Returns (result, should_end_call)."""
+    if name == "handoff_to_scheduler":
+        target = next(
+            (
+                t.get("handoff_to")
+                for t in bp["agents"][state["agent"]]["tools"]
+                if t["name"] == name and t.get("handoff")
+            ),
+            None,
+        )
+        if not target or target not in bp["agents"]:
+            return {"success": False, "error": "unknown handoff target"}, False
+        state["agent"] = target
+        return {
+            "success": True,
+            "role": target,
+            "instructions": bp["agents"][target]["instructions"],
+            "note": "You are now the scheduler. Follow the instructions field exactly.",
+        }, False
+
+    if name == "schedule_appointment":
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                f"{tool_server_url()}/appointments", json={"date": args["date"]}
+            )
+            resp.raise_for_status()
+            return {"success": True, "date": resp.json()["date"]}, False
+
+    if name == "end_call":
+        return {"success": True}, True
+
+    return {"success": False, "error": f"unknown tool {name}"}, False
+
+
+async def run_tool(
+    name: str,
+    args: dict[str, Any],
+    bp: dict[str, Any],
+    state: dict[str, Any],
+    *,
+    call_id: str | None = None,
+) -> tuple[dict[str, Any], bool]:
+    """Execute a tool under an `execute_tool` span. Errors soft-fail so the call
+    survives and the trace still flushes."""
+    from report import call_offset_ms, finish_tool_span, tool_span
+
+    offset = call_offset_ms()
+    with tool_span(name, args, call_id=call_id) as span:
+        try:
+            result, stop = await _execute_tool(name, args, bp, state)
+            ok = bool(result.get("success"))
+        except Exception as e:  # noqa: BLE001 — a dead tool must not kill the call
+            result, stop, ok = {"success": False, "error": f"{type(e).__name__}: {e}"}, False, False
+        finish_tool_span(
+            span, result, ok=ok, name=name, parameters=args, start_offset_ms=offset
+        )
+        return result, stop
+
+
+def function_schemas(bp: dict[str, Any], handler) -> list:
+    """tools.json → Pipecat FunctionSchema list, all bound to one handler."""
+    from pipecat.adapters.schemas.function_schema import FunctionSchema
+
+    schemas = []
+    for name in tool_names(bp):
+        spec = bp["catalog"][name]
+        raw = spec.get("inputSchema") or {}
+        schemas.append(
+            FunctionSchema(
+                name=name,
+                description=spec.get("description", name),
+                properties=dict(raw.get("properties") or {}),
+                required=list(raw.get("required") or []),
+                handler=handler,
+            )
+        )
+    return schemas
+
+
+# ── services ─────────────────────────────────────────────────────────────────
+
+
+def build_llm(runtime: str, instructions: str, tools: list):
+    """The runtime's LLM (or S2S) service. `tools`/`instructions` are only passed
+    here for the S2S services that need them at construction time."""
+    model = RUNTIMES[runtime]
+
+    if runtime == "openai-realtime-2.1":
+        from pipecat.services.openai.realtime.events import SessionProperties
+        from pipecat.services.openai.realtime.llm import OpenAIRealtimeLLMService
+
+        return OpenAIRealtimeLLMService(
+            api_key=os.environ["OPENAI_API_KEY"],
+            model=model,
+            session_properties=SessionProperties(instructions=instructions),
+        )
+
+    if runtime == "gemini-flash-live-3.1":
+        from pipecat.services.google.gemini_live.llm import GeminiLiveLLMService
+
+        # the plugin quirk carried over from the LiveKit prior art: the system
+        # prompt must go in on the constructor, not as a context message.
+        return GeminiLiveLLMService(
+            api_key=os.environ["GOOGLE_API_KEY"],
+            model=model,
+            system_instruction=instructions,
+            tools=tools,
+        )
+
+    from pipecat.services.openai.llm import OpenAILLMService
+
+    return OpenAILLMService(api_key=os.environ["OPENAI_API_KEY"], model=model)
+
+
+def build_tts():
+    from pipecat.services.elevenlabs.tts import ElevenLabsTTSService
+
+    return ElevenLabsTTSService(
+        api_key=os.environ["ELEVENLABS_API_KEY"],
+        model=TTS_MODEL,
+        voice_id=TTS_VOICE_ID,
+    )
+
+
+def build_stt_tts(runtime: str):
+    """(stt, tts) for the cascaded runtime; (None, None) for the S2S ones."""
+    if runtime != "cascaded":
+        return None, None
+
+    from pipecat.services.deepgram.flux.stt import DeepgramFluxSTTService
+
+    stt = DeepgramFluxSTTService(
+        api_key=os.environ["DEEPGRAM_API_KEY"], model=STT_MODEL
+    )
+    return stt, build_tts()
+
+
+def demo() -> None:
+    """Self-check: blueprint, tool schemas and the soft handoff, no network."""
+    import asyncio
+
+    bp = load_blueprint("control-industry")
+    assert bp["start"] == "receptionist", bp["start"]
+    assert tool_names(bp) == [
+        "handoff_to_scheduler",
+        "end_call",
+        "schedule_appointment",
+    ], tool_names(bp)
+    assert "Bluejay's Repair Services" in system_prompt(bp)
+    assert set(RUNTIMES) == {
+        "cascaded",
+        "openai-realtime-2.1",
+        "gemini-flash-live-3.1",
+    }
+
+    # the scripted opener must stay verbatim from the industry prompt, and only
+    # the runtimes that cannot speak first may be given a greeting TTS
+    assert f'say: "{GREETING}"' in bp["agents"]["receptionist"]["instructions"], GREETING
+    assert GREETING_TTS_RUNTIMES <= set(RUNTIMES), GREETING_TTS_RUNTIMES
+    assert "cascaded" not in GREETING_TTS_RUNTIMES
+
+    # (the greeting-only TTS gate needs pipecat installed — see check.py)
+
+    state = {"agent": bp["start"]}
+    res, stop = asyncio.run(run_tool("handoff_to_scheduler", {}, bp, state))
+    assert res["success"] and state["agent"] == "scheduler" and not stop, res
+    assert "schedule_appointment" in res["instructions"]
+
+    res, stop = asyncio.run(run_tool("end_call", {"reason": "done"}, bp, state))
+    assert res == {"success": True} and stop
+
+    # unreachable tool server must soft-fail, not raise
+    os.environ["TOOL_SERVER_URL"] = "http://127.0.0.1:1"
+    res, stop = asyncio.run(
+        run_tool("schedule_appointment", {"date": "08/18/2026"}, bp, state)
+    )
+    assert res["success"] is False and "error" in res, res
+
+    print("harness self-check ok")
+
+
+if __name__ == "__main__":
+    demo()

--- a/voice-agent-harnesses/pipecat/harness.py
+++ b/voice-agent-harnesses/pipecat/harness.py
@@ -1,12 +1,29 @@
-"""Blueprint → Pipecat services, tools and pipeline, for three runtimes.
+"""Blueprint → Pipecat services, tools and nodes, for three runtimes.
 
 Pipecat runs our code, so the industry tools are plain Python coroutines wrapped
 in `report.tool_span` — all three (`handoff_to_scheduler`, `schedule_appointment`,
 `end_call`) produce real `execute_tool` spans, no untimeable gaps.
 
-Handoff is soft (prompt + tool result), not Pipecat Flows: Flows explicitly does
-not support realtime S2S services, and two of the three runtimes are S2S. Doing
-it the same way in all three keeps the runtimes comparable.
+The handoff is a real agent switch in every runtime, not a prompt injection: each
+blueprint agent gets its own prompt and its own tool set, and `handoff_to_scheduler`
+moves the call from one to the other. What "the other agent" is made of differs by
+runtime, because Pipecat's own machinery differs:
+
+  cascaded              Pipecat Flows (`pipecat.flows`). One text LLM, one node per
+                        blueprint agent, each node carrying its own `task_messages`
+                        and its own `functions`. The consolidated handler returns
+                        `(result, next_node)` and FlowManager swaps the context and
+                        the advertised tool set (`LLMSetToolsFrame`).
+  openai-realtime-2.1   Two `OpenAIRealtimeLLMService` instances behind an
+  gemini-flash-live-3.1 `LLMSwitcher`, one per blueprint agent, each with its own
+                        websocket session, its own `instructions` and its own
+                        `tools`. `ManuallySwitchServiceFrame` moves the call.
+                        Flows explicitly does not support S2S services ("Gemini
+                        Live, OpenAI Realtime, Ultravox, AWS Nova Sonic"), because
+                        it transitions by mutating one live session — which is the
+                        exact thing two sessions make unnecessary.
+
+Either way the receptionist's model never sees `schedule_appointment`.
 
 Runtimes:
   cascaded              Deepgram Flux flux-general-en → gpt-4.1 → ElevenLabs eleven_flash_v2_5
@@ -33,6 +50,8 @@ RUNTIMES = {
     "gemini-flash-live-3.1": "gemini-3.1-flash-live-preview",
 }
 DEFAULT_RUNTIME = "cascaded"
+# The runtimes whose "agent" is a speech-to-speech session rather than a text LLM.
+S2S_RUNTIMES = frozenset({"openai-realtime-2.1", "gemini-flash-live-3.1"})
 
 STT_MODEL = os.environ.get("PIPECAT_STT_MODEL", "flux-general-en")
 TTS_MODEL = os.environ.get("PIPECAT_TTS_MODEL", "eleven_flash_v2_5")
@@ -45,12 +64,6 @@ TTS_VOICE_ID = os.environ.get("PIPECAT_TTS_VOICE_ID", "21m00Tcm4TlvDq8ikWAM")
 # (`session.say(GREETING)`), for the same plugin limitation.
 GREETING = "Welcome to Bluejay's Repair Services!"
 GREETING_TTS_RUNTIMES = frozenset({"gemini-flash-live-3.1"})
-
-HANDOFF_NOTE = (
-    "\n\n# Multi-agent note\n"
-    "Start as the receptionist. Only call schedule_appointment after "
-    "handoff_to_scheduler has succeeded and you have adopted the scheduler role."
-)
 
 
 def industry_path(name: str | Path) -> Path:
@@ -89,17 +102,26 @@ def load_blueprint(industry_dir: str | Path) -> dict[str, Any]:
     }
 
 
-def system_prompt(bp: dict[str, Any]) -> str:
-    return bp["agents"][bp["start"]]["instructions"] + HANDOFF_NOTE
+def agent_order(bp: dict[str, Any]) -> list[str]:
+    """Blueprint agents, starting agent first."""
+    return [bp["start"]] + [n for n in bp["agents"] if n != bp["start"]]
 
 
-def tool_names(bp: dict[str, Any]) -> list[str]:
-    seen: list[str] = []
-    for agent in bp["agents"].values():
-        for t in agent["tools"]:
-            if t["name"] not in seen and t["name"] in bp["catalog"]:
-                seen.append(t["name"])
-    return seen
+def instructions(bp: dict[str, Any], agent: str) -> str:
+    return bp["agents"][agent]["instructions"]
+
+
+def tool_names(bp: dict[str, Any], agent: str) -> list[str]:
+    """The tools *this* agent may call. Nobody else's."""
+    return [t["name"] for t in bp["agents"][agent]["tools"] if t["name"] in bp["catalog"]]
+
+
+def handoff_target(bp: dict[str, Any], agent: str, tool: str) -> str | None:
+    for t in bp["agents"][agent]["tools"]:
+        if t["name"] == tool and t.get("handoff"):
+            target = t.get("handoff_to")
+            return target if target in bp["agents"] else None
+    return None
 
 
 # ── tools ────────────────────────────────────────────────────────────────────
@@ -112,25 +134,18 @@ def tool_server_url() -> str:
 async def _execute_tool(
     name: str, args: dict[str, Any], bp: dict[str, Any], state: dict[str, Any]
 ) -> tuple[dict[str, Any], bool]:
-    """Run a blueprint tool. Returns (result, should_end_call)."""
+    """Run a blueprint tool. Returns (result, should_end_call).
+
+    A handoff only resolves and records the target here; moving the call is the
+    caller's job, because *how* you move it is a runtime property (a Flows node
+    transition, or an `LLMSwitcher` swap to the target agent's own S2S session).
+    """
     if name == "handoff_to_scheduler":
-        target = next(
-            (
-                t.get("handoff_to")
-                for t in bp["agents"][state["agent"]]["tools"]
-                if t["name"] == name and t.get("handoff")
-            ),
-            None,
-        )
-        if not target or target not in bp["agents"]:
+        target = handoff_target(bp, state["agent"], name)
+        if not target:
             return {"success": False, "error": "unknown handoff target"}, False
         state["agent"] = target
-        return {
-            "success": True,
-            "role": target,
-            "instructions": bp["agents"][target]["instructions"],
-            "note": "You are now the scheduler. Follow the instructions field exactly.",
-        }, False
+        return {"success": True, "role": target}, False
 
     if name == "schedule_appointment":
         async with httpx.AsyncClient(timeout=30.0) as client:
@@ -167,32 +182,72 @@ async def run_tool(
         return result, stop
 
 
-def function_schemas(bp: dict[str, Any], handler) -> list:
-    """tools.json → Pipecat FunctionSchema list, all bound to one handler."""
-    from pipecat.adapters.schemas.function_schema import FunctionSchema
+def _spec(bp: dict[str, Any], name: str) -> tuple[str, dict, list]:
+    spec = bp["catalog"][name]
+    raw = spec.get("inputSchema") or {}
+    return (
+        spec.get("description", name),
+        dict(raw.get("properties") or {}),
+        list(raw.get("required") or []),
+    )
 
-    schemas = []
-    for name in tool_names(bp):
-        spec = bp["catalog"][name]
-        raw = spec.get("inputSchema") or {}
-        schemas.append(
-            FunctionSchema(
-                name=name,
-                description=spec.get("description", name),
-                properties=dict(raw.get("properties") or {}),
-                required=list(raw.get("required") or []),
-                handler=handler,
+
+def agent_tools_schema(bp: dict[str, Any], agent: str, handler):
+    """One agent's tools as a Pipecat `ToolsSchema`, bound to `handler`.
+
+    Handed to the S2S service at construction, so the session advertises this
+    agent's tools and nothing else. Pipecat registers the handlers off the
+    service's own tools when the context advertises none
+    (`LLMService._sync_registered_tool_handlers`).
+    """
+    from pipecat.adapters.schemas.function_schema import FunctionSchema
+    from pipecat.adapters.schemas.tools_schema import ToolsSchema
+
+    return ToolsSchema(
+        standard_tools=[
+            FunctionSchema(name=name, description=d, properties=p, required=r, handler=handler)
+            for name in tool_names(bp, agent)
+            for d, p, r in [_spec(bp, name)]
+        ]
+    )
+
+
+def flows_node(bp: dict[str, Any], agent: str, handler):
+    """One agent as a Pipecat Flows node: its own prompt, its own functions.
+
+    `handler` is called as `handler(name, args, flow_manager)` and must return
+    Flows' consolidated `(result, next_node)`.
+
+    RESET, not APPEND: a handoff hands the caller to a different agent, so the
+    scheduler starts on its own prompt rather than inheriting the receptionist's.
+    That matches what the S2S runtimes get for free from a second session.
+    """
+    import functools
+
+    from pipecat.flows import FlowsFunctionSchema, NodeConfig
+    from pipecat.flows.types import ContextStrategy, ContextStrategyConfig
+
+    return NodeConfig(
+        name=agent,
+        task_messages=[{"role": "system", "content": instructions(bp, agent)}],
+        functions=[
+            FlowsFunctionSchema(
+                name=name, description=d, properties=p, required=r,
+                handler=functools.partial(handler, name),
             )
-        )
-    return schemas
+            for name in tool_names(bp, agent)
+            for d, p, r in [_spec(bp, name)]
+        ],
+        context_strategy=ContextStrategyConfig(strategy=ContextStrategy.RESET),
+    )
 
 
 # ── services ─────────────────────────────────────────────────────────────────
 
 
-def build_llm(runtime: str, instructions: str, tools: list):
-    """The runtime's LLM (or S2S) service. `tools`/`instructions` are only passed
-    here for the S2S services that need them at construction time."""
+def build_llm(runtime: str, instructions: str, tools):
+    """One agent's LLM. For the S2S runtimes this *is* the agent: its own model
+    session, opened with its own instructions and its own tool set."""
     model = RUNTIMES[runtime]
 
     if runtime == "openai-realtime-2.1":
@@ -202,7 +257,7 @@ def build_llm(runtime: str, instructions: str, tools: list):
         return OpenAIRealtimeLLMService(
             api_key=os.environ["OPENAI_API_KEY"],
             model=model,
-            session_properties=SessionProperties(instructions=instructions),
+            session_properties=SessionProperties(instructions=instructions, tools=tools),
         )
 
     if runtime == "gemini-flash-live-3.1":
@@ -217,9 +272,18 @@ def build_llm(runtime: str, instructions: str, tools: list):
             tools=tools,
         )
 
+    # cascaded: prompt and tools are per-node, set by Flows.
     from pipecat.services.openai.llm import OpenAILLMService
 
     return OpenAILLMService(api_key=os.environ["OPENAI_API_KEY"], model=model)
+
+
+def build_agent_llms(runtime: str, bp: dict[str, Any], handler) -> dict[str, Any]:
+    """One S2S service per blueprint agent, receptionist first."""
+    return {
+        agent: build_llm(runtime, instructions(bp, agent), agent_tools_schema(bp, agent, handler))
+        for agent in agent_order(bp)
+    }
 
 
 def build_tts():
@@ -246,35 +310,42 @@ def build_stt_tts(runtime: str):
 
 
 def demo() -> None:
-    """Self-check: blueprint, tool schemas and the soft handoff, no network."""
+    """Self-check: blueprint, per-agent tool split and the handoff, no network."""
     import asyncio
 
     bp = load_blueprint("control-industry")
     assert bp["start"] == "receptionist", bp["start"]
-    assert tool_names(bp) == [
-        "handoff_to_scheduler",
-        "end_call",
-        "schedule_appointment",
-    ], tool_names(bp)
-    assert "Bluejay's Repair Services" in system_prompt(bp)
+    assert agent_order(bp) == ["receptionist", "scheduler"], agent_order(bp)
     assert set(RUNTIMES) == {
         "cascaded",
         "openai-realtime-2.1",
         "gemini-flash-live-3.1",
     }
+    assert S2S_RUNTIMES < set(RUNTIMES)
+
+    # The whole point: the receptionist cannot book. Its agent never carries
+    # schedule_appointment, so no model session it drives is ever told about it.
+    assert tool_names(bp, "receptionist") == ["handoff_to_scheduler", "end_call"]
+    assert tool_names(bp, "scheduler") == ["schedule_appointment", "end_call"]
+    assert "schedule_appointment" not in tool_names(bp, "receptionist")
+    assert "handoff_to_scheduler" not in tool_names(bp, "scheduler")
+
+    assert handoff_target(bp, "receptionist", "handoff_to_scheduler") == "scheduler"
+    assert handoff_target(bp, "scheduler", "handoff_to_scheduler") is None
 
     # the scripted opener must stay verbatim from the industry prompt, and only
     # the runtimes that cannot speak first may be given a greeting TTS
-    assert f'say: "{GREETING}"' in bp["agents"]["receptionist"]["instructions"], GREETING
-    assert GREETING_TTS_RUNTIMES <= set(RUNTIMES), GREETING_TTS_RUNTIMES
-    assert "cascaded" not in GREETING_TTS_RUNTIMES
+    assert f'say: "{GREETING}"' in instructions(bp, "receptionist"), GREETING
+    assert GREETING_TTS_RUNTIMES <= S2S_RUNTIMES
 
-    # (the greeting-only TTS gate needs pipecat installed — see check.py)
+    # (the tool-set split as the services actually see it needs pipecat — see check.py)
 
     state = {"agent": bp["start"]}
     res, stop = asyncio.run(run_tool("handoff_to_scheduler", {}, bp, state))
-    assert res["success"] and state["agent"] == "scheduler" and not stop, res
-    assert "schedule_appointment" in res["instructions"]
+    assert res == {"success": True, "role": "scheduler"} and not stop, res
+    assert state["agent"] == "scheduler"
+    # no instructions blob in the tool result — the switch is the mechanism now
+    assert "instructions" not in res
 
     res, stop = asyncio.run(run_tool("end_call", {"reason": "done"}, bp, state))
     assert res == {"success": True} and stop

--- a/voice-agent-harnesses/pipecat/harness.py
+++ b/voice-agent-harnesses/pipecat/harness.py
@@ -49,6 +49,11 @@ RUNTIMES = {
     "openai-realtime-2.1": "gpt-realtime-2.1",
     "gemini-flash-live-3.1": "gemini-3.1-flash-live-preview",
 }
+RUNTIME_SECRET_KEYS = {
+    "cascaded": frozenset({"DEEPGRAM_API_KEY", "OPENAI_API_KEY", "ELEVENLABS_API_KEY"}),
+    "openai-realtime-2.1": frozenset({"OPENAI_API_KEY"}),
+    "gemini-flash-live-3.1": frozenset({"GOOGLE_API_KEY"}),
+}
 DEFAULT_RUNTIME = "cascaded"
 # The runtimes whose "agent" is a speech-to-speech session rather than a text LLM.
 S2S_RUNTIMES = frozenset({"openai-realtime-2.1", "gemini-flash-live-3.1"})

--- a/voice-agent-harnesses/pipecat/harness.py
+++ b/voice-agent-harnesses/pipecat/harness.py
@@ -52,7 +52,7 @@ RUNTIMES = {
 RUNTIME_SECRET_KEYS = {
     "cascaded": frozenset({"DEEPGRAM_API_KEY", "OPENAI_API_KEY", "ELEVENLABS_API_KEY"}),
     "openai-realtime-2.1": frozenset({"OPENAI_API_KEY"}),
-    "gemini-flash-live-3.1": frozenset({"GOOGLE_API_KEY"}),
+    "gemini-flash-live-3.1": frozenset({"GOOGLE_API_KEY", "ELEVENLABS_API_KEY"}),
 }
 DEFAULT_RUNTIME = "cascaded"
 # The runtimes whose "agent" is a speech-to-speech session rather than a text LLM.

--- a/voice-agent-harnesses/pipecat/harness.py
+++ b/voice-agent-harnesses/pipecat/harness.py
@@ -156,18 +156,14 @@ async def run_tool(
 ) -> tuple[dict[str, Any], bool]:
     """Execute a tool under an `execute_tool` span. Errors soft-fail so the call
     survives and the trace still flushes."""
-    from report import call_offset_ms, finish_tool_span, tool_span
-
-    offset = call_offset_ms()
+    from report import finish_tool_span, tool_span
     with tool_span(name, args, call_id=call_id) as span:
         try:
             result, stop = await _execute_tool(name, args, bp, state)
             ok = bool(result.get("success"))
         except Exception as e:  # noqa: BLE001 — a dead tool must not kill the call
             result, stop, ok = {"success": False, "error": f"{type(e).__name__}: {e}"}, False, False
-        finish_tool_span(
-            span, result, ok=ok, name=name, parameters=args, start_offset_ms=offset
-        )
+        finish_tool_span(span, result, ok=ok)
         return result, stop
 
 

--- a/voice-agent-harnesses/pipecat/openai-realtime-2.1/agent.py
+++ b/voice-agent-harnesses/pipecat/openai-realtime-2.1/agent.py
@@ -1,0 +1,14 @@
+"""Local smoke for the `openai-realtime-2.1` runtime — builds the real services and pipeline
+without a transport, so a bad service kwarg fails here instead of mid-call.
+
+    uv run python voice-agent-harnesses/pipecat/openai-realtime-2.1/agent.py control-industry
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from check import check_runtime
+
+if __name__ == "__main__":
+    check_runtime("openai-realtime-2.1", sys.argv[1] if len(sys.argv) > 1 else "control-industry")

--- a/voice-agent-harnesses/pipecat/report.py
+++ b/voice-agent-harnesses/pipecat/report.py
@@ -1,0 +1,614 @@
+"""OpenTelemetry → Bluejay OTLP for the Pipecat harness.
+
+Same GenAI-native span tree the other MIVAS harnesses emit:
+
+  voice.call (root) — gen_ai.provider.name=pipecat
+    ├── agent.speech          (Bot{Started,Stopped}SpeakingFrame)
+    ├── customer.speech       (User{Started,Stopped}SpeakingFrame)
+    └── execute_tool <name>   (gen_ai.tool.*; in-process tool handlers)
+
+After the call we POST to update-simulation-result with `trace_ids` only —
+conversation tool markers come from the execute_tool spans, and posting
+`tool_calls` as well double-counts them.
+
+Unlike the CHIRP harnesses there is no `X-Simulation-Result-Id` header: Bluejay
+starts a Pipecat Cloud agent through `POST /v1/public/<agent>/start` and that
+call carries no per-run metadata (see `resolve_simulation_result_id`).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+from contextlib import asynccontextmanager, contextmanager
+from contextvars import ContextVar
+from typing import Any, AsyncIterator, Iterator
+
+import httpx
+from opentelemetry import trace as otel_trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.trace import Span, SpanKind, Status, StatusCode
+
+logger = logging.getLogger("mivas.otel.pipecat")
+if not logger.handlers:
+    _h = logging.StreamHandler(sys.stdout)
+    _h.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+    logger.addHandler(_h)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+DEFAULT_OTLP_ENDPOINT = "https://otlp.getbluejay.ai/v1/traces"
+DEFAULT_API_URL = "https://api.getbluejay.ai/v1"
+FINAL_STATUSES = {
+    "COMPLETED",
+    "FAILED",
+    "SYSTEM_ERROR",
+    "NO_ANSWER",
+    "CANCELLED",
+    "NO_CONNECTION",
+}
+EARLY_UPSERT_STATUSES = {"EVALUATING", "EVALUATED", "CONVERSATION_ENDED"}
+PROVIDER = "pipecat"
+TRACER_NAME = "mivas.pipecat"
+
+_provider: TracerProvider | None = None
+_root_span: ContextVar[Span | None] = ContextVar("mivas_pipecat_otel_root", default=None)
+_call_t0: ContextVar[float | None] = ContextVar("mivas_pipecat_otel_t0", default=None)
+_reported_tools: ContextVar[list[dict[str, Any]] | None] = ContextVar(
+    "mivas_pipecat_reported_tools", default=None
+)
+# module fallbacks when asyncio tasks don't inherit ContextVars
+_active_root: Span | None = None
+_active_t0: float | None = None
+_active_tools: list[dict[str, Any]] | None = None
+
+
+def _api_url() -> str:
+    return os.environ.get("BLUEJAY_API_URL", DEFAULT_API_URL).rstrip("/")
+
+
+def _otlp_endpoint() -> str:
+    return os.environ.get("BLUEJAY_OTLP_ENDPOINT", DEFAULT_OTLP_ENDPOINT)
+
+
+def _service_name() -> str:
+    return os.environ.get("BLUEJAY_SERVICE_NAME", "mivas-pipecat")
+
+
+def _api_key() -> str | None:
+    return os.environ.get("BLUEJAY_API_KEY") or None
+
+
+def _json_attr(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, default=str)
+    except Exception:
+        return str(value)
+
+
+def call_offset_ms() -> int:
+    t0 = _call_t0.get()
+    if t0 is None:
+        t0 = _active_t0
+    if t0 is None:
+        return 0
+    return max(0, int((time.monotonic() - t0) * 1000))
+
+
+def setup_otel() -> TracerProvider | None:
+    """Install global OTel exporter to Bluejay OTLP. No-op without BLUEJAY_API_KEY."""
+    global _provider
+
+    api_key = _api_key()
+    if not api_key:
+        return None
+
+    if _provider is not None:
+        return _provider
+
+    endpoint = _otlp_endpoint()
+    resource = Resource.create({SERVICE_NAME: _service_name()})
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(
+        SimpleSpanProcessor(
+            OTLPSpanExporter(endpoint, headers={"X-API-KEY": api_key})
+        )
+    )
+    otel_trace.set_tracer_provider(provider)
+    _provider = provider
+    logger.info("otel → %s service=%s", endpoint, _service_name())
+    return provider
+
+
+def flush() -> None:
+    if _provider is not None:
+        try:
+            _provider.force_flush()
+        except Exception as e:
+            logger.error("otel flush failed: %s", e)
+
+
+def _parent_span() -> Span | None:
+    parent = _root_span.get()
+    if parent is not None and parent.get_span_context().is_valid:
+        return parent
+    if _active_root is not None and _active_root.get_span_context().is_valid:
+        return _active_root
+    cur = otel_trace.get_current_span()
+    if cur is not None and cur.get_span_context().is_valid:
+        return cur
+    return None
+
+
+def record_tool_call(
+    name: str,
+    parameters: Any,
+    output: Any,
+    *,
+    start_offset_ms: int | None = None,
+) -> None:
+    """Buffer a tool call for the end-of-call update-simulation-result POST."""
+    tools = _reported_tools.get()
+    if tools is None:
+        tools = _active_tools
+    if tools is None:
+        return
+    tools.append(
+        {
+            "name": str(name),
+            "parameters": parameters if isinstance(parameters, dict) else {"raw": parameters},
+            "output": output,
+            "start_offset_ms": int(
+                start_offset_ms if start_offset_ms is not None else call_offset_ms()
+            ),
+        }
+    )
+
+
+@contextmanager
+def tool_span(
+    name: str,
+    parameters: Any = None,
+    *,
+    call_id: str | None = None,
+) -> Iterator[Span | None]:
+    """Child span under the active voice.call root. No-op outside traced_run."""
+    parent = _parent_span()
+    if parent is None:
+        yield None
+        return
+
+    tracer = otel_trace.get_tracer(TRACER_NAME)
+    parent_ctx = otel_trace.set_span_in_context(parent)
+    attrs: dict[str, Any] = {
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.provider.name": PROVIDER,
+        "gen_ai.tool.name": name,
+        "gen_ai.tool.call.arguments": _json_attr(parameters if parameters is not None else {}),
+        # conversation timestamps come from span start vs voice.call (OTel extraction)
+    }
+    if call_id:
+        attrs["gen_ai.tool.call.id"] = str(call_id)
+
+    with tracer.start_as_current_span(
+        f"execute_tool {name}",
+        context=parent_ctx,
+        kind=SpanKind.CLIENT,
+        attributes=attrs,
+    ) as span:
+        try:
+            yield span
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)[:400]))
+            raise
+
+
+def finish_tool_span(
+    span: Span | None,
+    output: Any,
+    *,
+    ok: bool = True,
+    name: str | None = None,
+    parameters: Any = None,
+    start_offset_ms: int | None = None,
+) -> None:
+    if span is not None:
+        span.set_attribute("gen_ai.tool.call.result", _json_attr(output))
+        if ok:
+            span.set_status(Status(StatusCode.OK))
+        else:
+            span.set_status(Status(StatusCode.ERROR, _json_attr(output)[:400]))
+
+
+def start_speech_span(
+    utterance_id: str, *, speaker: str = "agent"
+) -> Span | None:
+    """Begin agent.speech or customer.speech under voice.call."""
+    parent = _parent_span()
+    if parent is None:
+        return None
+    tracer = otel_trace.get_tracer(TRACER_NAME)
+    parent_ctx = otel_trace.set_span_in_context(parent)
+    is_customer = speaker in ("customer", "user", "digital_human")
+    span_name = "customer.speech" if is_customer else "agent.speech"
+    attrs: dict[str, Any] = {
+        "gen_ai.operation.name": (
+            "speech_to_text" if is_customer else "text_to_speech"
+        ),
+        "gen_ai.provider.name": PROVIDER,
+        "mivas.utterance_id": str(utterance_id),
+        "mivas.speech.speaker": "customer" if is_customer else "agent",
+        "bluejay.speech.start_offset_ms": call_offset_ms(),
+    }
+    span = tracer.start_span(
+        span_name,
+        context=parent_ctx,
+        kind=SpanKind.INTERNAL,
+        attributes=attrs,
+    )
+    return span
+
+def end_speech_span(span: Span | None) -> None:
+    if span is None:
+        return
+    span.set_attribute("bluejay.speech.end_offset_ms", call_offset_ms())
+    span.set_status(Status(StatusCode.OK))
+    span.end()
+
+
+IN_FLIGHT_STATUSES = ("DISPATCHED", "RUNNING", "READY", "QUEUED", "INITIALIZING")
+
+
+async def resolve_simulation_result_id(simulation_id: Any) -> str | None:
+    """Find the in-flight simulation result for `simulation_id`.
+
+    Bluejay's PIPECAT dispatch hands the bot only the static
+    `pipecat_agent_configuration` as the start `body`; the run's
+    simulation_result_id is never passed through (LiveKit gets it on the job
+    metadata, Pipecat has no equivalent). So the bot bakes its simulation_id
+    into that config and looks the live result up over the API instead.
+
+    ponytail: newest-run + first in-flight result. Correct at max_concurrent=1,
+    which is what the MIVAS control sims run at; a concurrent sim would need
+    Bluejay to pass the id through (see README).
+    """
+    key = _api_key()
+    if not key or not simulation_id:
+        return None
+    headers = {"X-API-Key": key}
+    try:
+        async with httpx.AsyncClient(timeout=20) as client:
+            r = await client.get(
+                f"{_api_url()}/get-simulation-runs/{simulation_id}", headers=headers
+            )
+            r.raise_for_status()
+            runs = (r.json() or {}).get("simulation_runs") or []
+            if not runs:
+                return None
+            run_id = max(runs, key=lambda s: int(s.get("id") or 0)).get("id")
+            r = await client.get(
+                f"{_api_url()}/retrieve-simulation-results/{run_id}", headers=headers
+            )
+            r.raise_for_status()
+            body = r.json() or {}
+            results = body.get("simulation_results") or body.get("results") or []
+    except Exception as e:
+        logger.error("resolve_simulation_result_id failed: %s: %s", type(e).__name__, e)
+        return None
+
+    for res in results:
+        if str(res.get("status")) in IN_FLIGHT_STATUSES:
+            logger.info(
+                "resolved simulation_result_id=%s (run=%s status=%s)",
+                res.get("id"), run_id, res.get("status"),
+            )
+            return str(res.get("id"))
+    logger.warning(
+        "no in-flight result on run=%s (statuses=%s)",
+        run_id, [r.get("status") for r in results],
+    )
+    return None
+
+
+async def _await_terminal_upsert(
+    client: httpx.AsyncClient, simulation_result_id: str, timeout: float = 300.0
+) -> str | None:
+    """Wait for a *final* status before the upsert.
+
+    300 s, not 150 s: eval regularly takes ~3 min to settle, and every second
+    short of that forces the early-post + relink path below, which appends the
+    execute_tool spans a second time. Still inside Pipecat Cloud's 600 s
+    maxSessionDuration even after a full 180 s call.
+
+    Posting during EVALUATING works, but eval then wipes trace_ids and the relink
+    POST re-extracts the execute_tool spans on top of the ones the first POST
+    already produced — every tool lands on the timeline twice. One POST after the
+    sim settles gives a surviving link and one row per tool; `_relink_after_final`
+    stays as the safety net for when this wait times out.
+    """
+    deadline = time.monotonic() + timeout
+    key = _api_key()
+    if not key:
+        return None
+    while time.monotonic() < deadline:
+        try:
+            r = await client.get(
+                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                headers={"X-API-Key": key},
+            )
+            if r.status_code == 200:
+                st = str(
+                    ((r.json() or {}).get("simulation_result") or {}).get("status")
+                )
+                if st in FINAL_STATUSES:
+                    return st
+        except Exception:
+            pass
+        await asyncio.sleep(1.0)
+    return None
+
+
+async def post_simulation_enrichment(
+    simulation_result_id: str,
+    *,
+    trace_id: str | None,
+    tool_calls: list[dict[str, Any]] | None = None,
+) -> None:
+    """Link OTel trace_ids. tool_calls ignored — use execute_tool spans."""
+    del tool_calls
+    key = _api_key()
+    if not key or not simulation_result_id:
+        logger.warning(
+            "skip update-simulation-result — "
+            "simulation_result_id=%s key=%s",
+            simulation_result_id,
+            bool(key),
+        )
+        return
+    if not str(simulation_result_id).isdigit():
+        logger.warning(
+            "skip update-simulation-result — non-numeric sim id=%s",
+            simulation_result_id,
+        )
+        return
+
+    body: dict[str, Any] = {"simulation_result_id": str(simulation_result_id)}
+    if trace_id:
+        body["trace_ids"] = [trace_id]
+    if "trace_ids" not in body and "tool_calls" not in body:
+        logger.warning("skip update-simulation-result — nothing to post")
+        return
+
+    await asyncio.sleep(0.5)
+
+    last_err: str | None = None
+    for attempt in range(1, 4):
+        try:
+            async with httpx.AsyncClient(timeout=20) as client:
+                st = await _await_terminal_upsert(client, simulation_result_id)
+                if st is None:
+                    check = await client.get(
+                        f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                        headers={"X-API-Key": key},
+                    )
+                    if check.status_code == 404:
+                        logger.warning(
+                            "skip update-simulation-result — sim=%s not found",
+                            simulation_result_id,
+                        )
+                        return
+                r = await client.post(
+                    f"{_api_url()}/update-simulation-result",
+                    json=body,
+                    headers={"X-API-Key": key, "Content-Type": "application/json"},
+                )
+                if r.status_code >= 400:
+                    last_err = f"{r.status_code} {r.text[:300]} (status={st})"
+                    logger.error(
+                        "update-simulation-result FAILED attempt=%s %s",
+                        attempt,
+                        last_err,
+                    )
+                    if r.status_code == 404:
+                        return
+                else:
+                    logger.info(
+                        "update-simulation-result ok trace=%s sim=%s terminal=%s attempt=%s",
+                        trace_id,
+                        simulation_result_id,
+                        st,
+                        attempt,
+                    )
+                    if (st is None or st in EARLY_UPSERT_STATUSES) and trace_id:
+                        await _relink_after_final(
+                            client, simulation_result_id, body, key, trace_id, st
+                        )
+                    return
+        except Exception as e:
+            last_err = f"{type(e).__name__}: {e}"
+            logger.error(
+                "update-simulation-result error attempt=%s %s", attempt, last_err
+            )
+        await asyncio.sleep(1.0 * attempt)
+    logger.error("update-simulation-result gave up: %s", last_err)
+
+
+
+async def _relink_after_final(
+    client: httpx.AsyncClient,
+    simulation_result_id: str,
+    body: dict[str, Any],
+    key: str,
+    trace_id: str,
+    early_status: str | None,
+) -> None:
+    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link).
+
+    Only if it actually got wiped: each POST re-extracts the execute_tool spans and
+    appends them, so a redundant relink double-counts every tool on the timeline.
+    """
+    final: str | None = None
+    linked = False
+    deadline = time.monotonic() + 120.0
+    while time.monotonic() < deadline:
+        try:
+            r = await client.get(
+                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                headers={"X-API-Key": key},
+            )
+            if r.status_code == 200:
+                result = (r.json() or {}).get("simulation_result") or {}
+                st = str(result.get("status"))
+                if st in FINAL_STATUSES:
+                    final = st
+                    linked = trace_id in (result.get("trace_ids") or [])
+                    break
+        except Exception:
+            pass
+        await asyncio.sleep(2.0)
+    if final is not None and linked:
+        logger.info(
+            "relink not needed after %s — trace=%s still linked sim=%s final=%s",
+            early_status,
+            trace_id,
+            simulation_result_id,
+            final,
+        )
+        return
+    if final is None:
+        logger.warning(
+            "relink skipped — still not final after early upsert terminal=%s sim=%s",
+            early_status,
+            simulation_result_id,
+        )
+        return
+    r = await client.post(
+        f"{_api_url()}/update-simulation-result",
+        json=body,
+        headers={"X-API-Key": key, "Content-Type": "application/json"},
+    )
+    if r.status_code >= 400:
+        logger.error(
+            "relink after %s FAILED sim=%s %s %s",
+            early_status,
+            simulation_result_id,
+            r.status_code,
+            r.text[:300],
+        )
+    else:
+        logger.info(
+            "relink after %s ok trace=%s sim=%s final=%s",
+            early_status,
+            trace_id,
+            simulation_result_id,
+            final,
+        )
+
+# back-compat alias used by older call sites
+async def post_trace_ids(simulation_result_id: str, trace_id: str) -> None:
+    await post_simulation_enrichment(
+        simulation_result_id, trace_id=trace_id, tool_calls=_reported_tools.get()
+    )
+
+
+@asynccontextmanager
+async def traced_run(
+    workflow_name: str,
+    *,
+    simulation_result_id: str | None = None,
+    model: str | None = None,
+) -> AsyncIterator[None]:
+    """OTel voice.call root; flush + link trace_ids/tool_calls on exit."""
+    global _active_root, _active_t0, _active_tools
+
+    provider = setup_otel()
+    if provider is None:
+        yield
+        return
+
+    tracer = otel_trace.get_tracer(TRACER_NAME)
+    attrs: dict[str, Any] = {
+        "gen_ai.system": PROVIDER,
+        "gen_ai.provider.name": PROVIDER,
+        "gen_ai.operation.name": "invoke_agent",
+        "mivas.workflow.name": workflow_name,
+    }
+    if model:
+        attrs["gen_ai.request.model"] = model
+    if simulation_result_id:
+        attrs["bluejay.simulation_result_id"] = str(simulation_result_id)
+
+    otel_tid: str | None = None
+    root_token = None
+    tools_token = None
+    t0 = time.monotonic()
+    t0_token = _call_t0.set(t0)
+    tool_buf: list[dict[str, Any]] = []
+    prev_active = _active_root
+    prev_t0 = _active_t0
+    prev_tools = _active_tools
+    try:
+        with tracer.start_as_current_span(
+            "voice.call",
+            kind=SpanKind.SERVER,
+            attributes=attrs,
+        ) as root:
+            root_token = _root_span.set(root)
+            tools_token = _reported_tools.set(tool_buf)
+            _active_root = root
+            _active_t0 = t0
+            _active_tools = tool_buf
+            ctx = root.get_span_context()
+            if ctx.is_valid:
+                otel_tid = format(ctx.trace_id, "032x")
+                logger.info(
+                    "otel trace_id=%s sim=%s workflow=%s model=%s",
+                    otel_tid,
+                    simulation_result_id,
+                    workflow_name,
+                    model,
+                )
+            try:
+                yield
+            except Exception as e:
+                if type(e).__name__.startswith("ConnectionClosed"):
+                    root.set_status(Status(StatusCode.OK))
+                else:
+                    raise
+    finally:
+        _active_root = prev_active
+        _active_t0 = prev_t0
+        _active_tools = prev_tools
+        if root_token is not None:
+            _root_span.reset(root_token)
+        if tools_token is not None:
+            _reported_tools.reset(tools_token)
+        _call_t0.reset(t0_token)
+        flush()
+        if simulation_result_id and (otel_tid or tool_buf):
+            try:
+                await post_simulation_enrichment(
+                    simulation_result_id,
+                    trace_id=otel_tid,
+                                    )
+            except Exception as e:
+                logger.error(
+                    "post_simulation_enrichment crashed: %s: %s",
+                    type(e).__name__,
+                    e,
+                )
+        elif simulation_result_id and not otel_tid:
+            logger.error(
+                "have simulation_result_id=%s but no otel trace id to post",
+                simulation_result_id,
+            )

--- a/voice-agent-harnesses/pipecat/report.py
+++ b/voice-agent-harnesses/pipecat/report.py
@@ -54,20 +54,15 @@ FINAL_STATUSES = {
     "CANCELLED",
     "NO_CONNECTION",
 }
-EARLY_UPSERT_STATUSES = {"EVALUATING", "EVALUATED", "CONVERSATION_ENDED"}
 PROVIDER = "pipecat"
 TRACER_NAME = "mivas.pipecat"
 
 _provider: TracerProvider | None = None
 _root_span: ContextVar[Span | None] = ContextVar("mivas_pipecat_otel_root", default=None)
 _call_t0: ContextVar[float | None] = ContextVar("mivas_pipecat_otel_t0", default=None)
-_reported_tools: ContextVar[list[dict[str, Any]] | None] = ContextVar(
-    "mivas_pipecat_reported_tools", default=None
-)
 # module fallbacks when asyncio tasks don't inherit ContextVars
 _active_root: Span | None = None
 _active_t0: float | None = None
-_active_tools: list[dict[str, Any]] | None = None
 
 
 def _api_url() -> str:
@@ -149,31 +144,6 @@ def _parent_span() -> Span | None:
     return None
 
 
-def record_tool_call(
-    name: str,
-    parameters: Any,
-    output: Any,
-    *,
-    start_offset_ms: int | None = None,
-) -> None:
-    """Buffer a tool call for the end-of-call update-simulation-result POST."""
-    tools = _reported_tools.get()
-    if tools is None:
-        tools = _active_tools
-    if tools is None:
-        return
-    tools.append(
-        {
-            "name": str(name),
-            "parameters": parameters if isinstance(parameters, dict) else {"raw": parameters},
-            "output": output,
-            "start_offset_ms": int(
-                start_offset_ms if start_offset_ms is not None else call_offset_ms()
-            ),
-        }
-    )
-
-
 @contextmanager
 def tool_span(
     name: str,
@@ -218,9 +188,6 @@ def finish_tool_span(
     output: Any,
     *,
     ok: bool = True,
-    name: str | None = None,
-    parameters: Any = None,
-    start_offset_ms: int | None = None,
 ) -> None:
     if span is not None:
         span.set_attribute("gen_ai.tool.call.result", _json_attr(output))
@@ -330,11 +297,11 @@ async def _await_terminal_upsert(
     execute_tool spans a second time. Still inside Pipecat Cloud's 600 s
     maxSessionDuration even after a full 180 s call.
 
-    Posting during EVALUATING works, but eval then wipes trace_ids and the relink
-    POST re-extracts the execute_tool spans on top of the ones the first POST
-    already produced — every tool lands on the timeline twice. One POST after the
-    sim settles gives a surviving link and one row per tool; `_relink_after_final`
-    stays as the safety net for when this wait times out.
+    Posting during EVALUATING works, but eval then wipes trace_ids, and re-posting
+    makes Bluejay re-extract the execute_tool spans on top of the ones the first
+    POST already produced — every tool lands on the timeline twice. One POST after
+    the sim settles gives a surviving link and one row per tool. On timeout we post
+    anyway and log it; we never re-post, because that is the double-count.
     """
     deadline = time.monotonic() + timeout
     key = _api_key()
@@ -362,10 +329,8 @@ async def post_simulation_enrichment(
     simulation_result_id: str,
     *,
     trace_id: str | None,
-    tool_calls: list[dict[str, Any]] | None = None,
 ) -> None:
-    """Link OTel trace_ids. tool_calls ignored — use execute_tool spans."""
-    del tool_calls
+    """Link OTel trace_ids; conversation tools come from execute_tool spans."""
     key = _api_key()
     if not key or not simulation_result_id:
         logger.warning(
@@ -385,7 +350,7 @@ async def post_simulation_enrichment(
     body: dict[str, Any] = {"simulation_result_id": str(simulation_result_id)}
     if trace_id:
         body["trace_ids"] = [trace_id]
-    if "trace_ids" not in body and "tool_calls" not in body:
+    if "trace_ids" not in body:
         logger.warning("skip update-simulation-result — nothing to post")
         return
 
@@ -429,9 +394,12 @@ async def post_simulation_enrichment(
                         st,
                         attempt,
                     )
-                    if (st is None or st in EARLY_UPSERT_STATUSES) and trace_id:
-                        await _relink_after_final(
-                            client, simulation_result_id, body, key, trace_id, st
+                    if st is None:
+                        logger.warning(
+                            "linked without a final status — sim=%s may still be "
+                            "EVALUATING; if eval wipes trace_ids the link is lost "
+                            "(we do not re-post: a second POST double-counts tools)",
+                            simulation_result_id,
                         )
                     return
         except Exception as e:
@@ -444,83 +412,6 @@ async def post_simulation_enrichment(
 
 
 
-async def _relink_after_final(
-    client: httpx.AsyncClient,
-    simulation_result_id: str,
-    body: dict[str, Any],
-    key: str,
-    trace_id: str,
-    early_status: str | None,
-) -> None:
-    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link).
-
-    Only if it actually got wiped: each POST re-extracts the execute_tool spans and
-    appends them, so a redundant relink double-counts every tool on the timeline.
-    """
-    final: str | None = None
-    linked = False
-    deadline = time.monotonic() + 120.0
-    while time.monotonic() < deadline:
-        try:
-            r = await client.get(
-                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
-                headers={"X-API-Key": key},
-            )
-            if r.status_code == 200:
-                result = (r.json() or {}).get("simulation_result") or {}
-                st = str(result.get("status"))
-                if st in FINAL_STATUSES:
-                    final = st
-                    linked = trace_id in (result.get("trace_ids") or [])
-                    break
-        except Exception:
-            pass
-        await asyncio.sleep(2.0)
-    if final is not None and linked:
-        logger.info(
-            "relink not needed after %s — trace=%s still linked sim=%s final=%s",
-            early_status,
-            trace_id,
-            simulation_result_id,
-            final,
-        )
-        return
-    if final is None:
-        logger.warning(
-            "relink skipped — still not final after early upsert terminal=%s sim=%s",
-            early_status,
-            simulation_result_id,
-        )
-        return
-    r = await client.post(
-        f"{_api_url()}/update-simulation-result",
-        json=body,
-        headers={"X-API-Key": key, "Content-Type": "application/json"},
-    )
-    if r.status_code >= 400:
-        logger.error(
-            "relink after %s FAILED sim=%s %s %s",
-            early_status,
-            simulation_result_id,
-            r.status_code,
-            r.text[:300],
-        )
-    else:
-        logger.info(
-            "relink after %s ok trace=%s sim=%s final=%s",
-            early_status,
-            trace_id,
-            simulation_result_id,
-            final,
-        )
-
-# back-compat alias used by older call sites
-async def post_trace_ids(simulation_result_id: str, trace_id: str) -> None:
-    await post_simulation_enrichment(
-        simulation_result_id, trace_id=trace_id, tool_calls=_reported_tools.get()
-    )
-
-
 @asynccontextmanager
 async def traced_run(
     workflow_name: str,
@@ -529,7 +420,7 @@ async def traced_run(
     model: str | None = None,
 ) -> AsyncIterator[None]:
     """OTel voice.call root; flush + link trace_ids/tool_calls on exit."""
-    global _active_root, _active_t0, _active_tools
+    global _active_root, _active_t0
 
     provider = setup_otel()
     if provider is None:
@@ -550,13 +441,10 @@ async def traced_run(
 
     otel_tid: str | None = None
     root_token = None
-    tools_token = None
     t0 = time.monotonic()
     t0_token = _call_t0.set(t0)
-    tool_buf: list[dict[str, Any]] = []
     prev_active = _active_root
     prev_t0 = _active_t0
-    prev_tools = _active_tools
     try:
         with tracer.start_as_current_span(
             "voice.call",
@@ -564,10 +452,8 @@ async def traced_run(
             attributes=attrs,
         ) as root:
             root_token = _root_span.set(root)
-            tools_token = _reported_tools.set(tool_buf)
             _active_root = root
             _active_t0 = t0
-            _active_tools = tool_buf
             ctx = root.get_span_context()
             if ctx.is_valid:
                 otel_tid = format(ctx.trace_id, "032x")
@@ -588,14 +474,11 @@ async def traced_run(
     finally:
         _active_root = prev_active
         _active_t0 = prev_t0
-        _active_tools = prev_tools
         if root_token is not None:
             _root_span.reset(root_token)
-        if tools_token is not None:
-            _reported_tools.reset(tools_token)
         _call_t0.reset(t0_token)
         flush()
-        if simulation_result_id and (otel_tid or tool_buf):
+        if simulation_result_id and otel_tid:
             try:
                 await post_simulation_enrichment(
                     simulation_result_id,

--- a/voice-agent-harnesses/pipecat/requirements.txt
+++ b/voice-agent-harnesses/pipecat/requirements.txt
@@ -1,0 +1,4 @@
+pipecat-ai[daily,deepgram,elevenlabs,google,openai,runner,silero]==1.7.0
+opentelemetry-sdk>=1.30
+opentelemetry-exporter-otlp-proto-http>=1.30
+httpx>=0.27

--- a/voice-agent-harnesses/pipecat/requirements.txt
+++ b/voice-agent-harnesses/pipecat/requirements.txt
@@ -2,3 +2,4 @@ pipecat-ai[daily,deepgram,elevenlabs,google,openai,runner,silero]==1.7.0
 opentelemetry-sdk>=1.30
 opentelemetry-exporter-otlp-proto-http>=1.30
 httpx>=0.27
+loguru>=0.7

--- a/voice-agent-harnesses/retell/README.md
+++ b/voice-agent-harnesses/retell/README.md
@@ -82,7 +82,7 @@ set -a && source .env && set +a
 export PUBLIC_URL=https://<tunnel>.trycloudflare.com
 uv run python voice-agent-harnesses/retell/flux-gpt4.1-flash2.5/agent.py control-industry
 
-# terminal C — the bridge
+# terminal D — the bridge
 export BLUEJAY_API_KEY=… BLUEJAY_API_URL=https://api.getbluejay.ai/v1
 export BLUEJAY_OTLP_ENDPOINT=https://otlp.getbluejay.ai/v1/traces
 export BLUEJAY_SERVICE_NAME=mivas-retell

--- a/voice-agent-harnesses/retell/README.md
+++ b/voice-agent-harnesses/retell/README.md
@@ -1,3 +1,158 @@
-# retell
+# Retell harness
 
-Benchmarks and evaluation assets for retell voice agents.
+Retell AI over CHIRP. Multi-agent is native (`retell-llm` `states` + `edges`), tools are
+platform-side webhooks, and the call itself runs on LiveKit.
+
+## Runtime
+
+| Runtime | LLM | TTS | STT |
+|---|---|---|---|
+| `flux-gpt4.1-flash2.5` | `gpt-4.1` (retell-llm) | ElevenLabs `eleven_flash_v2_5` | Deepgram via `custom_stt_config`, `endpointing_ms: 100` |
+
+### ⚠️ Deepgram Flux is not available on Retell
+
+The runtime folder is named `flux-gpt4.1-flash2.5` to line up with the Vapi harness, but
+**Retell does not run Flux**. `create-agent` exposes no STT model field at all:
+`custom_stt_config` accepts only `{provider, endpointing_ms}` with `provider` in
+`azure | deepgram | soniox | assemblyai`. So this harness sends
+`stt_mode: "custom"`, `custom_stt_config: {provider: "deepgram", endpointing_ms: 100}` and
+Retell picks the Deepgram model. Any Retell-vs-Vapi comparison is *not* STT-matched.
+
+## Shape
+
+```
+Bluejay DH ──CHIRP ws (16k pcm + speech.*)──▶ adapters/chirp.py ──LiveKit room──▶ Retell
+                                                    ▲                               │
+                        POST {PUBLIC_URL}/tool/schedule_appointment ────────────────┘
+                                                    │
+                                        industries/*/tool_server.py
+```
+
+- **Agents**: one `retell-llm` with a `receptionist` state and a `scheduler` state. The
+  blueprint's `handoff_to_scheduler` becomes an `edge`; Retell surfaces it to the model as
+  `transition_to_scheduler` (the prompt is rewritten to say so), so the harness never routes
+  the handoff. `end_call` is Retell's built-in `{type: "end_call"}` tool.
+- **Tools**: Retell tools execute platform-side, so `schedule_appointment` is a
+  `{type: "custom"}` tool whose `url` points back at this process. The `execute_tool` span is
+  emitted in the webhook handler. The tunnel URL is ephemeral, so `ensure_agent` re-PATCHes the
+  llm (and therefore the tool URLs) on every boot; `.agents.json` keeps the ids stable.
+- **Transport**: `POST /v2/create-web-call` returns a LiveKit JWT for room `web_call_<call_id>`.
+  We publish a mic track fed by CHIRP pcm and subscribe to the agent track. LiveKit resamples,
+  so there is no `audioop` here. **The deprecated `wss://api.retellai.com/audio-websocket/…` +
+  `register-call` path is not used.**
+- **Agent turns**: LiveKit audio frames are continuous, so `agent.speech` is bracketed by
+  Retell's `agent_start_talking` / `agent_stop_talking` data messages. Retell fires a spurious
+  start/stop pair ~250 ms before each real turn; stops under `BLIP_S` (150 ms) are ignored.
+- **Tool spans**: `schedule_appointment` gets a live span in the webhook. The edge transition and
+  `end_call` execute inside Retell and reach no client channel, so after hangup the bridge reads
+  `GET /v2/get-call/{call_id}` and backfills them from `transcript_with_tool_calls`. `time_sec`
+  there is relative to the record's `start_timestamp` (epoch ms), so the backfilled spans get
+  explicit epoch-ns start/end and land in the same time base as the live ones. Invocations tagged
+  `type: "custom"` are skipped — those are the webhook tools that already have a span.
+  The transition is reported under the blueprint name **`handoff_to_scheduler`** for cross-provider
+  comparability, with Retell's own name kept in `mivas.provider.tool_name=transition_to_scheduler`.
+
+## Env
+
+| var | default | note |
+|---|---|---|
+| `RETELL_API_KEY` | — | required |
+| `PUBLIC_URL` | — | required; cloudflared https url, becomes the tool webhook base |
+| `RETELL_LIVEKIT_URL` | `wss://retell-ai-4ihahnq7.livekit.cloud` | hardcoded in `retell-client-js-sdk@2.0.8` |
+| `RETELL_LLM_MODEL` | `gpt-4.1` | |
+| `RETELL_VOICE_ID` | `11labs-Kate` | |
+| `RETELL_STT_PROVIDER` | `deepgram` | azure / deepgram / soniox / assemblyai |
+| `RETELL_ENDPOINTING_MS` | `100` | |
+| `RETELL_GREETING` | "Welcome to Bluejay's Repair Services!…" | retell-llm `begin_message` |
+| `RETELL_START_SPEAKER` | `agent` | `user` makes Retell wait for the caller — **and drops `begin_message`** |
+| `RETELL_AGENT_ID` / `RETELL_LLM_ID` | — | override `.agents.json` |
+| `CHIRP_PORT` | `8771` | serves both the ws and the tool webhook |
+
+## Run
+
+```bash
+# terminal A — industry state API
+uv run python industries/control-industry/tool_server.py
+
+# terminal B — tunnel (one tunnel covers ws + tool webhook)
+cloudflared tunnel --url http://127.0.0.1:8771 --no-autoupdate
+
+# terminal C — push the blueprint to Retell and check the ids
+set -a && source .env && set +a
+export PUBLIC_URL=https://<tunnel>.trycloudflare.com
+uv run python voice-agent-harnesses/retell/flux-gpt4.1-flash2.5/agent.py control-industry
+
+# terminal C — the bridge
+export BLUEJAY_API_KEY=… BLUEJAY_API_URL=https://api.getbluejay.ai/v1
+export BLUEJAY_OTLP_ENDPOINT=https://otlp.getbluejay.ai/v1/traces
+export BLUEJAY_SERVICE_NAME=mivas-retell
+export CHIRP_USER=mivas CHIRP_PASS=mivas
+export INDUSTRY=control-industry TOOL_SERVER_URL=http://127.0.0.1:8000
+export CHIRP_PORT=8771 PYTHONUNBUFFERED=1
+uv run python voice-agent-harnesses/retell/flux-gpt4.1-flash2.5/adapters/chirp.py
+```
+
+Point a Bluejay `WEBSOCKET` agent at `wss://<tunnel>.trycloudflare.com` with
+`websocket_username=mivas` / `websocket_password=mivas`.
+
+Extra dep vs the other harnesses: **`livekit`** (the Python rtc SDK).
+
+## Who speaks first
+
+`start_speaker: "agent"` + `begin_message` is the default: an inbound receptionist answers the
+phone, which is what the industry prompt's mandated greeting assumes. Setting
+`RETELL_START_SPEAKER=user` is accepted by the API but makes Retell **drop `begin_message`
+entirely** (verified: the created llm comes back with `begin_message: null`), so the greeting
+would then depend on the model obeying the prompt rather than being scripted.
+
+Observed with a digital human that also speaks first (`speaks_first: true`, `ai_generated`):
+no collision. Bluejay's caller waits for the greeting to finish (agent 0.21–3.42 s, caller's
+first word 3.02 s). What it does cost is a **redundant double greeting** — the caller opens with
+a content-free "Hello.", so the agent greets again before the caller states intent, burning ~7 s.
+That happens identically without `speaks_first`, so it is a digital-human artifact, not a
+`start_speaker` problem, and flipping `start_speaker` would not fix it.
+
+Recommendation: leave it on `agent`. Changing it would make Retell the only caller-first provider
+and break comparability. If the bench wants caller-first, flip it across all providers together.
+
+## Check
+
+```bash
+python voice-agent-harnesses/retell/test_platform_tools.py
+```
+Asserts the call-record → span mapping against a real Retell payload: webhook tools excluded,
+edge tool renamed to the blueprint name, `time_sec` → epoch ns.
+
+## Proof run (canonical)
+
+control-industry, sim 30209 / agent 30376 / DH 194135 (`speaks_first: false`):
+**https://app.getbluejay.ai/simulations/30209/runs/224729** — `simulation_result_id` 710643.
+
+`COMPLETED`, `trace_ids` non-empty, `goal_success: true`, all three tools on the timeline with
+`expected` paired against `actual` on the two the DH declares:
+
+| tool | source | start_offset_ms |
+|---|---|---|
+| `handoff_to_scheduler` | backfilled from call record | 14954 |
+| `schedule_appointment` | live webhook span | 28557 |
+| `end_call` | backfilled from call record | 38014 |
+
+Backfill alignment is exact: Retell's call starts 602 ms after `voice.call`, and
+`transition_to_scheduler` (`time_sec` 13.711) lands at 14313 ms in the trace — 13711 + 602 to the
+millisecond. Same for `end_call` (36.771 s → 37373 ms). The live webhook span trails Retell's own
+invocation time by ~112 ms, which is the HTTP hop.
+
+### Known issue — the agent has no current date
+
+In this run the scheduler booked **06/11/2024**, over two years in the past. That is a Tuesday, so
+the model computed "next Tuesday" correctly but anchored to its training prior: nothing in the
+context supplies today's date. Retell injects none, and this harness's `general_prompt` does not
+either.
+
+Every earlier passing run hid this, because the caller spoke the date aloud ("that would be August
+eighteenth, twenty twenty six") and the agent only had to echo it. Turning `speaks_first` off
+removed that crutch and exposed it.
+
+The fix is one line in `_llm_payload` — append `f"Today is {date.today():%A, %B %-d, %Y}."` to
+`general_prompt`. It is deliberately **not** applied here: it changes what the benchmark measures,
+so it should land across all providers at once or not at all. See the harness report.

--- a/voice-agent-harnesses/retell/adapters/chirp.py
+++ b/voice-agent-harnesses/retell/adapters/chirp.py
@@ -1,0 +1,282 @@
+"""16 kHz pcm websocket bridge ↔ Retell web call (LiveKit transport).
+
+Retell has no audio websocket of its own any more: `POST /v2/create-web-call`
+hands back a LiveKit JWT and the call lives in a LiveKit room. So we publish a
+microphone track fed by CHIRP pcm and subscribe to the agent's track for the
+return path. LiveKit resamples both directions for us (`AudioSource(16000)` /
+`AudioStream(sample_rate=16000)`), so there is no `audioop` here.
+
+Agent audio frames are continuous, so agent turns are bracketed by Retell's
+`agent_start_talking` / `agent_stop_talking` data messages, not by frame gaps.
+
+One FastAPI app serves both halves on one port so a single cloudflared tunnel
+covers them: `/` is the CHIRP websocket, `/tool/{name}` is the Retell webhook
+that runs `schedule_appointment` (Retell tools execute platform-side, so the
+`execute_tool` span is born there).
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import contextlib
+import json
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import uvicorn
+from fastapi import FastAPI, Request, WebSocket
+from typing import Any
+from livekit import rtc
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from harness import (  # noqa: E402
+    create_web_call,
+    ensure_agent,
+    industry_path,
+    livekit_url,
+    load_blueprint,
+    report_platform_tools,
+    run_tool,
+)
+from report import (  # noqa: E402
+    end_speech_span,
+    start_speech_span,
+    traced_run,
+)
+
+RATE, CHANNELS = 16_000, 1
+# Below this, an agent "turn" is a Retell state blip, not speech.
+BLIP_S = 0.15
+app = FastAPI(title="mivas retell chirp bridge")
+# ponytail: one agent id + one active call per process — benchmark runs are
+# sequential (max_concurrent=1). Per-call routing needs a call_id → root map.
+CFG: dict[str, Any] = {}
+
+
+@app.post("/tool/{name}")
+async def tool_webhook(name: str, request: Request) -> dict:
+    """Retell custom tool → `{call, name, args}`; the return value goes to the LLM."""
+    body = await request.json()
+    args = dict(body.get("args") or {})
+    call_id = (body.get("call") or {}).get("call_id")
+    result = await run_tool(name, args, call_id=call_id)
+    print(f"chirp tool {name} args={args} -> {result}", flush=True)
+    return result
+
+
+def _auth() -> str | None:
+    u, p = os.environ.get("CHIRP_USER", "").strip(), os.environ.get("CHIRP_PASS", "").strip()
+    return f"Basic {base64.b64encode(f'{u}:{p}'.encode()).decode()}" if u and p else None
+
+
+def _event(t: str, data: dict) -> str:
+    return json.dumps(
+        {"type": t, "id": str(uuid.uuid4()), "ts_ms": int(time.time() * 1000), "data": data},
+        separators=(",", ":"),
+    )
+
+
+@app.websocket("/")
+async def chirp(ws: WebSocket) -> None:
+    expected = _auth()
+    if expected and ws.headers.get("authorization") != expected:
+        await ws.close(1008, "unauthorized")
+        return
+    await ws.accept()
+    try:
+        await _bridge(ws)
+    except Exception as e:
+        print(f"chirp bridge error: {type(e).__name__}: {e}", flush=True)
+    finally:
+        with contextlib.suppress(Exception):
+            await ws.close()
+
+
+async def _bridge(ws: WebSocket) -> None:
+    sim_id = ws.headers.get("x-simulation-result-id")
+    sim_id = str(sim_id).strip() if sim_id else None
+    if sim_id:
+        print(f"chirp sim_result_id={sim_id}", flush=True)
+
+    call = create_web_call(CFG["agent_id"])
+    print(f"chirp retell call_id={call['call_id']}", flush=True)
+
+    end = asyncio.Event()
+    outq: asyncio.Queue[bytes | str] = asyncio.Queue()
+    agent_otel = None
+    agent_utt: str | None = None
+    agent_started: float = 0.0
+    customer_otel = None
+    agent_bytes = 0
+
+    async with traced_run(CFG["workflow"], simulation_result_id=sim_id, model=CFG["model"]):
+        room = rtc.Room()
+
+        def _agent_start() -> None:
+            nonlocal agent_otel, agent_utt, agent_started
+            if agent_utt is not None:
+                return
+            agent_utt = f"u_{uuid.uuid4().hex[:12]}"
+            agent_started = time.monotonic()
+            agent_otel = start_speech_span(agent_utt, speaker="agent")
+            outq.put_nowait(_event("speech.started", {"utterance_id": agent_utt}))
+
+        def _agent_stop(*, force: bool = False) -> None:
+            """Retell fires a spurious start/stop pair ~250 ms before each real turn;
+            a sub-BLIP_S utterance is that artifact, so hold the span open for the
+            real audio instead of littering the waterfall with 20 ms spans."""
+            nonlocal agent_otel, agent_utt
+            if agent_utt is None:
+                return
+            if not force and time.monotonic() - agent_started < BLIP_S:
+                return
+            end_speech_span(agent_otel)
+            outq.put_nowait(_event("speech.completed", {"utterance_id": agent_utt}))
+            agent_otel, agent_utt = None, None
+
+        @room.on("data_received")
+        def _on_data(packet: rtc.DataPacket) -> None:
+            try:
+                event = json.loads(bytes(packet.data).decode())
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                return
+            etype = event.get("event_type")
+            if etype == "agent_start_talking":
+                _agent_start()
+            elif etype == "agent_stop_talking":
+                _agent_stop()
+            elif etype not in ("update", None):
+                print(f"chirp retell data {etype}", flush=True)
+
+        @room.on("track_subscribed")
+        def _on_track(track: rtc.Track, *_a) -> None:
+            if track.kind == rtc.TrackKind.KIND_AUDIO:
+                asyncio.create_task(_pump(track))
+
+        @room.on("disconnected")
+        def _on_disconnected(*_a) -> None:
+            end.set()
+
+        @room.on("participant_disconnected")
+        def _on_participant_gone(*_a) -> None:
+            end.set()
+
+        async def _pump(track: rtc.Track) -> None:
+            nonlocal agent_bytes
+            async for ev in rtc.AudioStream(track, sample_rate=RATE, num_channels=CHANNELS):
+                pcm = bytes(ev.frame.data)
+                agent_bytes += len(pcm)
+                outq.put_nowait(pcm)
+
+        await room.connect(
+            livekit_url(), call["access_token"], options=rtc.RoomOptions(auto_subscribe=True)
+        )
+        source = rtc.AudioSource(RATE, CHANNELS)
+        await room.local_participant.publish_track(
+            rtc.LocalAudioTrack.create_audio_track("chirp", source),
+            rtc.TrackPublishOptions(source=rtc.TrackSource.SOURCE_MICROPHONE),
+        )
+
+        async def inbound() -> None:
+            """chirp pcm → LiveKit mic track; Bluejay speech.* → customer.speech spans."""
+            nonlocal customer_otel
+            caller_bytes = 0
+            try:
+                while True:
+                    msg = await ws.receive()
+                    if msg["type"] == "websocket.disconnect":
+                        break
+                    pcm = msg.get("bytes")
+                    if pcm:
+                        caller_bytes += len(pcm)
+                        await source.capture_frame(
+                            rtc.AudioFrame(pcm, RATE, CHANNELS, len(pcm) // 2)
+                        )
+                        continue
+                    text = msg.get("text")
+                    if not text:
+                        continue
+                    try:
+                        event = json.loads(text)
+                    except json.JSONDecodeError:
+                        continue
+                    etype = event.get("type")
+                    if etype == "speech.started":
+                        end_speech_span(customer_otel)
+                        uid = (event.get("data") or {}).get("utterance_id") or f"c_{uuid.uuid4().hex[:12]}"
+                        customer_otel = start_speech_span(uid, speaker="customer")
+                    elif etype == "speech.completed":
+                        end_speech_span(customer_otel)
+                        customer_otel = None
+            finally:
+                end_speech_span(customer_otel)
+                customer_otel = None
+                print(f"chirp caller_bytes={caller_bytes}", flush=True)
+                end.set()
+
+        async def sender() -> None:
+            """single queue keeps speech.* text frames ordered against agent pcm."""
+            while True:
+                item = await outq.get()
+                if isinstance(item, bytes):
+                    await ws.send_bytes(item)
+                else:
+                    await ws.send_text(item)
+
+        tasks = [
+            asyncio.create_task(inbound()),
+            asyncio.create_task(sender()),
+            asyncio.create_task(end.wait()),
+        ]
+        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+        for t in pending:
+            t.cancel()
+        await asyncio.gather(*pending, return_exceptions=True)
+        _agent_stop(force=True)
+        end_speech_span(customer_otel)
+        await room.disconnect()
+        print(f"chirp agent_bytes={agent_bytes}", flush=True)
+        # the edge transition and end_call ran inside Retell — read them off the
+        # call record so they land on the waterfall next to the webhook tool.
+        backfilled = await report_platform_tools(call["call_id"], CFG["bp"])
+        print(f"chirp platform tools {backfilled}", flush=True)
+        for t in done:
+            if not t.cancelled() and t.exception() is not None:
+                raise t.exception()  # type: ignore[misc]
+
+
+def main(model: str | None = None) -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--model", default=model or os.environ.get("RETELL_RUNTIME", "retell"))
+    p.add_argument("--industry", default=os.environ.get("INDUSTRY", "control-industry"))
+    p.add_argument("--host", default=os.environ.get("CHIRP_HOST", "0.0.0.0"))
+    p.add_argument("--port", type=int, default=int(os.environ.get("CHIRP_PORT", "8771")))
+    a = p.parse_args()
+
+    public_url = os.environ.get("PUBLIC_URL", "").strip()
+    if not public_url:
+        raise SystemExit("need PUBLIC_URL (cloudflared https url) — Retell calls tools over HTTPS")
+
+    industry_dir = industry_path(a.industry)
+    ids = ensure_agent(industry_dir, public_url)
+    CFG.update(
+        agent_id=ids["agent_id"],
+        bp=load_blueprint(industry_dir),
+        model=a.model,
+        workflow=f"mivas-{Path(industry_dir).name}-{a.model}",
+    )
+    print(
+        f"ws↔Retell {a.model} × {a.industry} :{a.port} auth={bool(_auth())} "
+        f"agent={ids['agent_id']} llm={ids['llm_id']} tools→{public_url}/tool/*",
+        flush=True,
+    )
+    uvicorn.run(app, host=a.host, port=a.port, log_level="warning")
+
+
+if __name__ == "__main__":
+    main()

--- a/voice-agent-harnesses/retell/flux-gpt4.1-flash2.5/adapters/chirp.py
+++ b/voice-agent-harnesses/retell/flux-gpt4.1-flash2.5/adapters/chirp.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from adapters.chirp import main  # noqa: E402
+
+if __name__ == "__main__":
+    main(model="retell-gpt4.1-flash2.5")

--- a/voice-agent-harnesses/retell/flux-gpt4.1-flash2.5/agent.py
+++ b/voice-agent-harnesses/retell/flux-gpt4.1-flash2.5/agent.py
@@ -1,0 +1,30 @@
+"""Retell harness — gpt-4.1 + ElevenLabs Flash v2.5, native states/edges multi-agent.
+
+There is no local text loop: Retell drives the whole call platform-side and the
+only way in is the LiveKit web call, so `--check` pushes the blueprint to Retell
+(states, edges, tool URLs) and prints the ids. Real runs go through
+`adapters/chirp.py`.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from harness import TOOL_SERVER_URL, ensure_agent, industry_path, load_blueprint  # noqa: E402
+
+MODEL = "retell-gpt4.1-flash2.5"
+
+
+if __name__ == "__main__":
+    industry = next((a for a in sys.argv[1:] if not a.startswith("-")), "control-industry")
+    industry_dir = Path(os.environ.get("INDUSTRY_DIR", str(industry_path(industry))))
+    public_url = os.environ.get("PUBLIC_URL", "https://example.invalid")
+    bp = load_blueprint(industry_dir)
+    ids = ensure_agent(industry_dir, public_url)
+    print(
+        f"ok {industry_dir.name} × {MODEL} agent={ids['agent_id']} llm={ids['llm_id']} "
+        f"states={list(bp['agents'])} tools→{public_url}/tool/* tool_server={TOOL_SERVER_URL}"
+    )

--- a/voice-agent-harnesses/retell/flux-gpt4.1-flash2.5/agent.py
+++ b/voice-agent-harnesses/retell/flux-gpt4.1-flash2.5/agent.py
@@ -21,7 +21,9 @@ MODEL = "retell-gpt4.1-flash2.5"
 if __name__ == "__main__":
     industry = next((a for a in sys.argv[1:] if not a.startswith("-")), "control-industry")
     industry_dir = Path(os.environ.get("INDUSTRY_DIR", str(industry_path(industry))))
-    public_url = os.environ.get("PUBLIC_URL", "https://example.invalid")
+    public_url = os.environ.get("PUBLIC_URL", "").strip()
+    if not public_url:
+        raise SystemExit("need PUBLIC_URL (cloudflared https url) — Retell calls tools over HTTPS")
     bp = load_blueprint(industry_dir)
     ids = ensure_agent(industry_dir, public_url)
     print(

--- a/voice-agent-harnesses/retell/harness.py
+++ b/voice-agent-harnesses/retell/harness.py
@@ -1,0 +1,357 @@
+"""Blueprint → Retell LLM state machine + agent.
+
+Multi-agent is native: the blueprint's receptionist/scheduler pair becomes a
+single retell-llm with two `states`, and the handoff becomes an `edge` between
+them (Retell exposes the transition to the model as `transition_to_scheduler`,
+server-side — the harness never routes it). `end_call` is the built-in
+`{type: "end_call"}` tool, also server-side.
+
+Only `schedule_appointment` reaches us, and it does so as an HTTPS callback:
+Retell tools are *platform* tools, so the tool `url` points back at the chirp
+process (`{PUBLIC_URL}/tool/schedule_appointment`). The tunnel URL is ephemeral,
+so `ensure_agent` re-PATCHes the tool URLs on every boot; the cached llm/agent
+ids in `.agents.json` survive.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HARNESS_DIR = Path(__file__).resolve().parent
+TOOL_SERVER_URL = os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
+
+API_BASE = "https://api.retellai.com"
+AGENT_CACHE_PATH = HARNESS_DIR / ".agents.json"
+DEFAULT_VOICE_ID = "11labs-Kate"
+DEFAULT_GREETING = "Welcome to Bluejay's Repair Services! How can I help you today?"
+# Retell's own room; the JS SDK hardcodes it. Overridable in case they re-shard.
+DEFAULT_LIVEKIT_URL = "wss://retell-ai-4ihahnq7.livekit.cloud"
+
+
+def industry_path(name: str | Path) -> Path:
+    path = Path(name)
+    if path.is_dir():
+        return path.resolve()
+    env_dir = os.environ.get("INDUSTRY_DIR", "").strip()
+    if env_dir and Path(env_dir).is_dir():
+        return Path(env_dir).resolve()
+    return (REPO_ROOT / "industries" / name).resolve()
+
+
+def load_blueprint(industry_dir: str | Path) -> dict[str, Any]:
+    industry_dir = industry_path(industry_dir)
+    blueprint = json.loads((industry_dir / "agent_blueprint.json").read_text())
+    catalog = {t["name"]: t for t in json.loads((industry_dir / "tools.json").read_text())["tools"]}
+    agents = {}
+    for entry in blueprint["agents"]:
+        agents[entry["name"]] = {
+            "name": entry["name"],
+            "instructions": (industry_dir / entry["system_prompt"]).read_text(),
+            "tools": entry["tools"],
+        }
+    return {
+        "industry_dir": industry_dir,
+        "start": blueprint["agents"][0]["name"],
+        "agents": agents,
+        "catalog": catalog,
+    }
+
+
+def _api_key() -> str:
+    key = os.environ.get("RETELL_API_KEY")
+    if not key:
+        raise SystemExit("need RETELL_API_KEY")
+    return key
+
+
+def livekit_url() -> str:
+    return os.environ.get("RETELL_LIVEKIT_URL", DEFAULT_LIVEKIT_URL)
+
+
+def _call(method: str, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
+    r = httpx.request(
+        method,
+        f"{API_BASE}{path}",
+        headers={"Authorization": f"Bearer {_api_key()}", "Content-Type": "application/json"},
+        json=body,
+        timeout=30.0,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def _custom_tool(spec: dict[str, Any], public_url: str) -> dict[str, Any]:
+    """tools.json entry → Retell `{type: "custom"}` webhook tool."""
+    raw = dict(spec.get("inputSchema") or {"type": "object"})
+    props = {}
+    for key, prop in (raw.get("properties") or {}).items():
+        p = {k: v for k, v in dict(prop).items() if k in {"type", "description", "enum"}}
+        p.setdefault("type", "string")
+        props[key] = p
+    parameters: dict[str, Any] = {"type": "object", "properties": props}
+    if raw.get("required"):
+        parameters["required"] = list(raw["required"])
+    return {
+        "type": "custom",
+        "name": spec["name"],
+        "description": spec.get("description", spec["name"]),
+        "url": f"{public_url.rstrip('/')}/tool/{spec['name']}",
+        "speak_during_execution": False,
+        "speak_after_execution": True,
+        "parameters": parameters,
+    }
+
+
+def _state_tools(agent_entry: dict[str, Any], bp: dict[str, Any], public_url: str) -> list[dict]:
+    """Handoffs become edges (see `_states`), `end_call` becomes Retell's built-in."""
+    tools: list[dict[str, Any]] = []
+    for t in agent_entry["tools"]:
+        name = t["name"]
+        if t.get("handoff"):
+            continue
+        if t.get("session") or name == "end_call":
+            spec = bp["catalog"].get(name) or {}
+            tools.append(
+                {
+                    "type": "end_call",
+                    "name": "end_call",
+                    "description": spec.get("description", "End the call."),
+                }
+            )
+            continue
+        spec = bp["catalog"].get(name)
+        if spec:
+            tools.append(_custom_tool(spec, public_url))
+    return tools
+
+
+def _adapt_prompt(prompt: str, handoff_tool_name: str | None, target_state: str) -> str:
+    """Retell surfaces an edge as `transition_to_<state>`, not the blueprint tool name."""
+    if not handoff_tool_name:
+        return prompt
+    transition = f"transition_to_{target_state}"
+    return prompt.replace(f"`{handoff_tool_name}`", f"`{transition}`").replace(
+        handoff_tool_name, transition
+    )
+
+
+def _states(bp: dict[str, Any], public_url: str) -> list[dict[str, Any]]:
+    states = []
+    for name, entry in bp["agents"].items():
+        handoff = next((t for t in entry["tools"] if t.get("handoff")), None)
+        state: dict[str, Any] = {
+            "name": name,
+            "state_prompt": _adapt_prompt(
+                entry["instructions"],
+                handoff["name"] if handoff else None,
+                handoff["handoff_to"] if handoff else "",
+            ),
+            "tools": _state_tools(entry, bp, public_url),
+        }
+        if handoff:
+            spec = bp["catalog"].get(handoff["name"]) or {}
+            state["edges"] = [
+                {
+                    "destination_state_name": handoff["handoff_to"],
+                    "description": spec.get("description")
+                    or f"Transition when the caller should be handled by {handoff['handoff_to']}.",
+                }
+            ]
+        states.append(state)
+    return states
+
+
+def _llm_payload(bp: dict[str, Any], public_url: str) -> dict[str, Any]:
+    return {
+        "model": os.environ.get("RETELL_LLM_MODEL", "gpt-4.1"),
+        "general_prompt": "You are a voice agent for Bluejay's Repair Services. "
+        "Follow the instructions of your current state exactly.",
+        "begin_message": os.environ.get("RETELL_GREETING", DEFAULT_GREETING),
+        # "agent" matches an inbound receptionist answering the phone, and is what
+        # the industry prompt's scripted greeting assumes. "user" makes Retell wait
+        # for the caller — and drops begin_message, so the greeting then depends on
+        # the model obeying the prompt. See README before flipping this.
+        "start_speaker": os.environ.get("RETELL_START_SPEAKER", "agent"),
+        "starting_state": bp["start"],
+        "states": _states(bp, public_url),
+    }
+
+
+def _agent_payload(llm_id: str, industry_name: str) -> dict[str, Any]:
+    return {
+        "agent_name": f"mivas-{industry_name}-retell",
+        "response_engine": {"type": "retell-llm", "llm_id": llm_id},
+        "voice_id": os.environ.get("RETELL_VOICE_ID", DEFAULT_VOICE_ID),
+        "voice_model": "eleven_flash_v2_5",
+        "language": "en-US",
+        # Retell exposes no STT model field and no Flux — provider + endpointing only.
+        "stt_mode": "custom",
+        "custom_stt_config": {
+            "provider": os.environ.get("RETELL_STT_PROVIDER", "deepgram"),
+            "endpointing_ms": int(os.environ.get("RETELL_ENDPOINTING_MS", "100")),
+        },
+    }
+
+
+def _load_cache() -> dict[str, Any]:
+    if not AGENT_CACHE_PATH.exists():
+        return {}
+    try:
+        return json.loads(AGENT_CACHE_PATH.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def ensure_agent(industry_dir: str | Path, public_url: str) -> dict[str, str]:
+    """Create (or reuse) the retell-llm + agent for an industry, with fresh tool URLs.
+
+    Cached ids come from RETELL_AGENT_ID/RETELL_LLM_ID or `.agents.json`; either way
+    the llm is PATCHed every boot so `{PUBLIC_URL}/tool/...` matches this run's tunnel.
+    """
+    bp = load_blueprint(industry_dir)
+    industry_name = Path(bp["industry_dir"]).name
+    payload = _llm_payload(bp, public_url)
+
+    cache = _load_cache()
+    cached = cache.get(industry_name) or {}
+    llm_id = os.environ.get("RETELL_LLM_ID", "").strip() or cached.get("llm_id")
+    agent_id = os.environ.get("RETELL_AGENT_ID", "").strip() or cached.get("agent_id")
+
+    if llm_id and agent_id:
+        _call("PATCH", f"/update-retell-llm/{llm_id}", payload)
+        return {"llm_id": llm_id, "agent_id": agent_id}
+
+    llm_id = _call("POST", "/create-retell-llm", payload)["llm_id"]
+    agent_id = _call("POST", "/create-agent", _agent_payload(llm_id, industry_name))["agent_id"]
+    cache[industry_name] = {"llm_id": llm_id, "agent_id": agent_id}
+    AGENT_CACHE_PATH.write_text(json.dumps(cache, indent=2) + "\n")
+    return cache[industry_name]
+
+
+def create_web_call(agent_id: str) -> dict[str, Any]:
+    """→ {access_token, call_id}. The token is a LiveKit JWT for room web_call_<id>."""
+    return _call("POST", "/v2/create-web-call", {"agent_id": agent_id})
+
+
+def handoff_tool_names(bp: dict[str, Any]) -> dict[str, str]:
+    """Retell's edge tool `transition_to_<state>` → the blueprint's handoff tool name."""
+    return {
+        f"transition_to_{t['handoff_to']}": t["name"]
+        for entry in bp["agents"].values()
+        for t in entry["tools"]
+        if t.get("handoff")
+    }
+
+
+def platform_tool_calls(record: dict[str, Any], renames: dict[str, str]) -> list[dict[str, Any]]:
+    """Call record → the tool calls Retell ran itself, as absolute-time span args.
+
+    `type: "custom"` invocations are our webhook tools and already have a live span;
+    everything else (edge transitions, end_call) ran platform-side and is invisible
+    until we backfill it. `time_sec` is relative to the record's `start_timestamp`
+    (epoch ms), so both become epoch nanoseconds.
+    """
+    entries = record.get("transcript_with_tool_calls") or []
+    base_ns = int(record.get("start_timestamp") or 0) * 1_000_000
+    if not base_ns:
+        return []
+    results = {
+        e.get("tool_call_id"): e for e in entries if e.get("role") == "tool_call_result"
+    }
+    calls = []
+    for e in entries:
+        if e.get("role") != "tool_call_invocation" or e.get("type") == "custom":
+            continue
+        provider_name = e.get("name") or "unknown"
+        start_ns = base_ns + int(float(e.get("time_sec") or 0) * 1e9)
+        done = results.get(e.get("tool_call_id"))
+        try:
+            args = json.loads(e.get("arguments") or "{}")
+        except json.JSONDecodeError:
+            args = {"raw": e.get("arguments")}
+        calls.append(
+            {
+                "name": renames.get(provider_name, provider_name),
+                "provider_name": provider_name,
+                "arguments": args,
+                "call_id": e.get("tool_call_id"),
+                "start_ns": start_ns,
+                # no result row for transitions/end_call — give them a visible sliver
+                "end_ns": base_ns + int(float(done["time_sec"]) * 1e9)
+                if done
+                else start_ns + 10_000_000,
+            }
+        )
+    return calls
+
+
+async def get_call(call_id: str, *, timeout: float = 20.0) -> dict[str, Any]:
+    """Poll the call record — Retell finalizes tool calls a moment after hangup."""
+    deadline = time.monotonic() + timeout
+    record: dict[str, Any] = {}
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        while time.monotonic() < deadline:
+            r = await client.get(
+                f"{API_BASE}/v2/get-call/{call_id}",
+                headers={"Authorization": f"Bearer {_api_key()}"},
+            )
+            if r.status_code == 200:
+                record = r.json()
+                if record.get("call_status") == "ended" and record.get(
+                    "transcript_with_tool_calls"
+                ):
+                    return record
+            await asyncio.sleep(1.0)
+    return record
+
+
+async def report_platform_tools(call_id: str, bp: dict[str, Any]) -> list[str]:
+    """Backfill execute_tool spans for the tools Retell ran without telling us."""
+    from report import record_past_tool_span
+
+    calls = platform_tool_calls(await get_call(call_id), handoff_tool_names(bp))
+    for c in calls:
+        record_past_tool_span(
+            c["name"],
+            c["arguments"],
+            {"success": True, "source": "retell_call_record"},
+            start_ns=c["start_ns"],
+            end_ns=c["end_ns"],
+            call_id=c["call_id"],
+            attributes={"mivas.provider.tool_name": c["provider_name"]},
+        )
+    return [c["name"] for c in calls]
+
+
+async def _execute_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
+    if name == "schedule_appointment":
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(f"{TOOL_SERVER_URL}/appointments", json={"date": args["date"]})
+            resp.raise_for_status()
+            return {"success": True, "date": resp.json()["date"]}
+    return {"success": False, "error": f"unknown tool {name}"}
+
+
+async def run_tool(name: str, args: dict[str, Any], *, call_id: str | None = None) -> dict[str, Any]:
+    """Execute a webhook tool under a GenAI execute_tool span. Never raises — a tool
+    failure becomes `{success: false, error: ...}` so the call (and OTel tree) finishes."""
+    from report import call_offset_ms, finish_tool_span, tool_span
+
+    offset = call_offset_ms()
+    with tool_span(name, args, call_id=call_id) as span:
+        try:
+            result = await _execute_tool(name, args)
+            finish_tool_span(span, result, ok=True, name=name, parameters=args, start_offset_ms=offset)
+            return result
+        except Exception as e:
+            err = {"success": False, "error": f"{type(e).__name__}: {e}"}
+            finish_tool_span(span, err, ok=False, name=name, parameters=args, start_offset_ms=offset)
+            return err

--- a/voice-agent-harnesses/retell/harness.py
+++ b/voice-agent-harnesses/retell/harness.py
@@ -344,14 +344,12 @@ async def run_tool(name: str, args: dict[str, Any], *, call_id: str | None = Non
     """Execute a webhook tool under a GenAI execute_tool span. Never raises — a tool
     failure becomes `{success: false, error: ...}` so the call (and OTel tree) finishes."""
     from report import call_offset_ms, finish_tool_span, tool_span
-
-    offset = call_offset_ms()
     with tool_span(name, args, call_id=call_id) as span:
         try:
             result = await _execute_tool(name, args)
-            finish_tool_span(span, result, ok=True, name=name, parameters=args, start_offset_ms=offset)
+            finish_tool_span(span, result, ok=True)
             return result
         except Exception as e:
             err = {"success": False, "error": f"{type(e).__name__}: {e}"}
-            finish_tool_span(span, err, ok=False, name=name, parameters=args, start_offset_ms=offset)
+            finish_tool_span(span, err, ok=False)
             return err

--- a/voice-agent-harnesses/retell/harness.py
+++ b/voice-agent-harnesses/retell/harness.py
@@ -227,6 +227,7 @@ def ensure_agent(industry_dir: str | Path, public_url: str) -> dict[str, str]:
 
     if llm_id and agent_id:
         _call("PATCH", f"/update-retell-llm/{llm_id}", payload)
+        _call("PATCH", f"/update-agent/{agent_id}", _agent_payload(llm_id, industry_name))
         return {"llm_id": llm_id, "agent_id": agent_id}
 
     llm_id = _call("POST", "/create-retell-llm", payload)["llm_id"]

--- a/voice-agent-harnesses/retell/report.py
+++ b/voice-agent-harnesses/retell/report.py
@@ -1,0 +1,599 @@
+"""OpenTelemetry → Bluejay OTLP for Retell harnesses.
+
+Retell has no Agents-SDK span tree, so we emit GenAI-native spans:
+
+  voice.call (root) — gen_ai.provider.name=retell
+    ├── agent.speech          (bracketed by Retell agent_start_talking/agent_stop_talking)
+    ├── customer.speech       (from inbound Bluejay speech.started/completed)
+    └── execute_tool <name>   (gen_ai.tool.*; emitted by the /tool webhook)
+
+After the call we POST to update-simulation-result with:
+  - trace_ids  → waterfall flamegraph
+  Conversation tool markers come from execute_tool OTel spans (not a tool_calls POST).
+
+Chirp supplies simulation_result_id via X-Simulation-Result-Id on upgrade.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+from contextlib import asynccontextmanager, contextmanager
+from contextvars import ContextVar
+from typing import Any, AsyncIterator, Iterator
+
+import httpx
+from opentelemetry import trace as otel_trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.trace import Span, SpanKind, Status, StatusCode
+
+logger = logging.getLogger("mivas.otel.retell")
+if not logger.handlers:
+    _h = logging.StreamHandler(sys.stdout)
+    _h.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+    logger.addHandler(_h)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+DEFAULT_OTLP_ENDPOINT = "https://otlp.getbluejay.ai/v1/traces"
+DEFAULT_API_URL = "https://api.getbluejay.ai/v1"
+FINAL_STATUSES = {
+    "COMPLETED",
+    "FAILED",
+    "SYSTEM_ERROR",
+    "NO_ANSWER",
+    "CANCELLED",
+    "NO_CONNECTION",
+}
+EARLY_UPSERT_STATUSES = {"EVALUATING", "EVALUATED", "CONVERSATION_ENDED"}
+PROVIDER = "retell"
+TRACER_NAME = "mivas.retell"
+
+_provider: TracerProvider | None = None
+_root_span: ContextVar[Span | None] = ContextVar("mivas_retell_otel_root", default=None)
+_call_t0: ContextVar[float | None] = ContextVar("mivas_retell_otel_t0", default=None)
+_reported_tools: ContextVar[list[dict[str, Any]] | None] = ContextVar(
+    "mivas_retell_reported_tools", default=None
+)
+# module fallbacks when asyncio tasks don't inherit ContextVars
+_active_root: Span | None = None
+_active_t0: float | None = None
+_active_tools: list[dict[str, Any]] | None = None
+
+
+def _api_url() -> str:
+    return os.environ.get("BLUEJAY_API_URL", DEFAULT_API_URL).rstrip("/")
+
+
+def _otlp_endpoint() -> str:
+    return os.environ.get("BLUEJAY_OTLP_ENDPOINT", DEFAULT_OTLP_ENDPOINT)
+
+
+def _service_name() -> str:
+    return os.environ.get("BLUEJAY_SERVICE_NAME", "mivas-retell")
+
+
+def _api_key() -> str | None:
+    return os.environ.get("BLUEJAY_API_KEY") or None
+
+
+def _json_attr(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, default=str)
+    except Exception:
+        return str(value)
+
+
+def call_offset_ms() -> int:
+    t0 = _call_t0.get()
+    if t0 is None:
+        t0 = _active_t0
+    if t0 is None:
+        return 0
+    return max(0, int((time.monotonic() - t0) * 1000))
+
+
+def setup_otel() -> TracerProvider | None:
+    """Install global OTel exporter to Bluejay OTLP. No-op without BLUEJAY_API_KEY."""
+    global _provider
+
+    api_key = _api_key()
+    if not api_key:
+        return None
+
+    if _provider is not None:
+        return _provider
+
+    endpoint = _otlp_endpoint()
+    resource = Resource.create({SERVICE_NAME: _service_name()})
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(
+        SimpleSpanProcessor(
+            OTLPSpanExporter(endpoint, headers={"X-API-KEY": api_key})
+        )
+    )
+    otel_trace.set_tracer_provider(provider)
+    _provider = provider
+    logger.info("otel → %s service=%s", endpoint, _service_name())
+    return provider
+
+
+def flush() -> None:
+    if _provider is not None:
+        try:
+            _provider.force_flush()
+        except Exception as e:
+            logger.error("otel flush failed: %s", e)
+
+
+def _parent_span() -> Span | None:
+    parent = _root_span.get()
+    if parent is not None and parent.get_span_context().is_valid:
+        return parent
+    if _active_root is not None and _active_root.get_span_context().is_valid:
+        return _active_root
+    cur = otel_trace.get_current_span()
+    if cur is not None and cur.get_span_context().is_valid:
+        return cur
+    return None
+
+
+def record_tool_call(
+    name: str,
+    parameters: Any,
+    output: Any,
+    *,
+    start_offset_ms: int | None = None,
+) -> None:
+    """Buffer a tool call for the end-of-call update-simulation-result POST."""
+    tools = _reported_tools.get()
+    if tools is None:
+        tools = _active_tools
+    if tools is None:
+        return
+    tools.append(
+        {
+            "name": str(name),
+            "parameters": parameters if isinstance(parameters, dict) else {"raw": parameters},
+            "output": output,
+            "start_offset_ms": int(
+                start_offset_ms if start_offset_ms is not None else call_offset_ms()
+            ),
+        }
+    )
+
+
+@contextmanager
+def tool_span(
+    name: str,
+    parameters: Any = None,
+    *,
+    call_id: str | None = None,
+) -> Iterator[Span | None]:
+    """Child span under the active voice.call root. No-op outside traced_run."""
+    parent = _parent_span()
+    if parent is None:
+        yield None
+        return
+
+    tracer = otel_trace.get_tracer(TRACER_NAME)
+    parent_ctx = otel_trace.set_span_in_context(parent)
+    attrs: dict[str, Any] = {
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.provider.name": PROVIDER,
+        "gen_ai.tool.name": name,
+        "gen_ai.tool.call.arguments": _json_attr(parameters if parameters is not None else {}),
+        # conversation timestamps come from span start vs voice.call (OTel extraction)
+    }
+    if call_id:
+        attrs["gen_ai.tool.call.id"] = str(call_id)
+
+    with tracer.start_as_current_span(
+        f"execute_tool {name}",
+        context=parent_ctx,
+        kind=SpanKind.CLIENT,
+        attributes=attrs,
+    ) as span:
+        try:
+            yield span
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)[:400]))
+            raise
+
+
+def finish_tool_span(
+    span: Span | None,
+    output: Any,
+    *,
+    ok: bool = True,
+    name: str | None = None,
+    parameters: Any = None,
+    start_offset_ms: int | None = None,
+) -> None:
+    if span is not None:
+        span.set_attribute("gen_ai.tool.call.result", _json_attr(output))
+        if ok:
+            span.set_status(Status(StatusCode.OK))
+        else:
+            span.set_status(Status(StatusCode.ERROR, _json_attr(output)[:400]))
+
+
+def record_past_tool_span(
+    name: str,
+    parameters: Any,
+    output: Any,
+    *,
+    start_ns: int,
+    end_ns: int,
+    call_id: str | None = None,
+    attributes: dict[str, Any] | None = None,
+) -> None:
+    """execute_tool span for a tool that already ran, with explicit wall-clock times.
+
+    Retell's platform tools (state transitions, end_call) execute inside Retell and
+    never reach our webhook, so they are backfilled from the call record after
+    hangup. OTel timestamps are epoch nanoseconds, and Retell's `start_timestamp`
+    is epoch too, so the backfilled spans land in the same time base as the spans
+    chirp emitted live.
+    """
+    parent = _parent_span()
+    if parent is None:
+        return
+    tracer = otel_trace.get_tracer(TRACER_NAME)
+    attrs: dict[str, Any] = {
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.provider.name": PROVIDER,
+        "gen_ai.tool.name": name,
+        "gen_ai.tool.call.arguments": _json_attr(parameters if parameters is not None else {}),
+        "gen_ai.tool.call.result": _json_attr(output),
+        **(attributes or {}),
+    }
+    if call_id:
+        attrs["gen_ai.tool.call.id"] = str(call_id)
+    span = tracer.start_span(
+        f"execute_tool {name}",
+        context=otel_trace.set_span_in_context(parent),
+        kind=SpanKind.CLIENT,
+        attributes=attrs,
+        start_time=start_ns,
+    )
+    span.set_status(Status(StatusCode.OK))
+    span.end(end_time=end_ns)
+
+
+def start_speech_span(
+    utterance_id: str, *, speaker: str = "agent"
+) -> Span | None:
+    """Begin agent.speech or customer.speech under voice.call."""
+    parent = _parent_span()
+    if parent is None:
+        return None
+    tracer = otel_trace.get_tracer(TRACER_NAME)
+    parent_ctx = otel_trace.set_span_in_context(parent)
+    is_customer = speaker in ("customer", "user", "digital_human")
+    span_name = "customer.speech" if is_customer else "agent.speech"
+    attrs: dict[str, Any] = {
+        "gen_ai.operation.name": (
+            "speech_to_text" if is_customer else "text_to_speech"
+        ),
+        "gen_ai.provider.name": PROVIDER,
+        "mivas.utterance_id": str(utterance_id),
+        "mivas.speech.speaker": "customer" if is_customer else "agent",
+        "bluejay.speech.start_offset_ms": call_offset_ms(),
+    }
+    span = tracer.start_span(
+        span_name,
+        context=parent_ctx,
+        kind=SpanKind.INTERNAL,
+        attributes=attrs,
+    )
+    return span
+
+def end_speech_span(span: Span | None) -> None:
+    if span is None:
+        return
+    span.set_attribute("bluejay.speech.end_offset_ms", call_offset_ms())
+    span.set_status(Status(StatusCode.OK))
+    span.end()
+
+
+async def _await_terminal_upsert(
+    client: httpx.AsyncClient, simulation_result_id: str, timeout: float = 300.0
+) -> str | None:
+    """Wait for a *final* status before the upsert.
+
+    300 s, not 150 s: eval needs ~175 s to settle and anything shorter forces the
+    early-post + relink path below, which double-counts every tool.
+
+    Posting during EVALUATING works, but eval then wipes trace_ids and the relink
+    POST re-extracts the execute_tool spans on top of the ones the first POST
+    already produced — every tool lands on the timeline twice. One POST after the
+    sim settles gives a surviving link and one row per tool; `_relink_after_final`
+    stays as the safety net for when this wait times out.
+    """
+    deadline = time.monotonic() + timeout
+    key = _api_key()
+    if not key:
+        return None
+    while time.monotonic() < deadline:
+        try:
+            r = await client.get(
+                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                headers={"X-API-Key": key},
+            )
+            if r.status_code == 200:
+                st = str(
+                    ((r.json() or {}).get("simulation_result") or {}).get("status")
+                )
+                if st in FINAL_STATUSES:
+                    return st
+        except Exception:
+            pass
+        await asyncio.sleep(1.0)
+    return None
+
+
+async def post_simulation_enrichment(
+    simulation_result_id: str,
+    *,
+    trace_id: str | None,
+    tool_calls: list[dict[str, Any]] | None = None,
+) -> None:
+    """Link OTel trace_ids. tool_calls ignored — use execute_tool spans."""
+    del tool_calls
+    key = _api_key()
+    if not key or not simulation_result_id:
+        logger.warning(
+            "skip update-simulation-result — "
+            "simulation_result_id=%s key=%s",
+            simulation_result_id,
+            bool(key),
+        )
+        return
+    if not str(simulation_result_id).isdigit():
+        logger.warning(
+            "skip update-simulation-result — non-numeric sim id=%s",
+            simulation_result_id,
+        )
+        return
+
+    body: dict[str, Any] = {"simulation_result_id": str(simulation_result_id)}
+    if trace_id:
+        body["trace_ids"] = [trace_id]
+    if "trace_ids" not in body and "tool_calls" not in body:
+        logger.warning("skip update-simulation-result — nothing to post")
+        return
+
+    await asyncio.sleep(0.5)
+
+    last_err: str | None = None
+    for attempt in range(1, 4):
+        try:
+            async with httpx.AsyncClient(timeout=20) as client:
+                st = await _await_terminal_upsert(client, simulation_result_id)
+                if st is None:
+                    check = await client.get(
+                        f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                        headers={"X-API-Key": key},
+                    )
+                    if check.status_code == 404:
+                        logger.warning(
+                            "skip update-simulation-result — sim=%s not found",
+                            simulation_result_id,
+                        )
+                        return
+                r = await client.post(
+                    f"{_api_url()}/update-simulation-result",
+                    json=body,
+                    headers={"X-API-Key": key, "Content-Type": "application/json"},
+                )
+                if r.status_code >= 400:
+                    last_err = f"{r.status_code} {r.text[:300]} (status={st})"
+                    logger.error(
+                        "update-simulation-result FAILED attempt=%s %s",
+                        attempt,
+                        last_err,
+                    )
+                    if r.status_code == 404:
+                        return
+                else:
+                    logger.info(
+                        "update-simulation-result ok trace=%s sim=%s terminal=%s attempt=%s",
+                        trace_id,
+                        simulation_result_id,
+                        st,
+                        attempt,
+                    )
+                    if (st is None or st in EARLY_UPSERT_STATUSES) and trace_id:
+                        await _relink_after_final(
+                            client, simulation_result_id, body, key, trace_id, st
+                        )
+                    return
+        except Exception as e:
+            last_err = f"{type(e).__name__}: {e}"
+            logger.error(
+                "update-simulation-result error attempt=%s %s", attempt, last_err
+            )
+        await asyncio.sleep(1.0 * attempt)
+    logger.error("update-simulation-result gave up: %s", last_err)
+
+
+
+async def _relink_after_final(
+    client: httpx.AsyncClient,
+    simulation_result_id: str,
+    body: dict[str, Any],
+    key: str,
+    trace_id: str,
+    early_status: str | None,
+) -> None:
+    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link).
+
+    Only if it actually got wiped: each POST re-extracts the execute_tool spans and
+    appends them, so a redundant relink double-counts every tool on the timeline.
+    """
+    final: str | None = None
+    linked = False
+    deadline = time.monotonic() + 120.0
+    while time.monotonic() < deadline:
+        try:
+            r = await client.get(
+                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                headers={"X-API-Key": key},
+            )
+            if r.status_code == 200:
+                result = (r.json() or {}).get("simulation_result") or {}
+                st = str(result.get("status"))
+                if st in FINAL_STATUSES:
+                    final = st
+                    linked = trace_id in (result.get("trace_ids") or [])
+                    break
+        except Exception:
+            pass
+        await asyncio.sleep(2.0)
+    if final is not None and linked:
+        logger.info(
+            "relink not needed after %s — trace=%s still linked sim=%s final=%s",
+            early_status,
+            trace_id,
+            simulation_result_id,
+            final,
+        )
+        return
+    if final is None:
+        logger.warning(
+            "relink skipped — still not final after early upsert terminal=%s sim=%s",
+            early_status,
+            simulation_result_id,
+        )
+        return
+    r = await client.post(
+        f"{_api_url()}/update-simulation-result",
+        json=body,
+        headers={"X-API-Key": key, "Content-Type": "application/json"},
+    )
+    if r.status_code >= 400:
+        logger.error(
+            "relink after %s FAILED sim=%s %s %s",
+            early_status,
+            simulation_result_id,
+            r.status_code,
+            r.text[:300],
+        )
+    else:
+        logger.info(
+            "relink after %s ok trace=%s sim=%s final=%s",
+            early_status,
+            trace_id,
+            simulation_result_id,
+            final,
+        )
+
+# back-compat alias used by older call sites
+async def post_trace_ids(simulation_result_id: str, trace_id: str) -> None:
+    await post_simulation_enrichment(
+        simulation_result_id, trace_id=trace_id, tool_calls=_reported_tools.get()
+    )
+
+
+@asynccontextmanager
+async def traced_run(
+    workflow_name: str,
+    *,
+    simulation_result_id: str | None = None,
+    model: str | None = None,
+) -> AsyncIterator[None]:
+    """OTel voice.call root; flush + link trace_ids/tool_calls on exit."""
+    global _active_root, _active_t0, _active_tools
+
+    provider = setup_otel()
+    if provider is None:
+        yield
+        return
+
+    tracer = otel_trace.get_tracer(TRACER_NAME)
+    attrs: dict[str, Any] = {
+        "gen_ai.system": PROVIDER,
+        "gen_ai.provider.name": PROVIDER,
+        "gen_ai.operation.name": "invoke_agent",
+        "mivas.workflow.name": workflow_name,
+    }
+    if model:
+        attrs["gen_ai.request.model"] = model
+    if simulation_result_id:
+        attrs["bluejay.simulation_result_id"] = str(simulation_result_id)
+
+    otel_tid: str | None = None
+    root_token = None
+    tools_token = None
+    t0 = time.monotonic()
+    t0_token = _call_t0.set(t0)
+    tool_buf: list[dict[str, Any]] = []
+    prev_active = _active_root
+    prev_t0 = _active_t0
+    prev_tools = _active_tools
+    try:
+        with tracer.start_as_current_span(
+            "voice.call",
+            kind=SpanKind.SERVER,
+            attributes=attrs,
+        ) as root:
+            root_token = _root_span.set(root)
+            tools_token = _reported_tools.set(tool_buf)
+            _active_root = root
+            _active_t0 = t0
+            _active_tools = tool_buf
+            ctx = root.get_span_context()
+            if ctx.is_valid:
+                otel_tid = format(ctx.trace_id, "032x")
+                logger.info(
+                    "otel trace_id=%s sim=%s workflow=%s model=%s",
+                    otel_tid,
+                    simulation_result_id,
+                    workflow_name,
+                    model,
+                )
+            try:
+                yield
+            except Exception as e:
+                if type(e).__name__.startswith("ConnectionClosed"):
+                    root.set_status(Status(StatusCode.OK))
+                else:
+                    raise
+    finally:
+        _active_root = prev_active
+        _active_t0 = prev_t0
+        _active_tools = prev_tools
+        if root_token is not None:
+            _root_span.reset(root_token)
+        if tools_token is not None:
+            _reported_tools.reset(tools_token)
+        _call_t0.reset(t0_token)
+        flush()
+        if simulation_result_id and (otel_tid or tool_buf):
+            try:
+                await post_simulation_enrichment(
+                    simulation_result_id,
+                    trace_id=otel_tid,
+                                    )
+            except Exception as e:
+                logger.error(
+                    "post_simulation_enrichment crashed: %s: %s",
+                    type(e).__name__,
+                    e,
+                )
+        elif simulation_result_id and not otel_tid:
+            logger.error(
+                "have simulation_result_id=%s but no otel trace id to post",
+                simulation_result_id,
+            )

--- a/voice-agent-harnesses/retell/report.py
+++ b/voice-agent-harnesses/retell/report.py
@@ -52,20 +52,15 @@ FINAL_STATUSES = {
     "CANCELLED",
     "NO_CONNECTION",
 }
-EARLY_UPSERT_STATUSES = {"EVALUATING", "EVALUATED", "CONVERSATION_ENDED"}
 PROVIDER = "retell"
 TRACER_NAME = "mivas.retell"
 
 _provider: TracerProvider | None = None
 _root_span: ContextVar[Span | None] = ContextVar("mivas_retell_otel_root", default=None)
 _call_t0: ContextVar[float | None] = ContextVar("mivas_retell_otel_t0", default=None)
-_reported_tools: ContextVar[list[dict[str, Any]] | None] = ContextVar(
-    "mivas_retell_reported_tools", default=None
-)
 # module fallbacks when asyncio tasks don't inherit ContextVars
 _active_root: Span | None = None
 _active_t0: float | None = None
-_active_tools: list[dict[str, Any]] | None = None
 
 
 def _api_url() -> str:
@@ -147,31 +142,6 @@ def _parent_span() -> Span | None:
     return None
 
 
-def record_tool_call(
-    name: str,
-    parameters: Any,
-    output: Any,
-    *,
-    start_offset_ms: int | None = None,
-) -> None:
-    """Buffer a tool call for the end-of-call update-simulation-result POST."""
-    tools = _reported_tools.get()
-    if tools is None:
-        tools = _active_tools
-    if tools is None:
-        return
-    tools.append(
-        {
-            "name": str(name),
-            "parameters": parameters if isinstance(parameters, dict) else {"raw": parameters},
-            "output": output,
-            "start_offset_ms": int(
-                start_offset_ms if start_offset_ms is not None else call_offset_ms()
-            ),
-        }
-    )
-
-
 @contextmanager
 def tool_span(
     name: str,
@@ -216,9 +186,6 @@ def finish_tool_span(
     output: Any,
     *,
     ok: bool = True,
-    name: str | None = None,
-    parameters: Any = None,
-    start_offset_ms: int | None = None,
 ) -> None:
     if span is not None:
         span.set_attribute("gen_ai.tool.call.result", _json_attr(output))
@@ -315,11 +282,11 @@ async def _await_terminal_upsert(
     300 s, not 150 s: eval needs ~175 s to settle and anything shorter forces the
     early-post + relink path below, which double-counts every tool.
 
-    Posting during EVALUATING works, but eval then wipes trace_ids and the relink
-    POST re-extracts the execute_tool spans on top of the ones the first POST
-    already produced — every tool lands on the timeline twice. One POST after the
-    sim settles gives a surviving link and one row per tool; `_relink_after_final`
-    stays as the safety net for when this wait times out.
+    Posting during EVALUATING works, but eval then wipes trace_ids, and re-posting
+    makes Bluejay re-extract the execute_tool spans on top of the ones the first
+    POST already produced — every tool lands on the timeline twice. One POST after
+    the sim settles gives a surviving link and one row per tool. On timeout we post
+    anyway and log it; we never re-post, because that is the double-count.
     """
     deadline = time.monotonic() + timeout
     key = _api_key()
@@ -347,10 +314,8 @@ async def post_simulation_enrichment(
     simulation_result_id: str,
     *,
     trace_id: str | None,
-    tool_calls: list[dict[str, Any]] | None = None,
 ) -> None:
-    """Link OTel trace_ids. tool_calls ignored — use execute_tool spans."""
-    del tool_calls
+    """Link OTel trace_ids; conversation tools come from execute_tool spans."""
     key = _api_key()
     if not key or not simulation_result_id:
         logger.warning(
@@ -370,7 +335,7 @@ async def post_simulation_enrichment(
     body: dict[str, Any] = {"simulation_result_id": str(simulation_result_id)}
     if trace_id:
         body["trace_ids"] = [trace_id]
-    if "trace_ids" not in body and "tool_calls" not in body:
+    if "trace_ids" not in body:
         logger.warning("skip update-simulation-result — nothing to post")
         return
 
@@ -414,9 +379,12 @@ async def post_simulation_enrichment(
                         st,
                         attempt,
                     )
-                    if (st is None or st in EARLY_UPSERT_STATUSES) and trace_id:
-                        await _relink_after_final(
-                            client, simulation_result_id, body, key, trace_id, st
+                    if st is None:
+                        logger.warning(
+                            "linked without a final status — sim=%s may still be "
+                            "EVALUATING; if eval wipes trace_ids the link is lost "
+                            "(we do not re-post: a second POST double-counts tools)",
+                            simulation_result_id,
                         )
                     return
         except Exception as e:
@@ -429,83 +397,6 @@ async def post_simulation_enrichment(
 
 
 
-async def _relink_after_final(
-    client: httpx.AsyncClient,
-    simulation_result_id: str,
-    body: dict[str, Any],
-    key: str,
-    trace_id: str,
-    early_status: str | None,
-) -> None:
-    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link).
-
-    Only if it actually got wiped: each POST re-extracts the execute_tool spans and
-    appends them, so a redundant relink double-counts every tool on the timeline.
-    """
-    final: str | None = None
-    linked = False
-    deadline = time.monotonic() + 120.0
-    while time.monotonic() < deadline:
-        try:
-            r = await client.get(
-                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
-                headers={"X-API-Key": key},
-            )
-            if r.status_code == 200:
-                result = (r.json() or {}).get("simulation_result") or {}
-                st = str(result.get("status"))
-                if st in FINAL_STATUSES:
-                    final = st
-                    linked = trace_id in (result.get("trace_ids") or [])
-                    break
-        except Exception:
-            pass
-        await asyncio.sleep(2.0)
-    if final is not None and linked:
-        logger.info(
-            "relink not needed after %s — trace=%s still linked sim=%s final=%s",
-            early_status,
-            trace_id,
-            simulation_result_id,
-            final,
-        )
-        return
-    if final is None:
-        logger.warning(
-            "relink skipped — still not final after early upsert terminal=%s sim=%s",
-            early_status,
-            simulation_result_id,
-        )
-        return
-    r = await client.post(
-        f"{_api_url()}/update-simulation-result",
-        json=body,
-        headers={"X-API-Key": key, "Content-Type": "application/json"},
-    )
-    if r.status_code >= 400:
-        logger.error(
-            "relink after %s FAILED sim=%s %s %s",
-            early_status,
-            simulation_result_id,
-            r.status_code,
-            r.text[:300],
-        )
-    else:
-        logger.info(
-            "relink after %s ok trace=%s sim=%s final=%s",
-            early_status,
-            trace_id,
-            simulation_result_id,
-            final,
-        )
-
-# back-compat alias used by older call sites
-async def post_trace_ids(simulation_result_id: str, trace_id: str) -> None:
-    await post_simulation_enrichment(
-        simulation_result_id, trace_id=trace_id, tool_calls=_reported_tools.get()
-    )
-
-
 @asynccontextmanager
 async def traced_run(
     workflow_name: str,
@@ -514,7 +405,7 @@ async def traced_run(
     model: str | None = None,
 ) -> AsyncIterator[None]:
     """OTel voice.call root; flush + link trace_ids/tool_calls on exit."""
-    global _active_root, _active_t0, _active_tools
+    global _active_root, _active_t0
 
     provider = setup_otel()
     if provider is None:
@@ -535,13 +426,10 @@ async def traced_run(
 
     otel_tid: str | None = None
     root_token = None
-    tools_token = None
     t0 = time.monotonic()
     t0_token = _call_t0.set(t0)
-    tool_buf: list[dict[str, Any]] = []
     prev_active = _active_root
     prev_t0 = _active_t0
-    prev_tools = _active_tools
     try:
         with tracer.start_as_current_span(
             "voice.call",
@@ -549,10 +437,8 @@ async def traced_run(
             attributes=attrs,
         ) as root:
             root_token = _root_span.set(root)
-            tools_token = _reported_tools.set(tool_buf)
             _active_root = root
             _active_t0 = t0
-            _active_tools = tool_buf
             ctx = root.get_span_context()
             if ctx.is_valid:
                 otel_tid = format(ctx.trace_id, "032x")
@@ -573,14 +459,11 @@ async def traced_run(
     finally:
         _active_root = prev_active
         _active_t0 = prev_t0
-        _active_tools = prev_tools
         if root_token is not None:
             _root_span.reset(root_token)
-        if tools_token is not None:
-            _reported_tools.reset(tools_token)
         _call_t0.reset(t0_token)
         flush()
-        if simulation_result_id and (otel_tid or tool_buf):
+        if simulation_result_id and otel_tid:
             try:
                 await post_simulation_enrichment(
                     simulation_result_id,

--- a/voice-agent-harnesses/retell/requirements.txt
+++ b/voice-agent-harnesses/retell/requirements.txt
@@ -1,0 +1,9 @@
+# Pack deps for Docker (`uv pip install -r`). Local root uses `uv sync` via pyproject.toml.
+httpx>=0.27.0
+fastapi>=0.115.0
+uvicorn>=0.32.0
+# Retell web calls are LiveKit rooms — this is the only new dep vs the other harnesses.
+livekit>=1.1.0
+opentelemetry-api>=1.27.0
+opentelemetry-sdk>=1.27.0
+opentelemetry-exporter-otlp-proto-http>=1.27.0

--- a/voice-agent-harnesses/retell/requirements.txt
+++ b/voice-agent-harnesses/retell/requirements.txt
@@ -2,6 +2,7 @@
 httpx>=0.27.0
 fastapi>=0.115.0
 uvicorn>=0.32.0
+websockets>=14.0
 # Retell web calls are LiveKit rooms — this is the only new dep vs the other harnesses.
 livekit>=1.1.0
 opentelemetry-api>=1.27.0

--- a/voice-agent-harnesses/retell/test_platform_tools.py
+++ b/voice-agent-harnesses/retell/test_platform_tools.py
@@ -1,0 +1,63 @@
+"""Check the call-record → span mapping against a real Retell payload.
+
+Excerpt from call_364d5c477f2439013ac9b093d80. Run: `python test_platform_tools.py`
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from harness import handoff_tool_names, platform_tool_calls  # noqa: E402
+
+RECORD = {
+    "start_timestamp": 1786384392155,
+    "transcript_with_tool_calls": [
+        {"role": "agent", "content": "Welcome to Bluejay's Repair Services!"},
+        {
+            "role": "tool_call_invocation",
+            "tool_call_id": "call_3Osr",
+            "name": "transition_to_scheduler",
+            "arguments": "{}",
+            "time_sec": 18.524,
+        },
+        {
+            "role": "tool_call_invocation",
+            "tool_call_id": "call_pXbW",
+            "name": "schedule_appointment",
+            "arguments": '{"date":"08/18/2026"}',
+            "time_sec": 38.143,
+            "type": "custom",
+        },
+        {
+            "role": "tool_call_result",
+            "tool_call_id": "call_pXbW",
+            "successful": True,
+            "time_sec": 38.455,
+        },
+        {
+            "role": "tool_call_invocation",
+            "tool_call_id": "call_wqGU",
+            "name": "end_call",
+            "arguments": '{"execution_message":"Goodbye!"}',
+            "time_sec": 63.191,
+            "type": "end_call",
+        },
+    ],
+}
+BP = {"agents": {"receptionist": {"tools": [{"name": "handoff_to_scheduler", "handoff": True, "handoff_to": "scheduler"}]}}}
+
+calls = platform_tool_calls(RECORD, handoff_tool_names(BP))
+
+# schedule_appointment hit our webhook and already has a live span — must not double up.
+assert [c["name"] for c in calls] == ["handoff_to_scheduler", "end_call"], calls
+# the edge tool is reported under the blueprint name, with Retell's name kept alongside.
+assert calls[0]["provider_name"] == "transition_to_scheduler"
+# time_sec is relative to start_timestamp (epoch ms) → epoch ns.
+assert calls[0]["start_ns"] == 1786384392155 * 1_000_000 + 18_524_000_000
+# no result row for a transition, so it gets a 10 ms sliver rather than zero width.
+assert calls[0]["end_ns"] - calls[0]["start_ns"] == 10_000_000
+assert calls[1]["arguments"] == {"execution_message": "Goodbye!"}
+# a record with no start_timestamp can't be placed on the timeline — emit nothing.
+assert platform_tool_calls({"transcript_with_tool_calls": RECORD["transcript_with_tool_calls"]}, {}) == []
+
+print("ok", [c["name"] for c in calls])

--- a/voice-agent-harnesses/test_await_terminal.py
+++ b/voice-agent-harnesses/test_await_terminal.py
@@ -55,7 +55,17 @@ async def main():
         sys.modules.pop("report", None)
         mod = importlib.import_module("report")
         sys.path.pop(0)
-        wait, relink = mod._await_terminal_upsert, mod._relink_after_final
+        wait = mod._await_terminal_upsert
+
+        if not hasattr(mod, "_relink_after_final"):
+            f = Feed("EVALUATING", "COMPLETED")
+            got = await wait(f, "1", timeout=30)
+            assert (got, f.polls, f.posts) == ("COMPLETED", 2, 0)
+            checked.append(name)
+            print(f"ok {name} (single-post final-status contract)")
+            continue
+
+        relink = mod._relink_after_final
 
         assert wait.__defaults__[-1] == 300.0, f"{name}: budget under eval's ~175 s"
         assert await wait(Feed("EVALUATING"), "1", timeout=2.5) is None, f"{name}: posts mid-eval"

--- a/voice-agent-harnesses/vapi/README.md
+++ b/voice-agent-harnesses/vapi/README.md
@@ -1,3 +1,66 @@
 # vapi
 
-Benchmarks and evaluation assets for vapi voice agents.
+Vapi harness via the REST + websocket-transport API — **native multi-agent** (a squad, not a soft handoff). Each blueprint agent is a persisted Vapi assistant; the receptionist hands off to the scheduler with a `handoff` tool whose destination is the scheduler assistant, server-side. `end_call` is Vapi's built-in `endCall` tool. Tools run on Vapi's side too, so `schedule_appointment` comes back to us as an HTTPS POST to `/tool/schedule_appointment`, which forwards to `TOOL_SERVER_URL`.
+
+| Folder | Runtime |
+|---|---|
+| `flux-gpt4.1-flash2.5/` | `vapi-flux-gpt4.1-flash2.5` |
+
+| Layer | Setting |
+|---|---|
+| STT | Deepgram Flux — `{provider: "deepgram", model: "flux-general-en", language: "en"}` |
+| LLM | OpenAI `gpt-4.1` |
+| TTS | ElevenLabs Flash v2.5 — `{provider: "11labs", model: "eleven_flash_v2_5", voiceId: "21m00Tcm4TlvDq8ikWAM"}` |
+| Transport | `vapi.websocket`, `pcm_s16le` raw @ 16 kHz both ways (same as CHIRP — no resampling) |
+
+Plain `"flux"` as the transcriber model is accepted by `POST /assistant` but fails at call time with `error-vapifault-deepgram-transcriber-failed`; use `flux-general-en`.
+
+Shared: `harness.py` (`ensure_squad` creates or refreshes the assistant pair + squad, `start_websocket_call` opens a call). Tracing: `report.py` (GenAI-native OTel → Bluejay OTLP, `gen_ai.provider.name=vapi`).
+
+## Env
+
+| Var | Default |
+|---|---|
+| `VAPI_API_KEY` | required |
+| `PUBLIC_URL` | required — https base the provider calls tools on (cloudflared tunnel for this run) |
+| `VAPI_VOICE_ID` | `21m00Tcm4TlvDq8ikWAM` (Rachel) |
+| `VAPI_LLM_MODEL` / `VAPI_STT_MODEL` / `VAPI_TTS_MODEL` | `gpt-4.1` / `flux-general-en` / `eleven_flash_v2_5` |
+| `VAPI_GREETING` | `Welcome to Bluejay's Repair Services!` |
+| `CHIRP_USER` / `CHIRP_PASS` / `CHIRP_PORT` | — / — / `8770` |
+| `TOOL_SERVER_URL`, `INDUSTRY` | `http://127.0.0.1:8000`, `control-industry` |
+| `BLUEJAY_API_KEY`, `BLUEJAY_OTLP_ENDPOINT`, `BLUEJAY_API_URL`, `BLUEJAY_SERVICE_NAME` | traces off without the key; service name `mivas-vapi` |
+
+Assistant/squad IDs are cached in `.agents.json` (gitignored, keyed by industry). The tunnel URL is ephemeral, so `ensure_squad` re-pushes the whole assistant config — prompts, tools, and the current `{PUBLIC_URL}/tool/<name>` webhook — on every chirp boot.
+
+## Run
+
+```bash
+uv sync
+set -a && source .env && set +a
+uv run python industries/control-industry/tool_server.py          # terminal A (shared, :8000)
+cloudflared tunnel --url http://127.0.0.1:8770 --no-autoupdate    # terminal B
+export PUBLIC_URL=https://<tunnel>.trycloudflare.com
+export CHIRP_USER=mivas CHIRP_PASS=mivas CHIRP_PORT=8770 PYTHONUNBUFFERED=1
+export BLUEJAY_API_KEY=... BLUEJAY_SERVICE_NAME=mivas-vapi
+uv run python voice-agent-harnesses/vapi/flux-gpt4.1-flash2.5/adapters/chirp.py   # terminal C
+```
+
+The chirp process serves both halves on one port so a single tunnel covers them: `/` is the CHIRP websocket Bluejay dials (`wss://<tunnel>`, Basic auth, `X-Simulation-Result-Id` on upgrade), `/tool/{name}` is Vapi's tool webhook.
+
+Smoke without Bluejay: `agent.py control-industry --check` pushes the blueprint and prints the ids; without `--check` it opens a real call, feeds silence, and reports the event stream plus agent audio bytes.
+
+## Proof run
+
+control-industry, agent 30375 / sim 30208 / DH 194134 (`speaks_first: false`, expecting `handoff_to_scheduler` + `schedule_appointment`) → result **710641**, https://app.getbluejay.ai/simulations/30208/runs/224727
+
+`COMPLETED`, 56 s, `goal_success=true`, trace `2940ff35a05416945a1f19fb8b2fd01d`. Both DH-expected tools fired and paired against `actual`: `handoff_to_scheduler` @11 374 ms, `schedule_appointment` @31 666 ms `{date: "08/18/2026"}` (tool-server row id 47), `endCall` @52 131 ms. Audio in 1 633 920 B / out 1 673 600 B.
+
+Provider-side ids for that run: squad `1e3742c2-2f88-4cc0-8b1b-f6a14e587fe5`, receptionist `834b8862-a0b8-430e-abcb-750e36c2a473`, scheduler `f0fbc0f4-dc03-4513-9b01-f961c0599b38`.
+
+The digital human must not speak first. With `speaks_first: true` the caller's opener and the assistant's `firstMessage` start within ~30 ms of each other and talk over one another; Vapi's `firstMessageMode: "assistant-waits-for-user"` would fix that (the greeting still comes from the receptionist prompt, just after the caller), but it is deliberately **not** set — the shipped config assumes the caller waits.
+
+## Spans
+
+Vapi streams agent audio as continuous binary frames with no gaps between turns, so the silence-gap heuristic the ElevenLabs bridge uses cannot find turn boundaries here. `agent.speech` is bracketed by `speech-update` (`role=assistant`, `started`/`stopped`) instead; `customer.speech` comes from Bluejay's inbound `speech.started`/`speech.completed`. `handoff_to_scheduler` and `endCall` never touch the webhook — they are read off `conversation-update` and emitted as zero-width `execute_tool` spans so the whole flow lands on the timeline.
+
+`report.py` waits for a *final* simulation status before its single `update-simulation-result` POST. Posting during `EVALUATING` also works, but eval then wipes `trace_ids` and the relink POST re-extracts the `execute_tool` spans on top of the first POST's, putting every tool on the conversation timeline twice. `_relink_after_final` remains as the safety net for when that wait times out.

--- a/voice-agent-harnesses/vapi/adapters/chirp.py
+++ b/voice-agent-harnesses/vapi/adapters/chirp.py
@@ -1,0 +1,281 @@
+"""16 kHz pcm websocket bridge ↔ Vapi, plus the tool webhook Vapi calls back on.
+
+Both are served by one FastAPI app so a single cloudflared tunnel covers them:
+`/` is the CHIRP socket Bluejay dials, `/tool/{name}` is what Vapi POSTs when the
+squad runs `schedule_appointment`. Vapi's websocket transport is raw 16 kHz
+pcm_s16le both directions, so no resampling either way.
+
+Agent audio arrives as continuous binary frames with no gaps, so the usual
+silence-gap heuristic can't find turn boundaries here — `agent.speech` is
+bracketed by Vapi's `speech-update` (role=assistant, started/stopped) instead.
+`customer.speech` comes from Bluejay's inbound `speech.started`/`speech.completed`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import contextlib
+import json
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+import uvicorn
+import websockets
+from fastapi import FastAPI, Request, WebSocket
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from harness import (  # noqa: E402
+    ensure_squad,
+    industry_path,
+    run_tool,
+    start_websocket_call,
+)
+from report import (  # noqa: E402
+    end_speech_span,
+    finish_tool_span,
+    start_speech_span,
+    tool_span,
+    traced_run,
+)
+
+app = FastAPI(title="mivas vapi chirp bridge")
+_cfg: dict[str, Any] = {}
+
+
+def _auth() -> str | None:
+    u, p = os.environ.get("CHIRP_USER", "").strip(), os.environ.get("CHIRP_PASS", "").strip()
+    return f"Basic {base64.b64encode(f'{u}:{p}'.encode()).decode()}" if u and p else None
+
+
+def _event(t: str, data: dict) -> str:
+    return json.dumps(
+        {"type": t, "id": str(uuid.uuid4()), "ts_ms": int(time.time() * 1000), "data": data},
+        separators=(",", ":"),
+    )
+
+
+def _msg_type(event: dict) -> str | None:
+    """Vapi sends server messages either bare or wrapped in `message`."""
+    return event.get("type") or ((event.get("message") or {}).get("type") if isinstance(event.get("message"), dict) else None)
+
+
+def _payload(event: dict) -> dict:
+    inner = event.get("message")
+    return inner if isinstance(inner, dict) and inner.get("type") else event
+
+
+@app.post("/tool/{name}")
+async def tool_webhook(name: str, request: Request) -> dict[str, Any]:
+    """Vapi tool-calls webhook → run_tool (which emits the execute_tool span).
+
+    # ponytail: spans bind to report.py's module-level active root, so exactly one
+    # call may be in flight; benchmark runs are max_concurrent=1. Key the span by
+    # call id if that ever changes.
+    """
+    body = await request.json()
+    calls = (_payload(body).get("toolCallList")) or []
+    results = []
+    for call in calls:
+        # live payload nests name/arguments under `function`; top level is the fallback
+        fn = call.get("function") or {}
+        args = fn.get("arguments") or call.get("arguments") or {}
+        if isinstance(args, str):
+            with contextlib.suppress(json.JSONDecodeError):
+                args = json.loads(args)
+        tool_name = fn.get("name") or call.get("name") or name
+        result = await run_tool(tool_name, dict(args), call_id=call.get("id"))
+        print(f"chirp tool {tool_name} args={args} -> {result}", flush=True)
+        results.append({"toolCallId": call.get("id"), "result": json.dumps(result)})
+    return {"results": results}
+
+
+@app.websocket("/")
+async def chirp(ws: WebSocket) -> None:
+    expected = _auth()
+    if expected and ws.headers.get("authorization") != expected:
+        await ws.close(1008, "unauthorized")
+        return
+    await ws.accept()
+    try:
+        await _bridge(ws)
+    except Exception as e:
+        print(f"chirp bridge error: {type(e).__name__}: {e}", flush=True)
+    finally:
+        with contextlib.suppress(Exception):
+            await ws.close()
+
+
+async def _bridge(ws: WebSocket) -> None:
+    model, industry = _cfg["model"], _cfg["industry"]
+    workflow = f"mivas-{Path(industry_path(industry)).name}-{model}"
+    sim_id = ws.headers.get("x-simulation-result-id")
+    if sim_id:
+        print(f"chirp sim_result_id={sim_id}", flush=True)
+
+    utt: str | None = None
+    speech_otel = None
+    customer_otel = None
+    seen_tools: set[str] = set()
+    end = asyncio.Event()
+    audio_in = audio_out = 0
+
+    async with traced_run(workflow, simulation_result_id=sim_id, model=model):
+        call_url, call_id = await asyncio.to_thread(start_websocket_call, _cfg["squad_id"])
+        print(f"chirp vapi call={call_id}", flush=True)
+        async with websockets.connect(call_url, max_size=None) as vapi_ws:
+
+            async def inbound() -> None:
+                """chirp pcm + Bluejay speech.* → Vapi; customer.speech spans."""
+                nonlocal customer_otel, audio_in
+                try:
+                    while not end.is_set():
+                        msg = await ws.receive()
+                        if msg["type"] == "websocket.disconnect":
+                            break
+                        if msg.get("bytes"):
+                            audio_in += len(msg["bytes"])
+                            await vapi_ws.send(msg["bytes"])
+                            continue
+                        if not msg.get("text"):
+                            continue
+                        try:
+                            event = json.loads(msg["text"])
+                        except json.JSONDecodeError:
+                            continue
+                        etype = event.get("type")
+                        data = event.get("data") or {}
+                        if etype == "speech.started":
+                            end_speech_span(customer_otel)
+                            customer_otel = start_speech_span(
+                                data.get("utterance_id") or f"c_{uuid.uuid4().hex[:12]}",
+                                speaker="customer",
+                            )
+                        elif etype == "speech.completed":
+                            end_speech_span(customer_otel)
+                            customer_otel = None
+                finally:
+                    end_speech_span(customer_otel)
+                    customer_otel = None
+                    end.set()
+                    with contextlib.suppress(Exception):
+                        await vapi_ws.close()
+
+            async def outbound() -> None:
+                """Vapi audio + events → chirp pcm, speech.*, agent.speech spans."""
+                nonlocal utt, speech_otel, audio_out
+                try:
+                    async for raw in vapi_ws:
+                        if end.is_set():
+                            break
+                        if isinstance(raw, bytes):
+                            audio_out += len(raw)
+                            await ws.send_bytes(raw)
+                            continue
+                        try:
+                            event = json.loads(raw)
+                        except json.JSONDecodeError:
+                            continue
+                        etype = _msg_type(event)
+                        body = _payload(event)
+                        if etype == "speech-update" and body.get("role") == "assistant":
+                            if body.get("status") == "started" and utt is None:
+                                utt = f"u_{uuid.uuid4().hex[:12]}"
+                                speech_otel = start_speech_span(utt, speaker="agent")
+                                await ws.send_text(_event("speech.started", {"utterance_id": utt}))
+                            elif body.get("status") == "stopped" and utt:
+                                await ws.send_text(_event("speech.completed", {"utterance_id": utt}))
+                                end_speech_span(speech_otel)
+                                speech_otel, utt = None, None
+                        elif etype == "conversation-update":
+                            _trace_server_tools(body, seen_tools)
+                        elif etype == "transcript" and body.get("transcriptType") == "final":
+                            print(
+                                f"chirp transcript [{body.get('role')}] {body.get('transcript')}",
+                                flush=True,
+                            )
+                        elif etype in ("hangup", "end-of-call-report"):
+                            print(f"chirp vapi {etype}", flush=True)
+                            break
+                        elif etype == "status-update" and body.get("status") == "ended":
+                            print(f"chirp vapi ended: {body.get('endedReason')}", flush=True)
+                            break
+                        elif etype == "error":
+                            print(f"chirp vapi error: {body}", flush=True)
+                            break
+                finally:
+                    if utt:
+                        await ws.send_text(_event("speech.completed", {"utterance_id": utt}))
+                        end_speech_span(speech_otel)
+                        speech_otel, utt = None, None
+                    end.set()
+                    with contextlib.suppress(Exception):
+                        await ws.close(1000)
+
+            tasks = [asyncio.create_task(inbound()), asyncio.create_task(outbound())]
+            done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            for t in pending:
+                t.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+            print(f"chirp audio in={audio_in}B out={audio_out}B", flush=True)
+            for t in done:
+                exc = None if t.cancelled() else t.exception()
+                if exc is not None and not type(exc).__name__.startswith("ConnectionClosed"):
+                    raise exc
+
+
+def _trace_server_tools(body: dict, seen: set[str]) -> None:
+    """Handoff and endCall run entirely server-side, so their only trace is the
+    tool_calls entry in `conversation-update`. Emit a zero-width execute_tool span
+    the first time each shows up so the timeline shows the full flow."""
+    for message in body.get("messages") or []:
+        for call in message.get("toolCalls") or message.get("tool_calls") or []:
+            fn = call.get("function") or {}
+            name = fn.get("name") or call.get("name")
+            key = str(call.get("id") or name)
+            if not name or name in ("schedule_appointment",) or key in seen:
+                continue
+            seen.add(key)
+            args = fn.get("arguments") or {}
+            if isinstance(args, str):
+                with contextlib.suppress(json.JSONDecodeError):
+                    args = json.loads(args)
+            print(f"chirp vapi server tool {name}", flush=True)
+            with tool_span(name, args) as span:
+                finish_tool_span(
+                    span,
+                    {"success": True, "source": "vapi"},
+                    ok=True,
+                    name=name,
+                    parameters=args,
+                )
+
+
+def main(model: str | None = None) -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--model", default=model or os.environ.get("VAPI_MODEL", "vapi-flux-gpt4.1-flash2.5"))
+    p.add_argument("--industry", default=os.environ.get("INDUSTRY", "control-industry"))
+    p.add_argument("--host", default=os.environ.get("CHIRP_HOST", "0.0.0.0"))
+    p.add_argument("--port", type=int, default=int(os.environ.get("CHIRP_PORT", "8770")))
+    a = p.parse_args()
+    public_url = os.environ.get("PUBLIC_URL", "").strip()
+    if not public_url:
+        raise SystemExit("need PUBLIC_URL (cloudflared https url) — Vapi tool webhooks point at it")
+
+    ids = ensure_squad(a.industry, public_url)
+    _cfg.update(model=a.model, industry=a.industry, squad_id=ids["squad_id"])
+    print(
+        f"ws↔Vapi {a.model} × {a.industry} :{a.port} auth={bool(_auth())} "
+        f"squad={ids['squad_id']} tools→{public_url}/tool/",
+        flush=True,
+    )
+    uvicorn.run(app, host=a.host, port=a.port, log_level="warning")
+
+
+if __name__ == "__main__":
+    main()

--- a/voice-agent-harnesses/vapi/flux-gpt4.1-flash2.5/adapters/chirp.py
+++ b/voice-agent-harnesses/vapi/flux-gpt4.1-flash2.5/adapters/chirp.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from adapters.chirp import main  # noqa: E402
+
+if __name__ == "__main__":
+    main(model="vapi-flux-gpt4.1-flash2.5")

--- a/voice-agent-harnesses/vapi/flux-gpt4.1-flash2.5/agent.py
+++ b/voice-agent-harnesses/vapi/flux-gpt4.1-flash2.5/agent.py
@@ -1,0 +1,66 @@
+"""Vapi harness — Deepgram Flux STT × gpt-4.1 × ElevenLabs Flash v2.5, crossed
+with any industry agent_blueprint.json.
+
+There is no local text loop: Vapi runs the squad server-side and the only way in
+is the websocket transport, so this entry point is `--check` (push the blueprint
+to Vapi and print the ids) plus a one-shot audio smoke that opens a real call and
+reports what came back.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+import websockets
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from harness import TOOL_SERVER_URL, ensure_squad, industry_path, start_websocket_call  # noqa: E402
+
+MODEL = "vapi-flux-gpt4.1-flash2.5"
+
+
+async def smoke(squad_id: str, seconds: float = 20.0) -> None:
+    """Open a call, feed silence, print events + audio byte count."""
+    url, call_id = start_websocket_call(squad_id)
+    print(f"call={call_id}")
+    audio = 0
+    async with websockets.connect(url, max_size=None) as ws:
+
+        async def feed() -> None:
+            while True:  # 20 ms of 16 kHz silence
+                await ws.send(b"\x00" * 640)
+                await asyncio.sleep(0.02)
+
+        feeder = asyncio.create_task(feed())
+        try:
+            async with asyncio.timeout(seconds):
+                async for raw in ws:
+                    if isinstance(raw, bytes):
+                        audio += len(raw)
+                    else:
+                        print(json.loads(raw))
+        except TimeoutError:
+            pass
+        finally:
+            feeder.cancel()
+    print(f"agent audio {audio}B")
+
+
+if __name__ == "__main__":
+    industry = next((a for a in sys.argv[1:] if not a.startswith("-")), "control-industry")
+    industry_dir = Path(os.environ.get("INDUSTRY_DIR", str(industry_path(industry))))
+    public_url = os.environ.get("PUBLIC_URL", "").strip()
+    if not public_url:
+        raise SystemExit("need PUBLIC_URL (cloudflared https url)")
+    ids = ensure_squad(industry_dir, public_url)
+    print(
+        f"ok {industry_dir.name} × {MODEL} squad={ids['squad_id']} "
+        f"receptionist={ids['receptionist_id']} scheduler={ids['scheduler_id']} "
+        f"tool_server={TOOL_SERVER_URL}"
+    )
+    if "--check" not in sys.argv:
+        asyncio.run(smoke(ids["squad_id"]))

--- a/voice-agent-harnesses/vapi/harness.py
+++ b/voice-agent-harnesses/vapi/harness.py
@@ -1,0 +1,315 @@
+"""Blueprint → Vapi squad (assistants + native handoff) helpers.
+
+Vapi is a platform: prompts, tools and handoffs all live server-side, so the
+harness only (re)pushes blueprint config and then serves the webhook Vapi calls
+back on. Multi-agent is a **squad**: the receptionist member carries a `handoff`
+tool whose destination is the scheduler member, and the first member answers the
+call. `end_call` is Vapi's built-in `endCall` tool, so it never reaches the
+harness — `schedule_appointment` is the only tool we execute, and it arrives as
+an HTTPS POST from Vapi to `adapters/chirp.py`'s `/tool/{name}` route (which is
+also where its `execute_tool` span comes from).
+
+Tool URLs point at the current cloudflared tunnel, which is ephemeral, so
+`ensure_squad` re-pushes the whole assistant config on every chirp boot; only the
+ids are cached (`.agents.json`).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+HARNESS_DIR = Path(__file__).resolve().parent
+TOOL_SERVER_URL = os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
+
+API_BASE = "https://api.vapi.ai"
+AGENT_CACHE_PATH = HARNESS_DIR / ".agents.json"
+DEFAULT_VOICE_ID = "21m00Tcm4TlvDq8ikWAM"  # Rachel
+DEFAULT_GREETING = "Welcome to Bluejay's Repair Services!"
+LLM_MODEL = os.environ.get("VAPI_LLM_MODEL", "gpt-4.1")
+# plain "flux" is rejected at call time (error-vapifault-deepgram-transcriber-failed)
+STT_MODEL = os.environ.get("VAPI_STT_MODEL", "flux-general-en")
+TTS_MODEL = os.environ.get("VAPI_TTS_MODEL", "eleven_flash_v2_5")
+# 16 kHz raw pcm both directions == CHIRP's format, so the bridge never resamples.
+AUDIO_FORMAT = {"format": "pcm_s16le", "container": "raw", "sampleRate": 16000}
+
+
+def industry_path(name: str | Path) -> Path:
+    path = Path(name)
+    if path.is_dir():
+        return path.resolve()
+    env_dir = os.environ.get("INDUSTRY_DIR", "").strip()
+    if env_dir and Path(env_dir).is_dir():
+        return Path(env_dir).resolve()
+    return (REPO_ROOT / "industries" / name).resolve()
+
+
+def load_blueprint(industry_dir: str | Path) -> dict[str, Any]:
+    industry_dir = industry_path(industry_dir)
+    blueprint = json.loads((industry_dir / "agent_blueprint.json").read_text())
+    catalog = {t["name"]: t for t in json.loads((industry_dir / "tools.json").read_text())["tools"]}
+    agents = {}
+    for entry in blueprint["agents"]:
+        agents[entry["name"]] = {
+            "name": entry["name"],
+            "instructions": (industry_dir / entry["system_prompt"]).read_text(),
+            "tools": entry["tools"],
+        }
+    return {
+        "industry_dir": industry_dir,
+        "start": blueprint["agents"][0]["name"],
+        "agents": agents,
+        "catalog": catalog,
+    }
+
+
+def _api_key() -> str:
+    key = os.environ.get("VAPI_API_KEY")
+    if not key:
+        raise SystemExit("need VAPI_API_KEY")
+    return key
+
+
+def _request(method: str, path: str, body: dict[str, Any] | None = None) -> dict[str, Any]:
+    r = httpx.request(
+        method,
+        f"{API_BASE}{path}",
+        headers={"Authorization": f"Bearer {_api_key()}", "Content-Type": "application/json"},
+        json=body,
+        timeout=60.0,
+    )
+    if r.status_code >= 400:
+        raise RuntimeError(f"vapi {method} {path} -> {r.status_code} {r.text[:600]}")
+    return r.json()
+
+
+def _function_tool(spec: dict[str, Any], public_url: str) -> dict[str, Any]:
+    """tools.json entry → Vapi custom function tool pointed at our webhook."""
+    raw = dict(spec.get("inputSchema") or {"type": "object"})
+    props = {}
+    for key, prop in (raw.get("properties") or {}).items():
+        p = {k: v for k, v in dict(prop).items() if k in {"type", "description", "enum"}}
+        p.setdefault("type", "string")
+        props[key] = p
+    parameters: dict[str, Any] = {"type": "object", "properties": props}
+    if raw.get("required"):
+        parameters["required"] = list(raw["required"])
+    return {
+        "type": "function",
+        "function": {
+            "name": spec["name"],
+            "description": spec.get("description", spec["name"]),
+            "parameters": parameters,
+        },
+        "server": {"url": f"{public_url.rstrip('/')}/tool/{spec['name']}"},
+    }
+
+
+def _handoff_tool(name: str, target_id: str, description: str) -> dict[str, Any]:
+    return {
+        "type": "handoff",
+        "destinations": [
+            {"type": "assistant", "assistantId": target_id, "description": description}
+        ],
+        "function": {"name": name, "description": description},
+    }
+
+
+def _build_tools(
+    agent_entry: dict[str, Any],
+    bp: dict[str, Any],
+    public_url: str,
+    *,
+    handoff_target_id: str | None = None,
+) -> list[dict[str, Any]]:
+    tools: list[dict[str, Any]] = []
+    for t in agent_entry["tools"]:
+        name = t["name"]
+        if t.get("handoff"):
+            if handoff_target_id:
+                spec = bp["catalog"].get(name) or {}
+                tools.append(
+                    _handoff_tool(
+                        name,
+                        handoff_target_id,
+                        spec.get("description") or f"Hand off to the {t['handoff_to']} agent.",
+                    )
+                )
+            continue
+        if t.get("session") or name == "end_call":
+            tools.append({"type": "endCall"})
+            continue
+        spec = bp["catalog"].get(name)
+        if spec:
+            tools.append(_function_tool(spec, public_url))
+    return tools
+
+
+def _assistant_payload(
+    *,
+    name: str,
+    prompt: str,
+    first_message: str | None,
+    tools: list[dict[str, Any]],
+    voice_id: str,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "name": name,
+        "model": {
+            "provider": "openai",
+            "model": LLM_MODEL,
+            "messages": [{"role": "system", "content": prompt}],
+            "tools": tools,
+        },
+        "voice": {"provider": "11labs", "model": TTS_MODEL, "voiceId": voice_id},
+        "transcriber": {"provider": "deepgram", "model": STT_MODEL, "language": "en"},
+    }
+    if first_message:
+        payload["firstMessage"] = first_message
+        payload["firstMessageMode"] = "assistant-speaks-first"
+    else:
+        # the scheduler is only ever reached by handoff; it opens the new leg itself.
+        payload["firstMessageMode"] = "assistant-speaks-first-with-model-generated-message"
+    return payload
+
+
+def _load_cache() -> dict[str, Any]:
+    if not AGENT_CACHE_PATH.exists():
+        return {}
+    try:
+        return json.loads(AGENT_CACHE_PATH.read_text())
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_cache(cache: dict[str, Any]) -> None:
+    AGENT_CACHE_PATH.write_text(json.dumps(cache, indent=2) + "\n")
+
+
+def _upsert_assistant(assistant_id: str | None, payload: dict[str, Any]) -> str:
+    if assistant_id:
+        try:
+            return _request("PATCH", f"/assistant/{assistant_id}", payload)["id"]
+        except RuntimeError as e:
+            if "404" not in str(e):
+                raise
+    return _request("POST", "/assistant", payload)["id"]
+
+
+def ensure_squad(industry_dir: str | Path, public_url: str, *, voice_id: str | None = None) -> dict[str, str]:
+    """Create or refresh the receptionist/scheduler assistants + squad for an industry.
+
+    Always re-pushes the full config so the `schedule_appointment` webhook points
+    at this run's tunnel; only ids are reused from `.agents.json`.
+    """
+    bp = load_blueprint(industry_dir)
+    industry_name = Path(bp["industry_dir"]).name
+    voice_id = voice_id or os.environ.get("VAPI_VOICE_ID", DEFAULT_VOICE_ID)
+
+    cache = _load_cache()
+    entry = dict(cache.get(industry_name) or {})
+
+    start_agent = bp["agents"][bp["start"]]
+    handoff = next((t for t in start_agent["tools"] if t.get("handoff")), None)
+    target_name = handoff["handoff_to"] if handoff else bp["start"]
+    target_agent = bp["agents"][target_name]
+
+    scheduler_id = _upsert_assistant(
+        entry.get("scheduler_id"),
+        _assistant_payload(
+            name=f"mivas-{industry_name}-{target_name}",
+            prompt=target_agent["instructions"],
+            first_message=None,
+            tools=_build_tools(target_agent, bp, public_url),
+            voice_id=voice_id,
+        ),
+    )
+    receptionist_id = _upsert_assistant(
+        entry.get("receptionist_id"),
+        _assistant_payload(
+            name=f"mivas-{industry_name}-{bp['start']}",
+            prompt=start_agent["instructions"],
+            first_message=os.environ.get("VAPI_GREETING", DEFAULT_GREETING),
+            tools=_build_tools(
+                start_agent, bp, public_url, handoff_target_id=scheduler_id if handoff else None
+            ),
+            voice_id=voice_id,
+        ),
+    )
+
+    squad_payload = {
+        "name": f"mivas-{industry_name}",
+        # first member answers the call
+        "members": [{"assistantId": receptionist_id}, {"assistantId": scheduler_id}],
+    }
+    squad_id = entry.get("squad_id")
+    if squad_id:
+        try:
+            squad_id = _request("PATCH", f"/squad/{squad_id}", squad_payload)["id"]
+        except RuntimeError as e:
+            if "404" not in str(e):
+                raise
+            squad_id = None
+    if not squad_id:
+        squad_id = _request("POST", "/squad", squad_payload)["id"]
+
+    entry = {
+        "receptionist_id": receptionist_id,
+        "scheduler_id": scheduler_id,
+        "squad_id": squad_id,
+    }
+    cache[industry_name] = entry
+    _save_cache(cache)
+    return entry
+
+
+def start_websocket_call(squad_id: str) -> tuple[str, str]:
+    """POST /call with the websocket transport → (websocketCallUrl, call_id)."""
+    resp = _request(
+        "POST",
+        "/call",
+        {
+            "squadId": squad_id,
+            "transport": {"provider": "vapi.websocket", "audioFormat": AUDIO_FORMAT},
+        },
+    )
+    return resp["transport"]["websocketCallUrl"], resp["id"]
+
+
+async def _post_appointment(date: str) -> dict[str, Any]:
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(f"{TOOL_SERVER_URL}/appointments", json={"date": date})
+        resp.raise_for_status()
+        body = resp.json()
+    return {"success": True, "date": body["date"]}
+
+
+async def _execute_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
+    if name == "schedule_appointment":
+        return await _post_appointment(args["date"])
+    return {"success": False, "error": f"unknown tool {name}"}
+
+
+async def run_tool(name: str, args: dict[str, Any], *, call_id: str | None = None) -> dict[str, Any]:
+    """Execute a Vapi function tool under an execute_tool span.
+
+    Never raises — failures become `{success: false, error: ...}` so the call (and
+    its OTel tree) still finishes cleanly.
+    """
+    from report import call_offset_ms, finish_tool_span, tool_span
+
+    offset = call_offset_ms()
+    with tool_span(name, args, call_id=call_id) as span:
+        try:
+            result = await _execute_tool(name, args)
+            finish_tool_span(span, result, ok=True, name=name, parameters=args, start_offset_ms=offset)
+            return result
+        except Exception as e:
+            err = {"success": False, "error": f"{type(e).__name__}: {e}"}
+            finish_tool_span(span, err, ok=False, name=name, parameters=args, start_offset_ms=offset)
+            return err

--- a/voice-agent-harnesses/vapi/harness.py
+++ b/voice-agent-harnesses/vapi/harness.py
@@ -302,14 +302,12 @@ async def run_tool(name: str, args: dict[str, Any], *, call_id: str | None = Non
     its OTel tree) still finishes cleanly.
     """
     from report import call_offset_ms, finish_tool_span, tool_span
-
-    offset = call_offset_ms()
     with tool_span(name, args, call_id=call_id) as span:
         try:
             result = await _execute_tool(name, args)
-            finish_tool_span(span, result, ok=True, name=name, parameters=args, start_offset_ms=offset)
+            finish_tool_span(span, result, ok=True)
             return result
         except Exception as e:
             err = {"success": False, "error": f"{type(e).__name__}: {e}"}
-            finish_tool_span(span, err, ok=False, name=name, parameters=args, start_offset_ms=offset)
+            finish_tool_span(span, err, ok=False)
             return err

--- a/voice-agent-harnesses/vapi/report.py
+++ b/voice-agent-harnesses/vapi/report.py
@@ -52,20 +52,15 @@ FINAL_STATUSES = {
     "CANCELLED",
     "NO_CONNECTION",
 }
-EARLY_UPSERT_STATUSES = {"EVALUATING", "EVALUATED", "CONVERSATION_ENDED"}
 PROVIDER = "vapi"
 TRACER_NAME = "mivas.vapi"
 
 _provider: TracerProvider | None = None
 _root_span: ContextVar[Span | None] = ContextVar("mivas_vapi_otel_root", default=None)
 _call_t0: ContextVar[float | None] = ContextVar("mivas_vapi_otel_t0", default=None)
-_reported_tools: ContextVar[list[dict[str, Any]] | None] = ContextVar(
-    "mivas_vapi_reported_tools", default=None
-)
 # module fallbacks when asyncio tasks don't inherit ContextVars
 _active_root: Span | None = None
 _active_t0: float | None = None
-_active_tools: list[dict[str, Any]] | None = None
 
 
 def _api_url() -> str:
@@ -147,31 +142,6 @@ def _parent_span() -> Span | None:
     return None
 
 
-def record_tool_call(
-    name: str,
-    parameters: Any,
-    output: Any,
-    *,
-    start_offset_ms: int | None = None,
-) -> None:
-    """Buffer a tool call for the end-of-call update-simulation-result POST."""
-    tools = _reported_tools.get()
-    if tools is None:
-        tools = _active_tools
-    if tools is None:
-        return
-    tools.append(
-        {
-            "name": str(name),
-            "parameters": parameters if isinstance(parameters, dict) else {"raw": parameters},
-            "output": output,
-            "start_offset_ms": int(
-                start_offset_ms if start_offset_ms is not None else call_offset_ms()
-            ),
-        }
-    )
-
-
 @contextmanager
 def tool_span(
     name: str,
@@ -216,9 +186,6 @@ def finish_tool_span(
     output: Any,
     *,
     ok: bool = True,
-    name: str | None = None,
-    parameters: Any = None,
-    start_offset_ms: int | None = None,
 ) -> None:
     if span is not None:
         span.set_attribute("gen_ai.tool.call.result", _json_attr(output))
@@ -272,11 +239,11 @@ async def _await_terminal_upsert(
     300 s, not 150 s: eval needs ~175 s to settle and anything shorter forces the
     early-post + relink path below, which double-counts every tool.
 
-    Posting during EVALUATING works, but eval then wipes trace_ids and the relink
-    POST re-extracts the execute_tool spans on top of the ones the first POST
-    already produced — every tool lands on the timeline twice. One POST after the
-    sim settles gives a surviving link and one row per tool; `_relink_after_final`
-    stays as the safety net for when this wait times out.
+    Posting during EVALUATING works, but eval then wipes trace_ids, and re-posting
+    makes Bluejay re-extract the execute_tool spans on top of the ones the first
+    POST already produced — every tool lands on the timeline twice. One POST after
+    the sim settles gives a surviving link and one row per tool. On timeout we post
+    anyway and log it; we never re-post, because that is the double-count.
     """
     deadline = time.monotonic() + timeout
     key = _api_key()
@@ -304,10 +271,8 @@ async def post_simulation_enrichment(
     simulation_result_id: str,
     *,
     trace_id: str | None,
-    tool_calls: list[dict[str, Any]] | None = None,
 ) -> None:
-    """Link OTel trace_ids. tool_calls ignored — use execute_tool spans."""
-    del tool_calls
+    """Link OTel trace_ids; conversation tools come from execute_tool spans."""
     key = _api_key()
     if not key or not simulation_result_id:
         logger.warning(
@@ -327,7 +292,7 @@ async def post_simulation_enrichment(
     body: dict[str, Any] = {"simulation_result_id": str(simulation_result_id)}
     if trace_id:
         body["trace_ids"] = [trace_id]
-    if "trace_ids" not in body and "tool_calls" not in body:
+    if "trace_ids" not in body:
         logger.warning("skip update-simulation-result — nothing to post")
         return
 
@@ -371,9 +336,12 @@ async def post_simulation_enrichment(
                         st,
                         attempt,
                     )
-                    if (st is None or st in EARLY_UPSERT_STATUSES) and trace_id:
-                        await _relink_after_final(
-                            client, simulation_result_id, body, key, trace_id, st
+                    if st is None:
+                        logger.warning(
+                            "linked without a final status — sim=%s may still be "
+                            "EVALUATING; if eval wipes trace_ids the link is lost "
+                            "(we do not re-post: a second POST double-counts tools)",
+                            simulation_result_id,
                         )
                     return
         except Exception as e:
@@ -386,83 +354,6 @@ async def post_simulation_enrichment(
 
 
 
-async def _relink_after_final(
-    client: httpx.AsyncClient,
-    simulation_result_id: str,
-    body: dict[str, Any],
-    key: str,
-    trace_id: str,
-    early_status: str | None,
-) -> None:
-    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link).
-
-    Only if it actually got wiped: each POST re-extracts the execute_tool spans and
-    appends them, so a redundant relink double-counts every tool on the timeline.
-    """
-    final: str | None = None
-    linked = False
-    deadline = time.monotonic() + 120.0
-    while time.monotonic() < deadline:
-        try:
-            r = await client.get(
-                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
-                headers={"X-API-Key": key},
-            )
-            if r.status_code == 200:
-                result = (r.json() or {}).get("simulation_result") or {}
-                st = str(result.get("status"))
-                if st in FINAL_STATUSES:
-                    final = st
-                    linked = trace_id in (result.get("trace_ids") or [])
-                    break
-        except Exception:
-            pass
-        await asyncio.sleep(2.0)
-    if final is not None and linked:
-        logger.info(
-            "relink not needed after %s — trace=%s still linked sim=%s final=%s",
-            early_status,
-            trace_id,
-            simulation_result_id,
-            final,
-        )
-        return
-    if final is None:
-        logger.warning(
-            "relink skipped — still not final after early upsert terminal=%s sim=%s",
-            early_status,
-            simulation_result_id,
-        )
-        return
-    r = await client.post(
-        f"{_api_url()}/update-simulation-result",
-        json=body,
-        headers={"X-API-Key": key, "Content-Type": "application/json"},
-    )
-    if r.status_code >= 400:
-        logger.error(
-            "relink after %s FAILED sim=%s %s %s",
-            early_status,
-            simulation_result_id,
-            r.status_code,
-            r.text[:300],
-        )
-    else:
-        logger.info(
-            "relink after %s ok trace=%s sim=%s final=%s",
-            early_status,
-            trace_id,
-            simulation_result_id,
-            final,
-        )
-
-# back-compat alias used by older call sites
-async def post_trace_ids(simulation_result_id: str, trace_id: str) -> None:
-    await post_simulation_enrichment(
-        simulation_result_id, trace_id=trace_id, tool_calls=_reported_tools.get()
-    )
-
-
 @asynccontextmanager
 async def traced_run(
     workflow_name: str,
@@ -471,7 +362,7 @@ async def traced_run(
     model: str | None = None,
 ) -> AsyncIterator[None]:
     """OTel voice.call root; flush + link trace_ids/tool_calls on exit."""
-    global _active_root, _active_t0, _active_tools
+    global _active_root, _active_t0
 
     provider = setup_otel()
     if provider is None:
@@ -492,13 +383,10 @@ async def traced_run(
 
     otel_tid: str | None = None
     root_token = None
-    tools_token = None
     t0 = time.monotonic()
     t0_token = _call_t0.set(t0)
-    tool_buf: list[dict[str, Any]] = []
     prev_active = _active_root
     prev_t0 = _active_t0
-    prev_tools = _active_tools
     try:
         with tracer.start_as_current_span(
             "voice.call",
@@ -506,10 +394,8 @@ async def traced_run(
             attributes=attrs,
         ) as root:
             root_token = _root_span.set(root)
-            tools_token = _reported_tools.set(tool_buf)
             _active_root = root
             _active_t0 = t0
-            _active_tools = tool_buf
             ctx = root.get_span_context()
             if ctx.is_valid:
                 otel_tid = format(ctx.trace_id, "032x")
@@ -530,14 +416,11 @@ async def traced_run(
     finally:
         _active_root = prev_active
         _active_t0 = prev_t0
-        _active_tools = prev_tools
         if root_token is not None:
             _root_span.reset(root_token)
-        if tools_token is not None:
-            _reported_tools.reset(tools_token)
         _call_t0.reset(t0_token)
         flush()
-        if simulation_result_id and (otel_tid or tool_buf):
+        if simulation_result_id and otel_tid:
             try:
                 await post_simulation_enrichment(
                     simulation_result_id,

--- a/voice-agent-harnesses/vapi/report.py
+++ b/voice-agent-harnesses/vapi/report.py
@@ -1,0 +1,556 @@
+"""OpenTelemetry → Bluejay OTLP for Vapi harnesses.
+
+Vapi has no Agents-SDK span tree, so we emit GenAI-native spans:
+
+  voice.call (root) — gen_ai.provider.name=vapi
+    ├── agent.speech          (bracketed by Vapi `speech-update` role=assistant)
+    ├── customer.speech       (from inbound Bluejay speech.started/completed)
+    └── execute_tool <name>   (gen_ai.tool.*; emitted by the /tool webhook)
+
+After the call we POST to update-simulation-result with:
+  - trace_ids  → waterfall flamegraph
+  Conversation tool markers come from execute_tool OTel spans (not a tool_calls POST).
+
+Chirp supplies simulation_result_id via X-Simulation-Result-Id on upgrade.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+from contextlib import asynccontextmanager, contextmanager
+from contextvars import ContextVar
+from typing import Any, AsyncIterator, Iterator
+
+import httpx
+from opentelemetry import trace as otel_trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.trace import Span, SpanKind, Status, StatusCode
+
+logger = logging.getLogger("mivas.otel.vapi")
+if not logger.handlers:
+    _h = logging.StreamHandler(sys.stdout)
+    _h.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+    logger.addHandler(_h)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+DEFAULT_OTLP_ENDPOINT = "https://otlp.getbluejay.ai/v1/traces"
+DEFAULT_API_URL = "https://api.getbluejay.ai/v1"
+FINAL_STATUSES = {
+    "COMPLETED",
+    "FAILED",
+    "SYSTEM_ERROR",
+    "NO_ANSWER",
+    "CANCELLED",
+    "NO_CONNECTION",
+}
+EARLY_UPSERT_STATUSES = {"EVALUATING", "EVALUATED", "CONVERSATION_ENDED"}
+PROVIDER = "vapi"
+TRACER_NAME = "mivas.vapi"
+
+_provider: TracerProvider | None = None
+_root_span: ContextVar[Span | None] = ContextVar("mivas_vapi_otel_root", default=None)
+_call_t0: ContextVar[float | None] = ContextVar("mivas_vapi_otel_t0", default=None)
+_reported_tools: ContextVar[list[dict[str, Any]] | None] = ContextVar(
+    "mivas_vapi_reported_tools", default=None
+)
+# module fallbacks when asyncio tasks don't inherit ContextVars
+_active_root: Span | None = None
+_active_t0: float | None = None
+_active_tools: list[dict[str, Any]] | None = None
+
+
+def _api_url() -> str:
+    return os.environ.get("BLUEJAY_API_URL", DEFAULT_API_URL).rstrip("/")
+
+
+def _otlp_endpoint() -> str:
+    return os.environ.get("BLUEJAY_OTLP_ENDPOINT", DEFAULT_OTLP_ENDPOINT)
+
+
+def _service_name() -> str:
+    return os.environ.get("BLUEJAY_SERVICE_NAME", "mivas-vapi")
+
+
+def _api_key() -> str | None:
+    return os.environ.get("BLUEJAY_API_KEY") or None
+
+
+def _json_attr(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, default=str)
+    except Exception:
+        return str(value)
+
+
+def call_offset_ms() -> int:
+    t0 = _call_t0.get()
+    if t0 is None:
+        t0 = _active_t0
+    if t0 is None:
+        return 0
+    return max(0, int((time.monotonic() - t0) * 1000))
+
+
+def setup_otel() -> TracerProvider | None:
+    """Install global OTel exporter to Bluejay OTLP. No-op without BLUEJAY_API_KEY."""
+    global _provider
+
+    api_key = _api_key()
+    if not api_key:
+        return None
+
+    if _provider is not None:
+        return _provider
+
+    endpoint = _otlp_endpoint()
+    resource = Resource.create({SERVICE_NAME: _service_name()})
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(
+        SimpleSpanProcessor(
+            OTLPSpanExporter(endpoint, headers={"X-API-KEY": api_key})
+        )
+    )
+    otel_trace.set_tracer_provider(provider)
+    _provider = provider
+    logger.info("otel → %s service=%s", endpoint, _service_name())
+    return provider
+
+
+def flush() -> None:
+    if _provider is not None:
+        try:
+            _provider.force_flush()
+        except Exception as e:
+            logger.error("otel flush failed: %s", e)
+
+
+def _parent_span() -> Span | None:
+    parent = _root_span.get()
+    if parent is not None and parent.get_span_context().is_valid:
+        return parent
+    if _active_root is not None and _active_root.get_span_context().is_valid:
+        return _active_root
+    cur = otel_trace.get_current_span()
+    if cur is not None and cur.get_span_context().is_valid:
+        return cur
+    return None
+
+
+def record_tool_call(
+    name: str,
+    parameters: Any,
+    output: Any,
+    *,
+    start_offset_ms: int | None = None,
+) -> None:
+    """Buffer a tool call for the end-of-call update-simulation-result POST."""
+    tools = _reported_tools.get()
+    if tools is None:
+        tools = _active_tools
+    if tools is None:
+        return
+    tools.append(
+        {
+            "name": str(name),
+            "parameters": parameters if isinstance(parameters, dict) else {"raw": parameters},
+            "output": output,
+            "start_offset_ms": int(
+                start_offset_ms if start_offset_ms is not None else call_offset_ms()
+            ),
+        }
+    )
+
+
+@contextmanager
+def tool_span(
+    name: str,
+    parameters: Any = None,
+    *,
+    call_id: str | None = None,
+) -> Iterator[Span | None]:
+    """Child span under the active voice.call root. No-op outside traced_run."""
+    parent = _parent_span()
+    if parent is None:
+        yield None
+        return
+
+    tracer = otel_trace.get_tracer(TRACER_NAME)
+    parent_ctx = otel_trace.set_span_in_context(parent)
+    attrs: dict[str, Any] = {
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.provider.name": PROVIDER,
+        "gen_ai.tool.name": name,
+        "gen_ai.tool.call.arguments": _json_attr(parameters if parameters is not None else {}),
+        # conversation timestamps come from span start vs voice.call (OTel extraction)
+    }
+    if call_id:
+        attrs["gen_ai.tool.call.id"] = str(call_id)
+
+    with tracer.start_as_current_span(
+        f"execute_tool {name}",
+        context=parent_ctx,
+        kind=SpanKind.CLIENT,
+        attributes=attrs,
+    ) as span:
+        try:
+            yield span
+        except Exception as e:
+            span.record_exception(e)
+            span.set_status(Status(StatusCode.ERROR, str(e)[:400]))
+            raise
+
+
+def finish_tool_span(
+    span: Span | None,
+    output: Any,
+    *,
+    ok: bool = True,
+    name: str | None = None,
+    parameters: Any = None,
+    start_offset_ms: int | None = None,
+) -> None:
+    if span is not None:
+        span.set_attribute("gen_ai.tool.call.result", _json_attr(output))
+        if ok:
+            span.set_status(Status(StatusCode.OK))
+        else:
+            span.set_status(Status(StatusCode.ERROR, _json_attr(output)[:400]))
+
+
+def start_speech_span(
+    utterance_id: str, *, speaker: str = "agent"
+) -> Span | None:
+    """Begin agent.speech or customer.speech under voice.call."""
+    parent = _parent_span()
+    if parent is None:
+        return None
+    tracer = otel_trace.get_tracer(TRACER_NAME)
+    parent_ctx = otel_trace.set_span_in_context(parent)
+    is_customer = speaker in ("customer", "user", "digital_human")
+    span_name = "customer.speech" if is_customer else "agent.speech"
+    attrs: dict[str, Any] = {
+        "gen_ai.operation.name": (
+            "speech_to_text" if is_customer else "text_to_speech"
+        ),
+        "gen_ai.provider.name": PROVIDER,
+        "mivas.utterance_id": str(utterance_id),
+        "mivas.speech.speaker": "customer" if is_customer else "agent",
+        "bluejay.speech.start_offset_ms": call_offset_ms(),
+    }
+    span = tracer.start_span(
+        span_name,
+        context=parent_ctx,
+        kind=SpanKind.INTERNAL,
+        attributes=attrs,
+    )
+    return span
+
+def end_speech_span(span: Span | None) -> None:
+    if span is None:
+        return
+    span.set_attribute("bluejay.speech.end_offset_ms", call_offset_ms())
+    span.set_status(Status(StatusCode.OK))
+    span.end()
+
+
+async def _await_terminal_upsert(
+    client: httpx.AsyncClient, simulation_result_id: str, timeout: float = 300.0
+) -> str | None:
+    """Wait for a *final* status before the upsert.
+
+    300 s, not 150 s: eval needs ~175 s to settle and anything shorter forces the
+    early-post + relink path below, which double-counts every tool.
+
+    Posting during EVALUATING works, but eval then wipes trace_ids and the relink
+    POST re-extracts the execute_tool spans on top of the ones the first POST
+    already produced — every tool lands on the timeline twice. One POST after the
+    sim settles gives a surviving link and one row per tool; `_relink_after_final`
+    stays as the safety net for when this wait times out.
+    """
+    deadline = time.monotonic() + timeout
+    key = _api_key()
+    if not key:
+        return None
+    while time.monotonic() < deadline:
+        try:
+            r = await client.get(
+                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                headers={"X-API-Key": key},
+            )
+            if r.status_code == 200:
+                st = str(
+                    ((r.json() or {}).get("simulation_result") or {}).get("status")
+                )
+                if st in FINAL_STATUSES:
+                    return st
+        except Exception:
+            pass
+        await asyncio.sleep(1.0)
+    return None
+
+
+async def post_simulation_enrichment(
+    simulation_result_id: str,
+    *,
+    trace_id: str | None,
+    tool_calls: list[dict[str, Any]] | None = None,
+) -> None:
+    """Link OTel trace_ids. tool_calls ignored — use execute_tool spans."""
+    del tool_calls
+    key = _api_key()
+    if not key or not simulation_result_id:
+        logger.warning(
+            "skip update-simulation-result — "
+            "simulation_result_id=%s key=%s",
+            simulation_result_id,
+            bool(key),
+        )
+        return
+    if not str(simulation_result_id).isdigit():
+        logger.warning(
+            "skip update-simulation-result — non-numeric sim id=%s",
+            simulation_result_id,
+        )
+        return
+
+    body: dict[str, Any] = {"simulation_result_id": str(simulation_result_id)}
+    if trace_id:
+        body["trace_ids"] = [trace_id]
+    if "trace_ids" not in body and "tool_calls" not in body:
+        logger.warning("skip update-simulation-result — nothing to post")
+        return
+
+    await asyncio.sleep(0.5)
+
+    last_err: str | None = None
+    for attempt in range(1, 4):
+        try:
+            async with httpx.AsyncClient(timeout=20) as client:
+                st = await _await_terminal_upsert(client, simulation_result_id)
+                if st is None:
+                    check = await client.get(
+                        f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                        headers={"X-API-Key": key},
+                    )
+                    if check.status_code == 404:
+                        logger.warning(
+                            "skip update-simulation-result — sim=%s not found",
+                            simulation_result_id,
+                        )
+                        return
+                r = await client.post(
+                    f"{_api_url()}/update-simulation-result",
+                    json=body,
+                    headers={"X-API-Key": key, "Content-Type": "application/json"},
+                )
+                if r.status_code >= 400:
+                    last_err = f"{r.status_code} {r.text[:300]} (status={st})"
+                    logger.error(
+                        "update-simulation-result FAILED attempt=%s %s",
+                        attempt,
+                        last_err,
+                    )
+                    if r.status_code == 404:
+                        return
+                else:
+                    logger.info(
+                        "update-simulation-result ok trace=%s sim=%s terminal=%s attempt=%s",
+                        trace_id,
+                        simulation_result_id,
+                        st,
+                        attempt,
+                    )
+                    if (st is None or st in EARLY_UPSERT_STATUSES) and trace_id:
+                        await _relink_after_final(
+                            client, simulation_result_id, body, key, trace_id, st
+                        )
+                    return
+        except Exception as e:
+            last_err = f"{type(e).__name__}: {e}"
+            logger.error(
+                "update-simulation-result error attempt=%s %s", attempt, last_err
+            )
+        await asyncio.sleep(1.0 * attempt)
+    logger.error("update-simulation-result gave up: %s", last_err)
+
+
+
+async def _relink_after_final(
+    client: httpx.AsyncClient,
+    simulation_result_id: str,
+    body: dict[str, Any],
+    key: str,
+    trace_id: str,
+    early_status: str | None,
+) -> None:
+    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link).
+
+    Only if it actually got wiped: each POST re-extracts the execute_tool spans and
+    appends them, so a redundant relink double-counts every tool on the timeline.
+    """
+    final: str | None = None
+    linked = False
+    deadline = time.monotonic() + 120.0
+    while time.monotonic() < deadline:
+        try:
+            r = await client.get(
+                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                headers={"X-API-Key": key},
+            )
+            if r.status_code == 200:
+                result = (r.json() or {}).get("simulation_result") or {}
+                st = str(result.get("status"))
+                if st in FINAL_STATUSES:
+                    final = st
+                    linked = trace_id in (result.get("trace_ids") or [])
+                    break
+        except Exception:
+            pass
+        await asyncio.sleep(2.0)
+    if final is not None and linked:
+        logger.info(
+            "relink not needed after %s — trace=%s still linked sim=%s final=%s",
+            early_status,
+            trace_id,
+            simulation_result_id,
+            final,
+        )
+        return
+    if final is None:
+        logger.warning(
+            "relink skipped — still not final after early upsert terminal=%s sim=%s",
+            early_status,
+            simulation_result_id,
+        )
+        return
+    r = await client.post(
+        f"{_api_url()}/update-simulation-result",
+        json=body,
+        headers={"X-API-Key": key, "Content-Type": "application/json"},
+    )
+    if r.status_code >= 400:
+        logger.error(
+            "relink after %s FAILED sim=%s %s %s",
+            early_status,
+            simulation_result_id,
+            r.status_code,
+            r.text[:300],
+        )
+    else:
+        logger.info(
+            "relink after %s ok trace=%s sim=%s final=%s",
+            early_status,
+            trace_id,
+            simulation_result_id,
+            final,
+        )
+
+# back-compat alias used by older call sites
+async def post_trace_ids(simulation_result_id: str, trace_id: str) -> None:
+    await post_simulation_enrichment(
+        simulation_result_id, trace_id=trace_id, tool_calls=_reported_tools.get()
+    )
+
+
+@asynccontextmanager
+async def traced_run(
+    workflow_name: str,
+    *,
+    simulation_result_id: str | None = None,
+    model: str | None = None,
+) -> AsyncIterator[None]:
+    """OTel voice.call root; flush + link trace_ids/tool_calls on exit."""
+    global _active_root, _active_t0, _active_tools
+
+    provider = setup_otel()
+    if provider is None:
+        yield
+        return
+
+    tracer = otel_trace.get_tracer(TRACER_NAME)
+    attrs: dict[str, Any] = {
+        "gen_ai.system": PROVIDER,
+        "gen_ai.provider.name": PROVIDER,
+        "gen_ai.operation.name": "invoke_agent",
+        "mivas.workflow.name": workflow_name,
+    }
+    if model:
+        attrs["gen_ai.request.model"] = model
+    if simulation_result_id:
+        attrs["bluejay.simulation_result_id"] = str(simulation_result_id)
+
+    otel_tid: str | None = None
+    root_token = None
+    tools_token = None
+    t0 = time.monotonic()
+    t0_token = _call_t0.set(t0)
+    tool_buf: list[dict[str, Any]] = []
+    prev_active = _active_root
+    prev_t0 = _active_t0
+    prev_tools = _active_tools
+    try:
+        with tracer.start_as_current_span(
+            "voice.call",
+            kind=SpanKind.SERVER,
+            attributes=attrs,
+        ) as root:
+            root_token = _root_span.set(root)
+            tools_token = _reported_tools.set(tool_buf)
+            _active_root = root
+            _active_t0 = t0
+            _active_tools = tool_buf
+            ctx = root.get_span_context()
+            if ctx.is_valid:
+                otel_tid = format(ctx.trace_id, "032x")
+                logger.info(
+                    "otel trace_id=%s sim=%s workflow=%s model=%s",
+                    otel_tid,
+                    simulation_result_id,
+                    workflow_name,
+                    model,
+                )
+            try:
+                yield
+            except Exception as e:
+                if type(e).__name__.startswith("ConnectionClosed"):
+                    root.set_status(Status(StatusCode.OK))
+                else:
+                    raise
+    finally:
+        _active_root = prev_active
+        _active_t0 = prev_t0
+        _active_tools = prev_tools
+        if root_token is not None:
+            _root_span.reset(root_token)
+        if tools_token is not None:
+            _reported_tools.reset(tools_token)
+        _call_t0.reset(t0_token)
+        flush()
+        if simulation_result_id and (otel_tid or tool_buf):
+            try:
+                await post_simulation_enrichment(
+                    simulation_result_id,
+                    trace_id=otel_tid,
+                                    )
+            except Exception as e:
+                logger.error(
+                    "post_simulation_enrichment crashed: %s: %s",
+                    type(e).__name__,
+                    e,
+                )
+        elif simulation_result_id and not otel_tid:
+            logger.error(
+                "have simulation_result_id=%s but no otel trace id to post",
+                simulation_result_id,
+            )

--- a/voice-agent-harnesses/vapi/requirements.txt
+++ b/voice-agent-harnesses/vapi/requirements.txt
@@ -1,0 +1,9 @@
+# Pack deps for Docker (`uv pip install -r`). Local root uses `uv sync` via pyproject.toml.
+httpx>=0.27.0
+websockets>=14.0
+# chirp serves the CHIRP socket and Vapi's tool webhook from one FastAPI app
+fastapi>=0.115.0
+uvicorn>=0.32.0
+opentelemetry-api>=1.27.0
+opentelemetry-sdk>=1.27.0
+opentelemetry-exporter-otlp-proto-http>=1.27.0


### PR DESCRIPTION
Adds six voice-agent harnesses — ten runtimes in total — each proven end to end against
`control-industry` on Bluejay.

## Harnesses

| harness | runtimes | multi-agent |
|---|---|---|
| `vapi/` | flux + gpt-4.1 + flash v2.5 | squad + handoff tool |
| `retell/` | gpt-4.1 + flash v2.5 (Deepgram STT) | retell-llm `states` + edges |
| `bland/` | in-house `base` | conversational pathway, webhook nodes |
| `cartesia/` | Line | Line handoff tools |
| `livekit/` | cascaded, `gpt-realtime-2.1`, `gemini-3.1-flash-live-preview` | LiveKit Agents handoff |
| `pipecat/` | cascaded, `gpt-realtime-2.1`, `gemini-3.1-flash-live-preview` | soft handoff (Flows can't do S2S) |

They split into two shapes. **Platform agents** (Vapi, Retell, Bland, Cartesia) host the
agent, so tools execute provider-side: each bridge serves the CHIRP websocket and a
`/tool/{name}` webhook on one port behind a single tunnel, and that webhook produces the
`execute_tool` spans. **Frameworks** (LiveKit, Pipecat) run our code, so tools execute
in-process and Bluejay dispatches them through its native connection types instead of CHIRP.

## Proof runs

Each `COMPLETED`, `goal_success: true`, linked trace, one actual per expected tool, ordered
interleaved spans at real offsets, audio both directions.

| harness / runtime | run |
|---|---|
| vapi | [30208/runs/224727](https://app.getbluejay.ai/simulations/30208/runs/224727) |
| retell | [30209/runs/224729](https://app.getbluejay.ai/simulations/30209/runs/224729) |
| bland | [30211/runs/224728](https://app.getbluejay.ai/simulations/30211/runs/224728) |
| cartesia | [30210/runs/224730](https://app.getbluejay.ai/simulations/30210/runs/224730) |
| livekit cascaded | [30223/runs/224783](https://app.getbluejay.ai/simulations/30223/runs/224783) |
| livekit realtime 2.1 | [30224/runs/224784](https://app.getbluejay.ai/simulations/30224/runs/224784) |
| livekit gemini live 3.1 | [30225/runs/224785](https://app.getbluejay.ai/simulations/30225/runs/224785) |
| pipecat cascaded | [30227/runs/225122](https://app.getbluejay.ai/simulations/30227/runs/225122) |
| pipecat realtime 2.1 | [30228/runs/225121](https://app.getbluejay.ai/simulations/30228/runs/225121) |
| pipecat gemini live 3.1 | [30229/runs/225123](https://app.getbluejay.ai/simulations/30229/runs/225123) |

The digital humans declare `expected_tool_calls`, so each result pairs `expected` against
`actual` per tool — that pairing is what catches a handoff that silently never fired.

## Reporting contract

Every `report.py` waits for a **final** simulation status before a single POST of
`trace_ids`. Posting during `EVALUATING` and relinking afterwards makes Bluejay re-extract
the `execute_tool` spans and append them, so every tool lands twice. It presents as flaky
rather than constant because it depends on whether the relink beats eval. Never POST
`tool_calls` alongside the spans.

## Provider limits documented rather than worked around

- **Retell has no STT model field** (`custom_stt_config` is provider + `endpointing_ms`), so
  Flux is unreachable and it runs plain Deepgram. Retell and Vapi are matched on LLM and TTS
  but not STT.
- **Retell's state transition and `end_call` run inside Retell**, so they're backfilled from
  its call record at hangup with `mivas.provider.tool_name` preserving the original name.
- **Gemini 3.1 Live disables mutable instructions/context/tools** in the LiveKit plugin, so
  that runtime uses one combined agent with a soft handoff, plus a TTS purely for the greeting.
- **Pipecat Flows requires a text LLM with function calling**, so its two speech-to-speech
  runtimes use a soft handoff; all three share it to stay comparable.
- **Pipecat `end_call`** must not tear the pipeline down immediately — a realtime model only
  generates its farewell after seeing the tool result. See the per-commit notes.

## Not included

The internal integration handoff doc now lives in a gitignored `docs/` folder.