### PR TITLE
Fix three regressions found by the full-harness regression pass

### DIFF
--- a/voice-agent-harnesses/bland/README.md
+++ b/voice-agent-harnesses/bland/README.md
@@ -57,9 +57,19 @@ Iterate on routing with Bland's text-chat endpoint (`POST /v1/pathway/chat/creat
 `POST /v1/pathway/chat/{chat_id}` with `{message}`) — it returns `current_node_id`, so a
 routing bug is one HTTP call away instead of one voice call away.
 
-The industry prompts tell the agent to *call* `handoff_to_scheduler`; a pathway node has
-no tools, so `harness.PATHWAY_NOTE` is appended to each node prompt. Without it the model
-reads the tool name out loud ("handoff underscore to scheduler") and stays put.
+The industry prompts tell the agent to *call* `handoff_to_scheduler` /
+`schedule_appointment`, but a Default node has no tools bound — the tools are the Webhook
+nodes and the routing is the edge descriptions. The only way the model can obey a "call
+this tool" instruction is to put the call in the one channel it does have, its dialogue,
+and Bland's TTS then reads that out: bare `handoff_to_scheduler`, or
+`<tool_call>schedule_appointment</tool_call>` mid-sentence after "I'll go ahead and book
+that for you now" (heard in run 713481, transcribed back by Bluejay's STT as
+"ToolappointmentToolAccall"). So `harness._strip_tool_instructions` drops every prompt
+sentence that names a blueprint tool, along with any heading left empty, before
+`PATHWAY_NOTE` is appended; the note now only covers the surrounding narration. Nothing is
+lost — the sentences it removes are duplicated by the edge descriptions, which are what
+actually route. Measured over the text-chat endpoint: 2 leaks in 3 scripted bookings
+before, 0 in 8 after. `base/agent.py --check` asserts no node prompt contains a tool name.
 
 ## Transport
 
@@ -120,11 +130,12 @@ Smoke without Bluejay: `uv run python voice-agent-harnesses/bland/base/agent.py 
 ## Proof run
 
 control-industry, agent **30387** / sim **30211** / DH **194138** →
-result **710642** at
-[simulations/30211/runs/224728](https://app.getbluejay.ai/simulations/30211/runs/224728) — `COMPLETED`,
+result **713651** at
+[simulations/30211/runs/225457](https://app.getbluejay.ai/simulations/30211/runs/225457) — `COMPLETED`,
 `goal_success: true`, both tools once each and both matched against the DH's
-`expected_tool_calls` (`handoff_to_scheduler` @16.4 s, `schedule_appointment`
-`{date: "08/18/2026"}` @27.2 s), clean turn-taking with no overlap.
+`expected_tool_calls` (`handoff_to_scheduler` @16.1 s, `schedule_appointment`
+`{date: "08/18/2026"}` @38.2 s), no tool syntax anywhere in the transcript,
+0 interruptions either way, `pronunciation: 5`, `agent_audio_clarity: 100`.
 
 The start node greets, which is what the industry prompt requires, so this assumes a
 digital human that does **not** speak first. With `speaks_first` the two openers collide

--- a/voice-agent-harnesses/bland/base/agent.py
+++ b/voice-agent-harnesses/bland/base/agent.py
@@ -25,8 +25,7 @@ def check(industry: str) -> None:
     bp = load_blueprint(industry)
     graph = pathway_graph(bp, "https://example.test")
     nodes = {n["id"]: n for n in graph["nodes"]}
-    # A Default node has no tools bound, so a prompt that tells the model to call one is
-    # only satisfiable by speaking the tool syntax ("<tool_call>schedule_appointment…").
+    # A Default node has no tools bound, so a prompt naming one gets read out loud.
     for nid in ("receptionist", "scheduler"):
         prompt = nodes[nid]["data"]["prompt"]
         assert not any(tool in prompt for tool in bp["catalog"]), prompt

--- a/voice-agent-harnesses/bland/base/agent.py
+++ b/voice-agent-harnesses/bland/base/agent.py
@@ -22,8 +22,14 @@ from harness import ensure_agent, load_blueprint, pathway_graph, session_ws_url 
 
 
 def check(industry: str) -> None:
-    graph = pathway_graph(load_blueprint(industry), "https://example.test")
+    bp = load_blueprint(industry)
+    graph = pathway_graph(bp, "https://example.test")
     nodes = {n["id"]: n for n in graph["nodes"]}
+    # A Default node has no tools bound, so a prompt that tells the model to call one is
+    # only satisfiable by speaking the tool syntax ("<tool_call>schedule_appointment…").
+    for nid in ("receptionist", "scheduler"):
+        prompt = nodes[nid]["data"]["prompt"]
+        assert not any(tool in prompt for tool in bp["catalog"]), prompt
     assert nodes["receptionist"]["data"]["isStart"], "receptionist must be the start node"
     assert nodes["end"]["type"] == "End Call"
     for nid, tool in (("handoff", "handoff_to_scheduler"), ("book", "schedule_appointment")):

--- a/voice-agent-harnesses/bland/harness.py
+++ b/voice-agent-harnesses/bland/harness.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import json
 import os
+import re
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
@@ -84,20 +86,44 @@ def _headers() -> dict[str, str]:
     return {"authorization": _api_key(), "Content-Type": "application/json"}
 
 
-# The industry prompts tell the agent to *call* handoff_to_scheduler / schedule_appointment.
-# A pathway node has no tools — those are edges — so without this note the model reads the
-# tool name out loud ("handoff underscore to scheduler") and never leaves the node.
+# A pathway Default node has no tools bound — tools are Webhook nodes and handoffs are
+# edges — so any prompt sentence that tells the model to *call* one is an instruction it
+# can only satisfy by emitting tool syntax into its dialogue, which Bland's TTS then reads
+# out ("<tool_call>schedule_appointment</tool_call>", "handoff underscore to scheduler").
+# The pathway routes on the edge descriptions, so those sentences are redundant as well as
+# harmful: strip them, and keep the note for the surrounding narration only.
 PATHWAY_NOTE = """
 
 # Bland pathway
-Tools and handoffs are edges in this pathway, not functions you call. Never say a tool
-name out loud and never announce a transfer or that you are looking something up — say
-your line, and the pathway moves you on by itself.
+Never announce a transfer or that you are looking something up, and never read out any
+name written in snake_case — say your line, and the pathway moves you on by itself.
 """
 
+_SENTENCE = re.compile(r"(?<=[.!?])\s+")
 
-def _adapt_prompt(instructions: str) -> str:
-    return instructions.rstrip() + PATHWAY_NOTE
+
+def _strip_tool_instructions(instructions: str, tool_names: Iterable[str]) -> str:
+    """Drop every sentence that names a blueprint tool, then any heading left empty."""
+    named = re.compile("|".join(re.escape(name) for name in tool_names))
+    kept = []
+    for line in instructions.splitlines():
+        if line.strip():
+            line = " ".join(s for s in _SENTENCE.split(line) if not named.search(s))
+            if not line.strip():
+                continue
+        kept.append(line)
+    body = []
+    for i, line in enumerate(kept):
+        if line.startswith("#"):
+            after = [x for x in kept[i + 1 :] if x.strip()]
+            if not after or after[0].startswith("#"):
+                continue
+        body.append(line)
+    return "\n".join(body).rstrip()
+
+
+def _adapt_prompt(instructions: str, tool_names: Iterable[str]) -> str:
+    return _strip_tool_instructions(instructions, tool_names) + PATHWAY_NOTE
 
 
 def _model_options() -> dict[str, Any]:
@@ -191,7 +217,7 @@ def pathway_graph(bp: dict[str, Any], public_url: str) -> dict[str, Any]:
             "type": "Default",
             "data": {
                 "name": start["name"],
-                "prompt": _adapt_prompt(start["instructions"]),
+                "prompt": _adapt_prompt(start["instructions"], bp["catalog"]),
                 "isStart": True,
                 "modelOptions": _model_options(),
             },
@@ -207,7 +233,7 @@ def pathway_graph(bp: dict[str, Any], public_url: str) -> dict[str, Any]:
             "type": "Default",
             "data": {
                 "name": target["name"],
-                "prompt": _adapt_prompt(target["instructions"]),
+                "prompt": _adapt_prompt(target["instructions"], bp["catalog"]),
                 "modelOptions": _model_options(),
             },
         },

--- a/voice-agent-harnesses/check_call_sites.py
+++ b/voice-agent-harnesses/check_call_sites.py
@@ -1,0 +1,59 @@
+"""Assert every report.py call site matches its own harness's signature.
+
+Each harness owns its own report.py, so a signature change there has to be made
+in that folder's callers too. A regex sweep missed a multi-line
+`finish_tool_span(span, ..., name=..., parameters=...)` in vapi/adapters/chirp.py
+and shipped a harness that died on its first server-side tool call — the runtime
+smoke only exercised harness.run_tool, never the adapter path.
+
+    uv run python voice-agent-harnesses/check_call_sites.py
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parent
+CHECKED = ("finish_tool_span", "tool_span", "start_speech_span", "record_past_tool_span")
+
+
+def signatures(report: pathlib.Path) -> dict[str, set[str]]:
+    """Keyword names each checked function in this harness's report.py accepts."""
+    out: dict[str, set[str]] = {}
+    for node in ast.parse(report.read_text()).body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name in CHECKED:
+            a = node.args
+            out[node.name] = {x.arg for x in (*a.args, *a.posonlyargs, *a.kwonlyargs)}
+    return out
+
+
+def main() -> int:
+    bad: list[str] = []
+    for report in sorted(ROOT.glob("*/report.py")):
+        harness = report.parent
+        sigs = signatures(report)
+        for py in harness.rglob("*.py"):
+            if py == report or ".venv" in py.parts or "__pycache__" in py.parts:
+                continue
+            for call in ast.walk(ast.parse(py.read_text())):
+                if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Name):
+                    continue
+                accepted = sigs.get(call.func.id)
+                if accepted is None:
+                    continue
+                for kw in call.keywords:
+                    if kw.arg and kw.arg not in accepted:
+                        bad.append(
+                            f"{py.relative_to(ROOT)}:{call.lineno} "
+                            f"{call.func.id}(… {kw.arg}=…) — not in {sorted(accepted)}"
+                        )
+    for line in bad:
+        print(f"FAIL {line}")
+    print(f"{'FAILED' if bad else 'ok'} — {len(bad)} bad call site(s)")
+    return 1 if bad else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/voice-agent-harnesses/check_call_sites.py
+++ b/voice-agent-harnesses/check_call_sites.py
@@ -1,59 +1,45 @@
 """Assert every report.py call site matches its own harness's signature.
 
-Each harness owns its own report.py, so a signature change there has to be made
-in that folder's callers too. A regex sweep missed a multi-line
-`finish_tool_span(span, ..., name=..., parameters=...)` in vapi/adapters/chirp.py
-and shipped a harness that died on its first server-side tool call — the runtime
-smoke only exercised harness.run_tool, never the adapter path.
+Each harness owns its own report.py, so a signature change there has to be made in
+that folder's callers too. A regex sweep missed a multi-line
+`finish_tool_span(span, ..., name=..., parameters=...)` in vapi/adapters/chirp.py and
+shipped a harness that died on its first server-side tool call — the runtime smoke
+only exercised harness.run_tool, never the adapter path.
 
-    uv run python voice-agent-harnesses/check_call_sites.py
+    python3 voice-agent-harnesses/check_call_sites.py
 """
-
-from __future__ import annotations
 
 import ast
 import pathlib
 import sys
 
 ROOT = pathlib.Path(__file__).resolve().parent
-CHECKED = ("finish_tool_span", "tool_span", "start_speech_span", "record_past_tool_span")
+bad = []
 
-
-def signatures(report: pathlib.Path) -> dict[str, set[str]]:
-    """Keyword names each checked function in this harness's report.py accepts."""
-    out: dict[str, set[str]] = {}
-    for node in ast.parse(report.read_text()).body:
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name in CHECKED:
-            a = node.args
-            out[node.name] = {x.arg for x in (*a.args, *a.posonlyargs, *a.kwonlyargs)}
-    return out
-
-
-def main() -> int:
-    bad: list[str] = []
-    for report in sorted(ROOT.glob("*/report.py")):
-        harness = report.parent
-        sigs = signatures(report)
-        for py in harness.rglob("*.py"):
-            if py == report or ".venv" in py.parts or "__pycache__" in py.parts:
+for report in sorted(ROOT.glob("*/report.py")):
+    # keywords each function in *this* harness's report.py accepts (**kwargs takes any)
+    sigs = {
+        fn.name: {a.arg for a in (*fn.args.posonlyargs, *fn.args.args, *fn.args.kwonlyargs)}
+        for fn in ast.parse(report.read_text()).body
+        if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)) and not fn.args.kwarg
+    }
+    for py in report.parent.rglob("*.py"):
+        if py == report or {".venv", "__pycache__"} & set(py.parts):
+            continue
+        for call in ast.walk(ast.parse(py.read_text())):
+            if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Name):
                 continue
-            for call in ast.walk(ast.parse(py.read_text())):
-                if not isinstance(call, ast.Call) or not isinstance(call.func, ast.Name):
-                    continue
-                accepted = sigs.get(call.func.id)
-                if accepted is None:
-                    continue
-                for kw in call.keywords:
-                    if kw.arg and kw.arg not in accepted:
-                        bad.append(
-                            f"{py.relative_to(ROOT)}:{call.lineno} "
-                            f"{call.func.id}(… {kw.arg}=…) — not in {sorted(accepted)}"
-                        )
-    for line in bad:
-        print(f"FAIL {line}")
-    print(f"{'FAILED' if bad else 'ok'} — {len(bad)} bad call site(s)")
-    return 1 if bad else 0
+            accepted = sigs.get(call.func.id)
+            if accepted is None:
+                continue
+            bad += [
+                f"FAIL {py.relative_to(ROOT)}:{call.lineno} {call.func.id}(… {kw.arg}=…)"
+                f" — not in {sorted(accepted)}"
+                for kw in call.keywords
+                if kw.arg and kw.arg not in accepted
+            ]
 
-
-if __name__ == "__main__":
-    sys.exit(main())
+for line in bad:
+    print(line)
+print(f"{'FAILED' if bad else 'ok'} — {len(bad)} bad call site(s)")
+sys.exit(1 if bad else 0)

--- a/voice-agent-harnesses/elevenlabs/adapters/chirp.py
+++ b/voice-agent-harnesses/elevenlabs/adapters/chirp.py
@@ -180,31 +180,27 @@ async def _bridge(ws, model: str, industry: str) -> None:
                                     }
                                 )
                             )
-                        elif etype in ("agent_tool_response", "agent_tool_request"):
-                            # system tools (transfer_to_agent / end_call) never hit
-                            # client_tool_call — emit an execute_tool span so Bluejay
-                            # can place them on the conversation + waterfall.
-                            payload = (
-                                event.get("agent_tool_response")
-                                or event.get("agent_tool_request")
-                                or {}
-                            )
-                            tool_name = payload.get("tool_name") or etype
-                            params = dict(
-                                payload.get("tool_details")
-                                or payload.get("parameters")
-                                or {}
-                            )
-                            print(f"chirp elevenlabs {etype}: {tool_name}", flush=True)
-                            if etype == "agent_tool_response" and tool_name in {
-                                "transfer_to_agent",
-                                "end_call",
-                            }:
-                                with tool_span(tool_name, params) as span:
+                        elif etype == "agent_tool_response":
+                            # System tools (transfer_to_agent / end_call) run server-side
+                            # and never hit client_tool_call — this is the only event that
+                            # exposes them, so emit an execute_tool span for Bluejay.
+                            # Payload is identity + outcome only (tool_name, tool_call_id,
+                            # tool_type, is_error, is_called, is_blocked) — no arguments.
+                            # Client tools are skipped: run_tool already spans those.
+                            payload = event.get("agent_tool_response") or {}
+                            tool_name = payload.get("tool_name")
+                            print(f"chirp elevenlabs agent_tool_response {payload}", flush=True)
+                            fired = payload.get("is_called", True) and not payload.get("is_blocked")
+                            if fired and tool_name in ("transfer_to_agent", "end_call"):
+                                ok = not payload.get("is_error")
+                                params = {"tool_type": payload.get("tool_type", "system")}
+                                with tool_span(
+                                    tool_name, params, call_id=payload.get("tool_call_id")
+                                ) as span:
                                     finish_tool_span(
                                         span,
-                                        {"success": True, "source": "elevenlabs_system_tool"},
-                                        ok=True,
+                                        {"success": ok, "source": "elevenlabs_system_tool"},
+                                        ok=ok,
                                         name=tool_name,
                                         parameters=params,
                                     )

--- a/voice-agent-harnesses/elevenlabs/harness.py
+++ b/voice-agent-harnesses/elevenlabs/harness.py
@@ -45,6 +45,10 @@ CLIENT_EVENTS = [
     "agent_response",
     "agent_response_correction",
     "client_tool_call",
+    # server-side system tools (transfer_to_agent / end_call) never arrive as a
+    # `client_tool_call`; `agent_tool_response` is the only way to see them.
+    # Response only, not `agent_tool_request` — one event per tool, no double-count.
+    "agent_tool_response",
     "agent_response_complete",
     "client_error",
     "guardrail_triggered",
@@ -142,13 +146,17 @@ def _transfer_condition(bp: dict[str, Any], handoff_tool_name: str, target_name:
 def _adapt_prompt(prompt: str, *, handoff_tool_name: str | None = None) -> str:
     """rewrite industry handoff tool names to ElevenLabs' transfer_to_agent system tool."""
     text = prompt
-    if handoff_tool_name and handoff_tool_name != "transfer_to_agent":
+    if not handoff_tool_name:
+        # no transfer tool on this agent (scheduler / single-agent industry) — the
+        # note would tell it to use a tool it doesn't have.
+        return text
+    if handoff_tool_name != "transfer_to_agent":
         text = text.replace(f"`{handoff_tool_name}`", "`transfer_to_agent`")
         text = text.replace(handoff_tool_name, "transfer_to_agent")
     note = (
         "\n\n# ElevenLabs multi-agent\n"
-        "Use the `transfer_to_agent` system tool for handoffs (agent_number 0 = scheduler). "
-        "Do not invent a handoff_to_* client tool.\n"
+        "Use the `transfer_to_agent` system tool for handoffs. It takes no arguments — "
+        "the destination is preconfigured. Do not invent a handoff_to_* client tool.\n"
     )
     if "ElevenLabs multi-agent" not in text:
         text = text.rstrip() + note

--- a/voice-agent-harnesses/livekit/README.md
+++ b/voice-agent-harnesses/livekit/README.md
@@ -91,16 +91,14 @@ actual per expected tool (`handoff_to_scheduler`, `schedule_appointment`).
 
 * **Hanging up waits for silence, not a fixed delay.** `end_call` only marks the
   *intent* to hang up; the goodbye is still playing. `await_farewell` polls
-  `AgentSession.agent_state` and deletes the room once the agent has been neither
-  `speaking` nor `thinking` for `HANGUP_QUIET_S` (4 s), capped at
-  `HANGUP_MAX_WAIT_S` (20 s). The old flat 4 s sleep clipped all three runtimes and
-  broke `gpt-realtime-2.1` outright: it calls `end_call` in the same response turn as
-  `schedule_appointment`, so the room went away mid-sentence ("…scheduled for
-  eighteighteentwenty", 713478/713612/713652), the caller never heard a goodbye,
-  never hung up, and the run burned the full 180 s cap. `thinking` matters as much as
-  `speaking` — the gap between the tool result and the farewell audio is where a
-  single `speaking` check fires early (713652). The three proof runs above waited
-  6.3 s, 14.3 s and 7.5 s respectively.
+  `AgentSession.agent_state` and deletes the room after `HANGUP_QUIET_S` (4 s) of
+  neither `speaking` nor `thinking`, capped at `HANGUP_MAX_WAIT_S` (20 s). The old flat
+  4 s sleep clipped all three runtimes and broke `gpt-realtime-2.1` outright: it calls
+  `end_call` in the same response turn as `schedule_appointment`, so the room went away
+  mid-sentence (713478/713612/713652), the caller never heard a goodbye, never hung up,
+  and the run burned the full 180 s cap. `thinking` counts as busy too: the gap before
+  the farewell audio is where a `speaking`-only check fires early (713652). The three
+  proof runs above waited 6.3 s, 14.3 s and 7.5 s.
 * **Job executor is THREAD, not PROCESS.** `spawn` pickles the entrypoint by
   reference and ours is a closure over the runtime's session/agent factories.
 * **The trace-linking POST lives in the entrypoint**, not a shutdown callback:

--- a/voice-agent-harnesses/livekit/README.md
+++ b/voice-agent-harnesses/livekit/README.md
@@ -81,14 +81,26 @@ which includes the ~2 min the simulation can linger after we hang up.
 All three `COMPLETED` with `goal_success: true`, a linked `trace_ids`, and exactly one
 actual per expected tool (`handoff_to_scheduler`, `schedule_appointment`).
 
-| runtime | agent | sim | run | result | link |
-| --- | --- | --- | --- | --- | --- |
-| cascaded | 30519 | 30223 | 225189 | 712620 | https://app.getbluejay.ai/simulations/30223/runs/225189 |
-| openai-realtime-2.1 | 30520 | 30224 | 225198 | 712629 | https://app.getbluejay.ai/simulations/30224/runs/225198 |
-| gemini-flash-live-3.1 | 30521 | 30225 | 225188 | 712619 | https://app.getbluejay.ai/simulations/30225/runs/225188 |
+| runtime | agent | sim | run | result | duration | `end_call` | link |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| cascaded | 30519 | 30223 | 225463 | 713666 | 82 s | 81.6 s | https://app.getbluejay.ai/simulations/30223/runs/225463 |
+| openai-realtime-2.1 | 30520 | 30224 | 225462 | 713665 | 58 s | 39.5 s | https://app.getbluejay.ai/simulations/30224/runs/225462 |
+| gemini-flash-live-3.1 | 30521 | 30225 | 225464 | 713667 | 52 s | 39.8 s | https://app.getbluejay.ai/simulations/30225/runs/225464 |
 
 ## Runtime notes
 
+* **Hanging up waits for silence, not a fixed delay.** `end_call` only marks the
+  *intent* to hang up; the goodbye is still playing. `await_farewell` polls
+  `AgentSession.agent_state` and deletes the room once the agent has been neither
+  `speaking` nor `thinking` for `HANGUP_QUIET_S` (4 s), capped at
+  `HANGUP_MAX_WAIT_S` (20 s). The old flat 4 s sleep clipped all three runtimes and
+  broke `gpt-realtime-2.1` outright: it calls `end_call` in the same response turn as
+  `schedule_appointment`, so the room went away mid-sentence ("…scheduled for
+  eighteighteentwenty", 713478/713612/713652), the caller never heard a goodbye,
+  never hung up, and the run burned the full 180 s cap. `thinking` matters as much as
+  `speaking` — the gap between the tool result and the farewell audio is where a
+  single `speaking` check fires early (713652). The three proof runs above waited
+  6.3 s, 14.3 s and 7.5 s respectively.
 * **Job executor is THREAD, not PROCESS.** `spawn` pickles the entrypoint by
   reference and ours is a closure over the runtime's session/agent factories.
 * **The trace-linking POST lives in the entrypoint**, not a shutdown callback:

--- a/voice-agent-harnesses/livekit/harness.py
+++ b/voice-agent-harnesses/livekit/harness.py
@@ -54,23 +54,12 @@ GREETING = "Welcome to Bluejay's Repair Services!"
 # step 1 of system-prompts/scheduler.md, verbatim. Only used by runtimes whose model
 # rejects generate_reply() (see Scheduler.on_enter); every other turn is model-generated.
 SCHEDULER_OPENER = "Hey, when do you want to schedule your repair appointment?"
-# How long the agent must be *quiet* after `end_call` before we tear the room down.
-# This used to be a flat sleep, which was enough for cascaded/Gemini (they finish the
-# farewell and the caller hangs up first) but not for gpt-realtime-2.1: it calls
-# `end_call` in the same response turn as `schedule_appointment` (2.6-2.9 s apart)
-# while still speaking, so a fixed 4 s deleted the room mid-sentence — the transcript
-# cut at "scheduled for eighteighteentwenty" (713478/713612) and at "Your repair
-# appointment is scheduled for" (713652). The digital human never heard a goodbye,
-# never hung up, and the run burned the full 180 s cap. The timer now *restarts*
-# whenever the agent is speaking or generating, so it measures 4 s of silence rather
-# than 4 s of wall clock; a model with nothing left to say still waits exactly 4 s.
+# Seconds of *silence* the agent must reach after `end_call` before we tear the room
+# down. This was a flat sleep, which deleted the room mid-farewell on gpt-realtime-2.1
+# (see README "Hanging up waits for silence"). Same env knobs as the pipecat harness.
 HANGUP_QUIET_S = float(os.environ.get("MIVAS_END_CALL_CLOSE_DELAY_S", "4.0"))
 # hard cap so a model that never stops talking cannot hold the room forever
 HANGUP_MAX_WAIT_S = float(os.environ.get("MIVAS_END_CALL_MAX_WAIT_S", "20.0"))
-# States where the agent still owes us audio. "thinking" is the gap between the
-# end_call tool result and the farewell audio starting — exactly where a check that
-# only looked for "speaking" fires early (713652 cut 1.7 s into that gap).
-AGENT_BUSY_STATES = ("thinking", "speaking")
 
 
 # ── blueprint ────────────────────────────────────────────────────────────────
@@ -268,26 +257,21 @@ def sim_result_id_from_job_metadata(raw: Any) -> str | None:
 async def await_farewell(session: AgentSession, disconnected: asyncio.Event) -> None:
     """Hold the room until the agent has gone quiet for HANGUP_QUIET_S.
 
-    `AgentSession.agent_state` is the same signal `wire_speech_spans` brackets
-    `agent.speech` on, polled rather than subscribed: the farewell can start at any
-    point in this window and an edge-triggered wait would miss the transition. The
-    quiet timer restarts on every busy sample, so a pause between the confirmation
-    and the goodbye does not count as "done talking".
+    Polled, not edge-triggered: the farewell can start anywhere in this window and a
+    one-shot wait would miss the transition. The quiet timer restarts on every busy
+    sample, so the pause before the goodbye does not count as "done talking".
     """
     loop = asyncio.get_running_loop()
-    deadline = loop.time() + HANGUP_MAX_WAIT_S
-    quiet_since = loop.time()
-    while not disconnected.is_set() and loop.time() < deadline:
-        if session.agent_state in AGENT_BUSY_STATES:
+    t0 = quiet_since = loop.time()
+    while not disconnected.is_set() and loop.time() - t0 < HANGUP_MAX_WAIT_S:
+        # "thinking" counts: it is the gap between the end_call tool result and the
+        # farewell audio, exactly where a speaking-only check fires early (713652).
+        if session.agent_state in ("thinking", "speaking"):
             quiet_since = loop.time()
         elif loop.time() - quiet_since >= HANGUP_QUIET_S:
             break
         await asyncio.sleep(0.2)
-    logger.info(
-        "farewell wait done after %.1fs (state=%s)",
-        loop.time() - (deadline - HANGUP_MAX_WAIT_S),
-        session.agent_state,
-    )
+    logger.info("farewell wait %.1fs (state=%s)", loop.time() - t0, session.agent_state)
 
 
 def wire_speech_spans(session: AgentSession) -> None:

--- a/voice-agent-harnesses/livekit/harness.py
+++ b/voice-agent-harnesses/livekit/harness.py
@@ -54,8 +54,23 @@ GREETING = "Welcome to Bluejay's Repair Services!"
 # step 1 of system-prompts/scheduler.md, verbatim. Only used by runtimes whose model
 # rejects generate_reply() (see Scheduler.on_enter); every other turn is model-generated.
 SCHEDULER_OPENER = "Hey, when do you want to schedule your repair appointment?"
-# the caller hangs up too; this is just long enough for the goodbye to play out
-HANGUP_GRACE_S = 4.0
+# How long the agent must be *quiet* after `end_call` before we tear the room down.
+# This used to be a flat sleep, which was enough for cascaded/Gemini (they finish the
+# farewell and the caller hangs up first) but not for gpt-realtime-2.1: it calls
+# `end_call` in the same response turn as `schedule_appointment` (2.6-2.9 s apart)
+# while still speaking, so a fixed 4 s deleted the room mid-sentence — the transcript
+# cut at "scheduled for eighteighteentwenty" (713478/713612) and at "Your repair
+# appointment is scheduled for" (713652). The digital human never heard a goodbye,
+# never hung up, and the run burned the full 180 s cap. The timer now *restarts*
+# whenever the agent is speaking or generating, so it measures 4 s of silence rather
+# than 4 s of wall clock; a model with nothing left to say still waits exactly 4 s.
+HANGUP_QUIET_S = float(os.environ.get("MIVAS_END_CALL_CLOSE_DELAY_S", "4.0"))
+# hard cap so a model that never stops talking cannot hold the room forever
+HANGUP_MAX_WAIT_S = float(os.environ.get("MIVAS_END_CALL_MAX_WAIT_S", "20.0"))
+# States where the agent still owes us audio. "thinking" is the gap between the
+# end_call tool result and the farewell audio starting — exactly where a check that
+# only looked for "speaking" fires early (713652 cut 1.7 s into that gap).
+AGENT_BUSY_STATES = ("thinking", "speaking")
 
 
 # ── blueprint ────────────────────────────────────────────────────────────────
@@ -250,6 +265,31 @@ def sim_result_id_from_job_metadata(raw: Any) -> str | None:
     return None
 
 
+async def await_farewell(session: AgentSession, disconnected: asyncio.Event) -> None:
+    """Hold the room until the agent has gone quiet for HANGUP_QUIET_S.
+
+    `AgentSession.agent_state` is the same signal `wire_speech_spans` brackets
+    `agent.speech` on, polled rather than subscribed: the farewell can start at any
+    point in this window and an edge-triggered wait would miss the transition. The
+    quiet timer restarts on every busy sample, so a pause between the confirmation
+    and the goodbye does not count as "done talking".
+    """
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + HANGUP_MAX_WAIT_S
+    quiet_since = loop.time()
+    while not disconnected.is_set() and loop.time() < deadline:
+        if session.agent_state in AGENT_BUSY_STATES:
+            quiet_since = loop.time()
+        elif loop.time() - quiet_since >= HANGUP_QUIET_S:
+            break
+        await asyncio.sleep(0.2)
+    logger.info(
+        "farewell wait done after %.1fs (state=%s)",
+        loop.time() - (deadline - HANGUP_MAX_WAIT_S),
+        session.agent_state,
+    )
+
+
 def wire_speech_spans(session: AgentSession) -> None:
     """agent.speech / customer.speech from real turn events (no silence heuristic)."""
     spans: dict[str, Any] = {"agent": None, "customer": None}
@@ -326,7 +366,7 @@ async def run_call(
             t.cancel()
 
         if hangup.is_set() and not disconnected.is_set():
-            await asyncio.sleep(HANGUP_GRACE_S)
+            await await_farewell(session, disconnected)
             try:
                 await ctx.delete_room()
             except Exception as e:

--- a/voice-agent-harnesses/livekit/test_harness.py
+++ b/voice-agent-harnesses/livekit/test_harness.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
@@ -74,28 +75,24 @@ def test_real_handoff() -> None:
 def test_await_farewell() -> None:
     """The hangup wait must outlast the agent's goodbye, but never run forever."""
 
-    class FakeSession:
-        def __init__(self, states: list[tuple[float, str]], start: str) -> None:
-            self.agent_state = start
-            loop = asyncio.get_event_loop()
-            for at, state in states:
-                loop.call_later(at, lambda s=state: setattr(self, "agent_state", s))
-
-    async def elapsed(states: list[tuple[float, str]], start: str, max_wait: float) -> float:
+    async def elapsed(start: str, states: list[tuple[float, str]], max_wait: float = 5.0) -> float:
         harness.HANGUP_QUIET_S, harness.HANGUP_MAX_WAIT_S = 0.3, max_wait
         loop = asyncio.get_running_loop()
+        session = SimpleNamespace(agent_state=start)
+        for at, state in states:
+            loop.call_later(at, setattr, session, "agent_state", state)
         t0 = loop.time()
-        await harness.await_farewell(FakeSession(states, start), asyncio.Event())
+        await harness.await_farewell(session, asyncio.Event())
         return loop.time() - t0
 
     # nothing left to say -> exactly the quiet window, as the old flat sleep did
-    assert 0.3 < asyncio.run(elapsed([], "listening", 5.0)) < 0.6
+    assert 0.3 < asyncio.run(elapsed("listening", [])) < 0.6
     # 713652: quiet at the old sample point, then the farewell starts -> keep waiting
-    assert 1.0 < asyncio.run(elapsed([(0.2, "thinking"), (1.0, "listening")], "listening", 5.0)) < 1.6
+    assert 1.0 < asyncio.run(elapsed("listening", [(0.2, "thinking"), (1.0, "listening")])) < 1.6
     # still speaking after the quiet window -> wait for it to stop
-    assert 0.7 < asyncio.run(elapsed([(0.6, "listening")], "speaking", 5.0)) < 1.2
+    assert 0.7 < asyncio.run(elapsed("speaking", [(0.6, "listening")])) < 1.2
     # a model that never stops talking is cut off at the cap
-    assert 0.5 < asyncio.run(elapsed([], "speaking", 0.6)) < 1.0
+    assert 0.5 < asyncio.run(elapsed("speaking", [], max_wait=0.6)) < 1.0
 
 
 if __name__ == "__main__":

--- a/voice-agent-harnesses/livekit/test_harness.py
+++ b/voice-agent-harnesses/livekit/test_harness.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from livekit.agents import llm as lk_llm
 
+import harness
 from harness import Receptionist, Scheduler, load_blueprint, sim_result_id_from_job_metadata
 
 
@@ -70,8 +71,36 @@ def test_real_handoff() -> None:
     assert scheduler.llm is not receptionist.llm
 
 
+def test_await_farewell() -> None:
+    """The hangup wait must outlast the agent's goodbye, but never run forever."""
+
+    class FakeSession:
+        def __init__(self, states: list[tuple[float, str]], start: str) -> None:
+            self.agent_state = start
+            loop = asyncio.get_event_loop()
+            for at, state in states:
+                loop.call_later(at, lambda s=state: setattr(self, "agent_state", s))
+
+    async def elapsed(states: list[tuple[float, str]], start: str, max_wait: float) -> float:
+        harness.HANGUP_QUIET_S, harness.HANGUP_MAX_WAIT_S = 0.3, max_wait
+        loop = asyncio.get_running_loop()
+        t0 = loop.time()
+        await harness.await_farewell(FakeSession(states, start), asyncio.Event())
+        return loop.time() - t0
+
+    # nothing left to say -> exactly the quiet window, as the old flat sleep did
+    assert 0.3 < asyncio.run(elapsed([], "listening", 5.0)) < 0.6
+    # 713652: quiet at the old sample point, then the farewell starts -> keep waiting
+    assert 1.0 < asyncio.run(elapsed([(0.2, "thinking"), (1.0, "listening")], "listening", 5.0)) < 1.6
+    # still speaking after the quiet window -> wait for it to stop
+    assert 0.7 < asyncio.run(elapsed([(0.6, "listening")], "speaking", 5.0)) < 1.2
+    # a model that never stops talking is cut off at the cap
+    assert 0.5 < asyncio.run(elapsed([], "speaking", 0.6)) < 1.0
+
+
 if __name__ == "__main__":
     test_sim_result_id()
     test_blueprint()
     test_real_handoff()
+    test_await_farewell()
     print("ok")

--- a/voice-agent-harnesses/openai/adapters/chirp.py
+++ b/voice-agent-harnesses/openai/adapters/chirp.py
@@ -19,6 +19,7 @@ import time
 import uuid
 from pathlib import Path
 
+from agents.realtime import RealtimeModelSendRawMessage
 from websockets.asyncio.server import serve
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -47,6 +48,20 @@ def _simulation_result_id(ws) -> str | None:
         return None
     val = headers.get("X-Simulation-Result-Id") or headers.get("x-simulation-result-id")
     return str(val) if val else None
+
+
+async def _nudge_greeting(session) -> None:
+    """Make the agent open the call.
+
+    ``semantic_vad`` only responds to caller audio, so a digital human with
+    ``speaks_first: false`` deadlocks both sides into silence. A bare
+    ``response.create`` asks for a turn without adding a conversation item, so
+    the greeting comes from the agent's own instructions and no phantom user
+    item / ``customer.speech`` span lands in the trace.
+    """
+    await session.model.send_event(
+        RealtimeModelSendRawMessage(message={"type": "response.create"})
+    )
 
 
 async def _bridge(ws, model: str, industry: str) -> None:
@@ -80,6 +95,7 @@ async def _bridge(ws, model: str, industry: str) -> None:
         ) as session:
             ctx["session"] = session
             events = tracer.wrap(session) if tracer is not None else session
+            await _nudge_greeting(session)
 
             async def inbound() -> None:
                 nonlocal up

--- a/voice-agent-harnesses/openai/adapters/chirp.py
+++ b/voice-agent-harnesses/openai/adapters/chirp.py
@@ -50,18 +50,13 @@ def _simulation_result_id(ws) -> str | None:
     return str(val) if val else None
 
 
-async def _nudge_greeting(session) -> None:
-    """Make the agent open the call.
-
-    ``semantic_vad`` only responds to caller audio, so a digital human with
-    ``speaks_first: false`` deadlocks both sides into silence. A bare
-    ``response.create`` asks for a turn without adding a conversation item, so
-    the greeting comes from the agent's own instructions and no phantom user
-    item / ``customer.speech`` span lands in the trace.
-    """
-    await session.model.send_event(
-        RealtimeModelSendRawMessage(message={"type": "response.create"})
-    )
+# Makes the agent open the call: `semantic_vad` only responds to caller audio, so a
+# digital human with `speaks_first: false` deadlocks both sides into silence. Bare, with
+# no conversation item, so the greeting comes from the agent's own instructions and no
+# phantom user item / `customer.speech` span lands in the trace. A raw message the SDK
+# can't validate is dropped with a log line, not an error — test_nudge_greeting.py is the
+# check that this one still converts.
+NUDGE_GREETING = RealtimeModelSendRawMessage(message={"type": "response.create"})
 
 
 async def _bridge(ws, model: str, industry: str) -> None:
@@ -95,7 +90,7 @@ async def _bridge(ws, model: str, industry: str) -> None:
         ) as session:
             ctx["session"] = session
             events = tracer.wrap(session) if tracer is not None else session
-            await _nudge_greeting(session)
+            await session.model.send_event(NUDGE_GREETING)
 
             async def inbound() -> None:
                 nonlocal up

--- a/voice-agent-harnesses/openai/test_nudge_greeting.py
+++ b/voice-agent-harnesses/openai/test_nudge_greeting.py
@@ -1,0 +1,37 @@
+"""The connect-time nudge must be a bare response.create — no user item."""
+
+import asyncio
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from adapters.chirp import _nudge_greeting  # noqa: E402
+
+
+def test_nudge_is_bare_response_create() -> None:
+    from agents.realtime.openai_realtime import _ConversionHelper
+
+    sent = []
+
+    class FakeModel:
+        async def send_event(self, event):
+            sent.append(event)
+
+    class FakeSession:
+        model = FakeModel()
+
+    asyncio.run(_nudge_greeting(FakeSession()))
+
+    assert len(sent) == 1, sent
+    # The SDK silently drops raw messages it can't validate — prove it converts.
+    converted = _ConversionHelper.try_convert_raw_message(sent[0])
+    assert converted is not None, "raw nudge failed SDK validation"
+    assert converted.type == "response.create", converted.type
+    # No conversation item => no phantom user.turn / customer.speech span.
+    assert "user_input" not in sent[0].message
+    assert not sent[0].message.get("other_data")
+
+
+if __name__ == "__main__":
+    test_nudge_is_bare_response_create()
+    print("ok nudge = bare response.create")

--- a/voice-agent-harnesses/openai/test_nudge_greeting.py
+++ b/voice-agent-harnesses/openai/test_nudge_greeting.py
@@ -1,37 +1,21 @@
-"""The connect-time nudge must be a bare response.create — no user item."""
+"""The connect-time nudge must be a bare response.create the SDK accepts.
 
-import asyncio
+A raw message the SDK can't validate is dropped with a log line rather than an error,
+so a bad one shows up only as an agent that never opens the call.
+Run: `python test_nudge_greeting.py`
+"""
+
 import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from adapters.chirp import _nudge_greeting  # noqa: E402
+from adapters.chirp import NUDGE_GREETING  # noqa: E402
+from agents.realtime.openai_realtime import _ConversionHelper  # noqa: E402
 
+converted = _ConversionHelper.try_convert_raw_message(NUDGE_GREETING)
+assert converted is not None, "raw nudge failed SDK validation"
+assert converted.type == "response.create", converted.type
+# no conversation item => no phantom user.turn / customer.speech span
+assert not NUDGE_GREETING.message.get("other_data"), NUDGE_GREETING.message
 
-def test_nudge_is_bare_response_create() -> None:
-    from agents.realtime.openai_realtime import _ConversionHelper
-
-    sent = []
-
-    class FakeModel:
-        async def send_event(self, event):
-            sent.append(event)
-
-    class FakeSession:
-        model = FakeModel()
-
-    asyncio.run(_nudge_greeting(FakeSession()))
-
-    assert len(sent) == 1, sent
-    # The SDK silently drops raw messages it can't validate — prove it converts.
-    converted = _ConversionHelper.try_convert_raw_message(sent[0])
-    assert converted is not None, "raw nudge failed SDK validation"
-    assert converted.type == "response.create", converted.type
-    # No conversation item => no phantom user.turn / customer.speech span.
-    assert "user_input" not in sent[0].message
-    assert not sent[0].message.get("other_data")
-
-
-if __name__ == "__main__":
-    test_nudge_is_bare_response_create()
-    print("ok nudge = bare response.create")
+print("ok nudge = bare response.create")

--- a/voice-agent-harnesses/pipecat/Dockerfile
+++ b/voice-agent-harnesses/pipecat/Dockerfile
@@ -1,6 +1,9 @@
 # Pipecat Cloud agent image. The base image owns the HTTP entrypoint and calls
 # `bot(args)` from /app/bot.py — do not add a CMD.
-FROM dailyco/pipecat-base:1.7.0
+# 0.1.27 is the base image's own version, not the pipecat-ai library version —
+# there is no dailyco/pipecat-base:1.7.0 and a build against it fails to resolve.
+# Same digest as :latest (sha256:5d761b89...), so this pins what already shipped.
+FROM dailyco/pipecat-base:0.1.27
 
 COPY requirements.txt requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt

--- a/voice-agent-harnesses/vapi/adapters/chirp.py
+++ b/voice-agent-harnesses/vapi/adapters/chirp.py
@@ -247,13 +247,9 @@ def _trace_server_tools(body: dict, seen: set[str]) -> None:
                     args = json.loads(args)
             print(f"chirp vapi server tool {name}", flush=True)
             with tool_span(name, args) as span:
-                finish_tool_span(
-                    span,
-                    {"success": True, "source": "vapi"},
-                    ok=True,
-                    name=name,
-                    parameters=args,
-                )
+                # tool_span already records name + arguments; finish_tool_span takes
+                # only (span, output, *, ok).
+                finish_tool_span(span, {"success": True, "source": "vapi"}, ok=True)
 
 
 def main(model: str | None = None) -> None:


### PR DESCRIPTION
A full regression across all 17 runtimes turned up three real defects. 16/17 pass after these fixes; the one remaining failure is described at the bottom and is **not** fixed here.

## 1. `main` was undeployable (Pipecat)

`3878d13` pinned `dailyco/pipecat-base:1.7.0`. That is the `pipecat-ai` **library** version, not the base image's — the tag 404s on Docker Hub and every deploy fails at metadata resolution. Pinned to `0.1.27`, which shares a digest with `latest` (`sha256:5d761b89…`), so it pins exactly the image that was already shipping.

This mattered beyond deploys: the live Pipecat deployment predated `9905a5b` (the real-agent-handoff work), so the regression would have been testing the wrong code.

## 2. Vapi was broken by `f702abb`

The LOC-cleanup commit removed `name` / `parameters` from `finish_tool_span` but missed a **multi-line** call site in `vapi/adapters/chirp.py:_trace_server_tools`. Every Vapi call died ~60 ms after the squad transfer:

```
TypeError: finish_tool_span() got an unexpected keyword argument 'name'
```

Vapi's log: `handoffCompleted` @11.121s → `transportDisconnected` @11.233s. Three runs reproduced it identically at 11s with `goal_success: false`.

The regex sweep behind that commit only matched same-line kwargs, and the runtime smoke only exercised `harness.run_tool`, never the adapter's server-tool path. **`check_call_sites.py`** closes the gap: AST-walks every harness and asserts each `report.py` call site passes only kwargs that harness's own signature accepts. Verified it fails on the pre-fix tree and passes after.

## 3. ElevenLabs system tools were invisible

`transfer_to_agent` reported `expected: 1, actual: []` on calls where the transfer demonstrably happened. `CLIENT_EVENTS` **overrides** ElevenLabs' server default rather than extending it, and omitted `agent_tool_response` — so the handler emitting `execute_tool` spans for `transfer_to_agent` and `end_call` never received an event and had never run. Its parsing was also wrong (read `tool_details`/`parameters`, which don't exist on that event).

Only `agent_tool_response` is requested, not `agent_tool_request`, so one tool yields one span. Agents recreated so the new allowlist takes effect.

Also drops a stale note `_adapt_prompt` appended to *every* agent including the scheduler, telling it to use a `transfer_to_agent` tool it doesn't have and citing an `agent_number` field ElevenLabs has no equivalent for — that is what made the scheduler narrate its reasoning aloud.

## Verification

| harness | run |
|---|---|
| vapi | [30208/225420](https://app.getbluejay.ai/simulations/30208/runs/225420) |
| elevenlabs | [30154/225422](https://app.getbluejay.ai/simulations/30154/runs/225422) |
| pipecat cascaded | [30227/225402](https://app.getbluejay.ai/simulations/30227/runs/225402) |
| pipecat realtime | [30228/225403](https://app.getbluejay.ai/simulations/30228/runs/225403) |
| pipecat gemini | [30229/225404](https://app.getbluejay.ai/simulations/30229/runs/225404) |

Each `COMPLETED` with a linked trace, one actual per expected tool, ordered spans with offsets inside the call.

## Not fixed here

**LiveKit `openai-realtime-2.1` does not end the call** (reproduced 2/2, results 713478 / 713612). `gpt-realtime-2.1` calls `end_call` in the same turn as `schedule_appointment` while still speaking, and `HANGUP_GRACE_S = 4.0` deletes the room mid-sentence — the transcript cuts at *"scheduled for eighteighteentwenty"*. The digital human never hears a goodbye, so it never hangs up, and the run rides to the 180s cap with ~123s of dead air. Wants the `_await_farewell` treatment Pipecat already uses (wait for the agent to actually stop speaking, capped) rather than a flat delay.

**OpenAI CHIRP harness never greets** — sits mute ~65s until Bluejay's silence prompt unblocks it, because `gemini/adapters/chirp.py` nudges the model on connect and the OpenAI adapter has no equivalent. Exposed by setting `speaks_first: false`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix regressions across Pipecat, Vapi, ElevenLabs, LiveKit, OpenAI, and Bland to restore deployability, correct server tool tracing, end calls cleanly, and prevent tool syntax from being spoken. Full-harness runs now complete across all runtimes.

- **Bug Fixes**
  - Pipecat: Pin `dailyco/pipecat-base:0.1.27` (same digest as `latest`) to replace a non-existent tag that broke deploys.
  - Vapi: Fix multi-line call to `finish_tool_span` by removing invalid kwargs; add `check_call_sites.py` to AST-check report call sites.
  - ElevenLabs: Include `agent_tool_response` in `CLIENT_EVENTS`, parse its payload, and emit execute_tool spans for `transfer_to_agent` and `end_call`; only add the transfer note when a transfer tool exists.
  - LiveKit: Replace the fixed hangup delay with `await_farewell` that waits for agent silence (counts `thinking` and `speaking`), capped by `HANGUP_MAX_WAIT_S`.
  - OpenAI: Send a bare `response.create` on connect so the agent greets without inserting a user item; test added to validate the nudge.
  - Bland: Strip tool-call sentences from node prompts before appending `PATHWAY_NOTE` to prevent TTS reading tool syntax; `base/agent.py --check` asserts prompts contain no tool names.

- **Refactors**
  - Trimmed comments and redundant test scaffolding; moved incident notes into harness READMEs. No behavior changes (same `await_farewell` timing and OpenAI greeting nudge).

<sup>Written for commit 45c05c7ed24b9fb3d9054788e4b7b2577399eeae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

