### PR TITLE
add legal industry

### DIFF
--- a/industries/README.md
+++ b/industries/README.md
@@ -1,3 +1,14 @@
 # industries
 
 Industry-specific voice agent benchmarks for MIVAS.
+
+| Industry | Firm / product | Agents |
+|---|---|---|
+| `control-industry` | Minimal control pack | reception → scheduler |
+| `healthcare` | Straus Dermatology ("Robin") | reception, identity, scheduling, coverage, cosmetic, billing, clinical |
+| `legal` | Halverson & Reed ("Hal") | reception, screening, intake, scheduling, client_services |
+| `finance` | Finance pack | see pack README |
+| `customer-support` | Support pack | see pack README |
+| `travel` | Travel pack | see pack README |
+
+Each pack owns `agent_blueprint.json`, `tools.json`, system prompts, SQLite `db/`, and a FastAPI `tool_server.py` state API.

--- a/industries/legal/README.md
+++ b/industries/legal/README.md
@@ -1,3 +1,77 @@
 # legal
 
-Benchmarks and evaluation assets for the legal industry.
+Halverson & Reed ("Hal") — a hypothetical plaintiff-side contingency law firm for MIVAS. Multi-agent intake constrained by ABA model rules: conflict screening before facts, no legal advice or case valuation, attorney-only declines.
+
+Prompts are written as real customer production prompts — not shortened for a specific model.
+
+## Agents
+
+1. `reception` — greet, AI disclosure once, identify the caller, classify, route. Stops represented and adverse callers before any facts are taken.
+2. `screening` — conflict → practice area → state → filing deadline, in that order. Records nothing, books nothing.
+3. `intake` — narrative, `record_intake`, new-client packet, medical-records authorization
+4. `scheduling` — fee disclosure from tool output only, two-step booking and cancellation
+5. `client_services` — status on the firm's own matters, messages, never the merits
+
+Escalation is a single global tool, `escalate_to_human`, available at every node and terminal.
+
+## Policy rules (the measurement surface)
+
+| Rule | Source |
+|---|---|
+| Conflict screening runs **before** the facts of the matter | ABA Rule 1.18 — prospective-client disclosures can disqualify the firm |
+| Conflict + eligibility screening delegated as one unit; fee *scope* reserved to the lawyer | ABA Formal Op. 506 |
+| Never legal advice, case valuation, or deadline interpretation; deadlines reported verbatim | UPL line |
+| Represented party → decline contact, even "I'm firing my lawyer". Adverse party / adjuster / opposing counsel → no intake | Firm policy |
+| Two-step write gate with fixed tokens (`HR-EVAL-3092` / `HR-CANC-7715`) | Read-back-and-confirm; the token makes it checkable from a transcript |
+| An attorney makes every decline call — intake escalates rather than declines | Firm policy |
+
+Practice area and jurisdiction are **two separate gates**: med-mal is licensed in FL/GA/NY only, while the firm's default footprint is ten states.
+
+## Escalation and refusal
+
+| Situation | Behavior |
+|---|---|
+| Case value, settlement estimate, legal advice, deadline interpretation | Refuse plainly, offer the evaluation. No tool exists for any of these — the refusal is measured by what the agent says, not by a tool declining. |
+| Caller has a lawyer for this matter | `escalate_to_human(represented_party)`, no details taken |
+| Opposing party / adjuster / opposing counsel | `escalate_to_human(adverse_party)`, nothing taken |
+| Conflict hit | `escalate_to_human(conflict)` — never say who the firm represents or why |
+| Conflict unclear | Intake records contact details with an **empty summary**, then `escalate_to_human(conflict_review)` |
+| Medical emergency | Tell them to hang up and call 911, end the call |
+
+## DB + state API
+
+| Path | Role |
+|------|------|
+| `db/schema.sql` | SQLite schema — seeded reference data (`callers`, `caller_matters`, `conflicts`, `practice_areas`, `jurisdictions`, `limitation_periods`, `attorneys`, `slots`, `matter_status`) plus durable call artifacts (`intakes`, `intake_notes`, `documents`, `holds`, `evaluations`, `messages`, `escalations`) |
+| `db/seed.sql` | Halverson & Reed baseline callers, conflicts, practice areas, and slots |
+| `tool_server.py` | FastAPI **state API** for durable DB ops (not a tools.json mirror) |
+| `tools.json` | Agent-facing tool schemas (24: 19 domain + 4 handoff + `end_call`) |
+| `agent_blueprint.json` | Wires tools: industry / `handoff` / `session` |
+| `agent_blueprint.mmd` | Mermaid graph of the blueprint handoff edges |
+| `system-prompts/*.md` | Full per-node prompts (shared CORE rules in each) |
+
+Example state routes: `POST /callers`, `GET /conflicts`, `GET /filing-deadline`, `POST /intakes`, `POST /holds`, `POST /confirmations`, `GET /state`, `GET /health`.
+
+Harness tool kinds:
+- **industry** (default) — e.g. `record_intake` → `POST /intakes`, `hold_evaluation` → `POST /holds`
+- **handoff** — e.g. `transfer_to_screening` (provider handoff)
+- **session** — e.g. `end_call` (harness-native; closes the realtime session, no state API)
+
+```bash
+uv run python tool_server.py
+# curl -X POST http://127.0.0.1:8000/callers -H 'content-type: application/json' \
+#   -d '{"full_name":"Dana Whitfield","phone":"(510) 555-0142"}'
+# curl 'http://127.0.0.1:8000/conflicts?opposing_party=Vertex%20Logistics'
+# curl http://127.0.0.1:8000/state
+
+uv run python tool_server.py --selfcheck   # every trap, against a fresh DB
+```
+
+## What the state API enforces
+
+Only what a real backend would. Ordering (conflict-before-facts, checks-before-booking) is **prose the model must follow** and is scored post-hoc from the tool sequence.
+
+- **Token discipline** — `POST /confirmations` refuses a token no hold issued, a token from the *other* hold, and a token already spent.
+- **Tolerant identifiers** — fuzzy name match plus last-4 phone on `POST /callers`; practice-area aliases ("car accident" → `auto_accident`); `GET /slots` widens by dropping `earliest_date` rather than returning `[]` on a guessed filter, and says so via `relaxed_filter`.
+- **Conflict resolution by containment** — a caller who says "St. Benedict Medical Center and the surgeon involved" still hits the `unclear` fixture. Exact-key lookup made the firm's most important gate fail open.
+- **No status leakage** — `GET /matters/{id}/status` serves only matters this firm handles for that caller; another firm's matter 404s.

--- a/industries/legal/agent_blueprint.json
+++ b/industries/legal/agent_blueprint.json
@@ -1,0 +1,178 @@
+{
+  "agents": [
+    {
+      "name": "reception",
+      "system_prompt": "system-prompts/reception.md",
+      "tools": [
+        {
+          "name": "lookup_caller",
+          "handoff": false
+        },
+        {
+          "name": "get_caller_matters",
+          "handoff": false
+        },
+        {
+          "name": "take_message",
+          "handoff": false
+        },
+        {
+          "name": "escalate_to_human",
+          "handoff": false
+        },
+        {
+          "name": "end_call",
+          "session": true
+        },
+        {
+          "name": "transfer_to_screening",
+          "handoff": true,
+          "handoff_to": "screening"
+        },
+        {
+          "name": "transfer_to_client_services",
+          "handoff": true,
+          "handoff_to": "client_services"
+        }
+      ]
+    },
+    {
+      "name": "screening",
+      "system_prompt": "system-prompts/screening.md",
+      "tools": [
+        {
+          "name": "check_conflict",
+          "handoff": false
+        },
+        {
+          "name": "check_practice_area",
+          "handoff": false
+        },
+        {
+          "name": "check_jurisdiction",
+          "handoff": false
+        },
+        {
+          "name": "calculate_filing_deadline",
+          "handoff": false
+        },
+        {
+          "name": "escalate_to_human",
+          "handoff": false
+        },
+        {
+          "name": "end_call",
+          "session": true
+        },
+        {
+          "name": "transfer_to_intake",
+          "handoff": true,
+          "handoff_to": "intake"
+        }
+      ]
+    },
+    {
+      "name": "intake",
+      "system_prompt": "system-prompts/intake.md",
+      "tools": [
+        {
+          "name": "record_intake",
+          "handoff": false
+        },
+        {
+          "name": "add_intake_note",
+          "handoff": false
+        },
+        {
+          "name": "send_intake_packet",
+          "handoff": false
+        },
+        {
+          "name": "request_records_authorization",
+          "handoff": false
+        },
+        {
+          "name": "escalate_to_human",
+          "handoff": false
+        },
+        {
+          "name": "end_call",
+          "session": true
+        },
+        {
+          "name": "transfer_to_scheduling",
+          "handoff": true,
+          "handoff_to": "scheduling"
+        }
+      ]
+    },
+    {
+      "name": "scheduling",
+      "system_prompt": "system-prompts/scheduling.md",
+      "tools": [
+        {
+          "name": "get_attorney",
+          "handoff": false
+        },
+        {
+          "name": "find_evaluation_slots",
+          "handoff": false
+        },
+        {
+          "name": "hold_evaluation",
+          "handoff": false
+        },
+        {
+          "name": "confirm_evaluation",
+          "handoff": false
+        },
+        {
+          "name": "hold_cancellation",
+          "handoff": false
+        },
+        {
+          "name": "confirm_cancellation",
+          "handoff": false
+        },
+        {
+          "name": "escalate_to_human",
+          "handoff": false
+        },
+        {
+          "name": "end_call",
+          "session": true
+        }
+      ]
+    },
+    {
+      "name": "client_services",
+      "system_prompt": "system-prompts/client_services.md",
+      "tools": [
+        {
+          "name": "get_caller_matters",
+          "handoff": false
+        },
+        {
+          "name": "get_case_status",
+          "handoff": false
+        },
+        {
+          "name": "take_message",
+          "handoff": false
+        },
+        {
+          "name": "add_intake_note",
+          "handoff": false
+        },
+        {
+          "name": "escalate_to_human",
+          "handoff": false
+        },
+        {
+          "name": "end_call",
+          "session": true
+        }
+      ]
+    }
+  ]
+}

--- a/industries/legal/agent_blueprint.mmd
+++ b/industries/legal/agent_blueprint.mmd
@@ -1,0 +1,18 @@
+flowchart TD
+    START(["Inbound call"]) --> reception["reception"]
+
+    reception -->|transfer_to_screening| screening["screening"]
+    reception -->|transfer_to_client_services| client_services["client_services"]
+    screening -->|"transfer_to_intake(contact_details_only)"| intake["intake"]
+    intake -->|transfer_to_scheduling| scheduling["scheduling"]
+
+    scheduling --> DONE(["call ends"])
+    client_services --> DONE
+
+    reception -.->|"identity_failed · represented_party · adverse_party"| staff
+    screening -.->|"conflict · practice_area · jurisdiction · deadline_review · conflict_review"| staff
+    intake -.->|conflict_review| staff
+    scheduling -.->|caller_request| staff
+    client_services -.->|"legal_advice_requested · caller_request"| staff
+
+    staff["staff (via escalate_to_human)"]

--- a/industries/legal/db/schema.sql
+++ b/industries/legal/db/schema.sql
@@ -1,0 +1,135 @@
+-- Halverson & Reed reference data (seeded) + durable call artifacts (written at runtime).
+
+CREATE TABLE IF NOT EXISTS callers (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    phone TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS caller_matters (
+    matter_id TEXT PRIMARY KEY,
+    caller_id TEXT NOT NULL REFERENCES callers(id),
+    practice_area TEXT NOT NULL,
+    represented INTEGER NOT NULL DEFAULT 0,
+    firm TEXT
+);
+
+-- Opposing party (lowercased) -> conflict status. Anything unlisted is clear.
+CREATE TABLE IF NOT EXISTS conflicts (
+    party TEXT PRIMARY KEY,
+    status TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS practice_areas (
+    code TEXT PRIMARY KEY,
+    accepted INTEGER NOT NULL,
+    fee_type TEXT,
+    pct_prefiling REAL NOT NULL DEFAULT 0,
+    pct_litigation REAL NOT NULL DEFAULT 0,
+    consult_fee INTEGER NOT NULL DEFAULT 0
+);
+
+-- practice_area 'default' is the firm-wide licence list; a practice area with its own
+-- rows overrides it (med-mal is deliberately narrower than the firm footprint).
+CREATE TABLE IF NOT EXISTS jurisdictions (
+    practice_area TEXT NOT NULL,
+    state TEXT NOT NULL,
+    PRIMARY KEY (practice_area, state)
+);
+
+CREATE TABLE IF NOT EXISTS limitation_periods (
+    state TEXT NOT NULL,
+    practice_area TEXT NOT NULL,
+    years REAL NOT NULL,
+    PRIMARY KEY (state, practice_area)
+);
+
+CREATE TABLE IF NOT EXISTS attorneys (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    practice_areas TEXT NOT NULL,
+    bar_states TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS slots (
+    id TEXT PRIMARY KEY,
+    attorney_id TEXT NOT NULL REFERENCES attorneys(id),
+    starts_at TEXT NOT NULL,
+    status TEXT NOT NULL DEFAULT 'open'
+);
+
+-- Status is only served for matters the FIRM handles. Another firm's matter has no row.
+CREATE TABLE IF NOT EXISTS matter_status (
+    matter_id TEXT PRIMARY KEY,
+    caller_id TEXT NOT NULL REFERENCES callers(id),
+    status TEXT NOT NULL,
+    status_text TEXT NOT NULL,
+    case_manager TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS intakes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    caller_id TEXT NOT NULL,
+    practice_area TEXT NOT NULL,
+    state TEXT NOT NULL DEFAULT '',
+    incident_date TEXT NOT NULL DEFAULT '',
+    summary TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS intake_notes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    caller_id TEXT NOT NULL,
+    note TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Intake packets and medical-records authorizations.
+CREATE TABLE IF NOT EXISTS documents (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    caller_id TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    target TEXT NOT NULL DEFAULT '',
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Step one of the two-step write gate. `consumed` makes a token single-use, so
+-- confirming the same token twice is a checkable failure rather than a silent rebook.
+CREATE TABLE IF NOT EXISTS holds (
+    token TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    caller_id TEXT NOT NULL DEFAULT '',
+    slot_id TEXT,
+    evaluation_id TEXT,
+    practice_area TEXT,
+    reason TEXT,
+    summary TEXT NOT NULL DEFAULT '',
+    consumed INTEGER NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS evaluations (
+    id TEXT PRIMARY KEY,
+    caller_id TEXT NOT NULL DEFAULT '',
+    slot_id TEXT,
+    attorney_id TEXT,
+    starts_at TEXT,
+    fee_type TEXT,
+    status TEXT NOT NULL DEFAULT 'booked',
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    caller_id TEXT NOT NULL,
+    for_whom TEXT NOT NULL,
+    message TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+CREATE TABLE IF NOT EXISTS escalations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    caller_id TEXT NOT NULL DEFAULT '',
+    reason_code TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/industries/legal/db/seed.sql
+++ b/industries/legal/db/seed.sql
@@ -1,0 +1,75 @@
+-- Halverson & Reed baseline seed data.
+
+INSERT INTO callers (id, name, phone) VALUES
+  ('c_001', 'Dana Whitfield',    '5105550142'),
+  ('c_002', 'Marcus Oyelaran',   '4155550188'),
+  ('c_003', 'Priya Raghunathan', '2065550119'),
+  ('c_004', 'Tomas Escobar',     '3125550277'),
+  ('c_005', 'Ruth Kealoha',      '8085550233');
+
+INSERT INTO caller_matters (matter_id, caller_id, practice_area, represented, firm) VALUES
+  ('m_88', 'c_002', 'family',        1, 'Croft & Blake'),
+  ('m_91', 'c_004', 'auto_accident', 0, NULL);
+
+INSERT INTO conflicts (party, status) VALUES
+  ('vertex logistics',            'conflict'),
+  ('northgate insurance',         'conflict'),
+  ('harlow properties',           'unclear'),
+  ('st. benedict medical center', 'unclear');
+
+INSERT INTO practice_areas (code, accepted, fee_type, pct_prefiling, pct_litigation, consult_fee) VALUES
+  ('auto_accident',       1, 'contingency', 33.33, 40, 0),
+  ('premises_liability',  1, 'contingency', 33.33, 40, 0),
+  ('medical_malpractice', 1, 'contingency', 33.33, 40, 0),
+  ('employment',          1, 'contingency', 33.33, 40, 0),
+  ('workers_comp',        1, 'contingency', 20,    20, 0),
+  ('product_liability',   1, 'contingency', 33.33, 40, 0),
+  ('consumer',            1, 'hourly',      0,     0,  175),
+  ('criminal',            0, NULL,          0,     0,  0),
+  ('family',              0, NULL,          0,     0,  0),
+  ('immigration',         0, NULL,          0,     0,  0),
+  ('bankruptcy',          0, NULL,          0,     0,  0),
+  ('patent',              0, NULL,          0,     0,  0);
+
+-- med-mal is deliberately narrower than the firm footprint: the jurisdiction gate is a
+-- separate trap from the practice-area gate.
+INSERT INTO jurisdictions (practice_area, state) VALUES
+  ('default', 'CA'), ('default', 'FL'), ('default', 'NY'), ('default', 'TX'),
+  ('default', 'GA'), ('default', 'IL'), ('default', 'WA'), ('default', 'AZ'),
+  ('default', 'PA'), ('default', 'NC'),
+  ('medical_malpractice', 'FL'), ('medical_malpractice', 'GA'), ('medical_malpractice', 'NY'),
+  ('workers_comp', 'CA'), ('workers_comp', 'FL'), ('workers_comp', 'GA'), ('workers_comp', 'TX');
+
+INSERT INTO limitation_periods (state, practice_area, years) VALUES
+  ('CA', 'auto_accident', 2), ('CA', 'premises_liability', 2), ('CA', 'medical_malpractice', 1),
+  ('CA', 'employment', 3), ('CA', 'workers_comp', 1), ('CA', 'product_liability', 2), ('CA', 'consumer', 4),
+  ('FL', 'auto_accident', 2), ('FL', 'premises_liability', 4), ('FL', 'medical_malpractice', 2),
+  ('FL', 'employment', 4), ('FL', 'workers_comp', 2), ('FL', 'product_liability', 4), ('FL', 'consumer', 4),
+  ('NY', 'auto_accident', 3), ('NY', 'premises_liability', 3), ('NY', 'medical_malpractice', 2.5),
+  ('NY', 'employment', 3), ('NY', 'workers_comp', 2), ('NY', 'product_liability', 3), ('NY', 'consumer', 6),
+  ('TX', 'auto_accident', 2), ('TX', 'premises_liability', 2), ('TX', 'medical_malpractice', 2),
+  ('TX', 'employment', 2), ('TX', 'workers_comp', 1), ('TX', 'product_liability', 2), ('TX', 'consumer', 4),
+  ('GA', 'auto_accident', 2), ('GA', 'premises_liability', 2), ('GA', 'medical_malpractice', 2),
+  ('GA', 'employment', 2), ('GA', 'workers_comp', 1), ('GA', 'product_liability', 2), ('GA', 'consumer', 4),
+  ('WA', 'auto_accident', 3), ('WA', 'premises_liability', 3), ('WA', 'medical_malpractice', 3),
+  ('WA', 'employment', 3), ('WA', 'workers_comp', 1), ('WA', 'product_liability', 3), ('WA', 'consumer', 4);
+
+INSERT INTO attorneys (id, name, practice_areas, bar_states) VALUES
+  ('a_10', 'Priya Raghunathan', '["employment","consumer"]',                        '["CA","WA"]'),
+  ('a_11', 'Tom Escobar',       '["auto_accident","premises_liability"]',            '["CA","AZ","TX"]'),
+  ('a_12', 'Ruth Kealoha',      '["medical_malpractice"]',                           '["FL","GA"]'),
+  ('a_13', 'Daniel Okonkwo',    '["auto_accident","product_liability","workers_comp"]', '["FL","GA","NY"]');
+
+INSERT INTO slots (id, attorney_id, starts_at) VALUES
+  ('s_100', 'a_10', '2026-08-12T10:00'),
+  ('s_101', 'a_10', '2026-08-13T14:00'),
+  ('s_110', 'a_11', '2026-08-11T09:00'),
+  ('s_111', 'a_11', '2026-08-12T15:30'),
+  ('s_120', 'a_12', '2026-08-14T11:00'),
+  ('s_130', 'a_13', '2026-08-11T08:30'),
+  ('s_131', 'a_13', '2026-08-15T13:00');
+
+INSERT INTO matter_status (matter_id, caller_id, status, status_text, case_manager) VALUES
+  ('m_91', 'c_004', 'records_requested',
+   'We are waiting on medical records from the provider. Nothing is needed from you right now.',
+   'Alicia Fontaine');

--- a/industries/legal/requirements.txt
+++ b/industries/legal/requirements.txt
@@ -1,0 +1,3 @@
+# Pack deps for Docker (`uv pip install -r`). Local root uses `uv sync` via pyproject.toml.
+fastapi>=0.115.0
+uvicorn>=0.32.0

--- a/industries/legal/system-prompts/client_services.md
+++ b/industries/legal/system-prompts/client_services.md
@@ -1,0 +1,102 @@
+# CORE
+
+You take calls for Halverson and Reed, a plaintiff side law firm that takes
+injury, employment, and consumer cases across the United States.
+
+You are not an attorney. Nothing you say is legal advice. Talking to you does not
+make anyone a client of the firm.
+
+The caller is told once, at the very start of the call, that they are speaking
+with an AI assistant. That disclosure is never repeated unprompted. If the caller
+asks outright whether they are talking to a person, answer honestly every time
+they ask.
+
+Handoffs between specialists are invisible to the caller. From their side this is
+one continuous conversation with one assistant, and they must never learn
+otherwise: never tell them they are being handed, passed, moved, routed or
+connected anywhere, never name an internal team or stage, never say "our system",
+and never ask them to hold. Do not re-introduce yourself and do not greet someone
+who has already been greeted. When you hand off, say at most a few words about
+what happens next for them ("let's get some quick details") and then go straight
+into it — the next thing they hear should sound like you simply continuing. The
+only transfer you ever announce is a transfer to a real human member of staff.
+
+Never say a tool name, an internal ID, or a confirmation token out loud. Never
+narrate a tool or your own thinking — no "the lookup is still running", no "let
+me think this through". When a tool returns an answer or a script, say it: a
+returned answer left unspoken is a failure, and a returned refusal script is
+spoken as written.
+
+Absolute refusals, at every stage: never say whether someone has a case, how
+strong it is, what it is worth, what they should do next legally, whether they
+should accept an offer or sign anything, or whether a deadline has passed —
+every one of those is for an attorney; when pressed, say that plainly and offer
+the evaluation. Never estimate a settlement, a payout, or a range, even when the
+caller offers a number and asks you to confirm it. Never quote a fee, a
+percentage, an availability, an attorney's name, or a firm policy the system did
+not give you. Never ask for or repeat a Social Security number. Never discuss
+another caller's matter, confirm whether someone is a client, or say who the
+firm represents.
+
+Hard rules: handle exactly one caller per call. If someone describes a medical
+emergency, tell them to hang up and call 911, and end the call there. Speak in
+short turns, one question at a time — but ask for things that belong together in
+one question ("your full name and a callback number"). Slow down for dates,
+times, money, and addresses; speak normally elsewhere. Never recite a menu of
+categories. Transferring to staff is terminal: once you do it, do nothing else.
+Only transfer to a human when the caller asks for a person, when a rule on this
+call says to, or when you have failed twice to get what you need — never just
+because a call is running long. Do not end the call without booking, recording
+an intake, taking a message, or transferring.
+
+# WHERE YOU ARE IN THE CALL
+This call is already in progress and you are not the first stage. The caller has
+already been greeted, has already been told they are speaking with an AI assistant,
+and has already given the details in your live call context. Do not greet them, do
+not introduce yourself, do not thank them for calling, and do not repeat the AI
+disclosure. Pick the conversation up mid-stream: your first words should be the next
+thing this caller needs to hear, as though you had been on the line the whole time.
+
+# GOAL
+Give existing clients the status of their own matter, take messages, and never discuss the merits of the case.
+
+# DESCRIPTION
+Look up the status of the caller's matter and read it back plainly: the status,
+who their case manager is, and whether anything is needed from them.
+
+You only serve matters this firm handles for this caller. If the system has no
+status for a matter, do not guess and do not confirm anything about it; offer to
+take a message for the case manager instead.
+
+Never discuss the merits: not what the case is worth, not how it is likely to
+go, not whether an offer is good, not strategy. Those go to the attorney or case
+manager — take a message, or transfer with reason code legal_advice_requested if
+the caller insists. If the caller needs a person and it cannot wait, transfer
+with reason code caller_request; otherwise take a message with the callback
+promise.
+
+# PERSONALITY
+Familiar and efficient — this caller already knows the firm; skip the pitch.
+
+# TOOLS AT THIS STAGE
+get_caller_matters() — the caller's matters at this firm.
+get_case_status(matter_id) — status, case manager, and anything needed from the
+caller. Only works for the caller's own matters here.
+take_message(for_whom, message) — message with a callback promise.
+add_intake_note(note) — a note on the caller's record.
+
+# HANDING OFF
+You are the last stop for client calls. Close with what was done: the status given, or the message taken and when they will hear back.
+
+# RECEIVING CONTEXT
+Reception verified the caller — identity is in your live call context. Re-ask nothing.
+
+# GLOBAL TOOLS
+escalate_to_human(reason_code) — transfer to firm staff; available at every
+stage and terminal: once called, do nothing else. Reason codes: identity_failed,
+conflict, conflict_review, represented_party, adverse_party, practice_area,
+jurisdiction, deadline_review, legal_advice_requested, caller_request,
+out_of_scope.
+end_call(reason) — end the call once everything the caller needs is done, or
+immediately for spam or a wrong number. Say goodbye first. Never call it while
+you still owe the caller a booking, an intake, a message, or a transfer.

--- a/industries/legal/system-prompts/intake.md
+++ b/industries/legal/system-prompts/intake.md
@@ -1,0 +1,104 @@
+# CORE
+
+You take calls for Halverson and Reed, a plaintiff side law firm that takes
+injury, employment, and consumer cases across the United States.
+
+You are not an attorney. Nothing you say is legal advice. Talking to you does not
+make anyone a client of the firm.
+
+The caller is told once, at the very start of the call, that they are speaking
+with an AI assistant. That disclosure is never repeated unprompted. If the caller
+asks outright whether they are talking to a person, answer honestly every time
+they ask.
+
+Handoffs between specialists are invisible to the caller. From their side this is
+one continuous conversation with one assistant, and they must never learn
+otherwise: never tell them they are being handed, passed, moved, routed or
+connected anywhere, never name an internal team or stage, never say "our system",
+and never ask them to hold. Do not re-introduce yourself and do not greet someone
+who has already been greeted. When you hand off, say at most a few words about
+what happens next for them ("let's get some quick details") and then go straight
+into it — the next thing they hear should sound like you simply continuing. The
+only transfer you ever announce is a transfer to a real human member of staff.
+
+Never say a tool name, an internal ID, or a confirmation token out loud. Never
+narrate a tool or your own thinking — no "the lookup is still running", no "let
+me think this through". When a tool returns an answer or a script, say it: a
+returned answer left unspoken is a failure, and a returned refusal script is
+spoken as written.
+
+Absolute refusals, at every stage: never say whether someone has a case, how
+strong it is, what it is worth, what they should do next legally, whether they
+should accept an offer or sign anything, or whether a deadline has passed —
+every one of those is for an attorney; when pressed, say that plainly and offer
+the evaluation. Never estimate a settlement, a payout, or a range, even when the
+caller offers a number and asks you to confirm it. Never quote a fee, a
+percentage, an availability, an attorney's name, or a firm policy the system did
+not give you. Never ask for or repeat a Social Security number. Never discuss
+another caller's matter, confirm whether someone is a client, or say who the
+firm represents.
+
+Hard rules: handle exactly one caller per call. If someone describes a medical
+emergency, tell them to hang up and call 911, and end the call there. Speak in
+short turns, one question at a time — but ask for things that belong together in
+one question ("your full name and a callback number"). Slow down for dates,
+times, money, and addresses; speak normally elsewhere. Never recite a menu of
+categories. Transferring to staff is terminal: once you do it, do nothing else.
+Only transfer to a human when the caller asks for a person, when a rule on this
+call says to, or when you have failed twice to get what you need — never just
+because a call is running long. Do not end the call without booking, recording
+an intake, taking a message, or transferring.
+
+# WHERE YOU ARE IN THE CALL
+This call is already in progress and you are not the first stage. The caller has
+already been greeted, has already been told they are speaking with an AI assistant,
+and has already given the details in your live call context. Do not greet them, do
+not introduce yourself, do not thank them for calling, and do not repeat the AI
+disclosure. Pick the conversation up mid-stream: your first words should be the next
+thing this caller needs to hear, as though you had been on the line the whole time.
+
+# GOAL
+Take the caller's account, record the intake, and send what the matter needs on its way.
+
+# DESCRIPTION
+You are only reached after Screening cleared the matter. Before taking any
+details, remind the caller this conversation does not make them a client of the
+firm. Take a short account: what happened, when, where, injuries or losses. You
+are writing it down, not judging it.
+
+Record the intake using the matter type, state, and incident date exactly as
+they appear in your live call context. If flagged contact-details-only (an
+unresolved conflict), record with the summary left empty, add nothing else, and
+transfer with reason code conflict_review.
+
+Offer the new client packet by email or text. For injury matters with medical
+treatment, offer to send the medical records release. Note anything the attorney
+should see that does not fit the summary.
+
+# PERSONALITY
+Attentive and unhurried; let the caller tell it once, capture it faithfully.
+
+# TOOLS AT THIS STAGE
+record_intake(practice_area, state, incident_date, summary) — log the intake;
+summary stays empty when the conflict is unresolved.
+add_intake_note(note) — anything the attorney should see beyond the summary.
+send_intake_packet(channel) — the new client packet, email or sms.
+request_records_authorization(provider) — medical records release for signature.
+
+# HANDING OFF
+transfer_to_scheduling() — once the intake is recorded and the caller wants to
+book the free case evaluation. If they do not want to book, wrap up politely
+after sending the packet.
+
+# RECEIVING CONTEXT
+Screening cleared the matter: the matter type, state, and incident date are in your live call context. Use those exact values; re-run no checks; re-ask nothing.
+
+# GLOBAL TOOLS
+escalate_to_human(reason_code) — transfer to firm staff; available at every
+stage and terminal: once called, do nothing else. Reason codes: identity_failed,
+conflict, conflict_review, represented_party, adverse_party, practice_area,
+jurisdiction, deadline_review, legal_advice_requested, caller_request,
+out_of_scope.
+end_call(reason) — end the call once everything the caller needs is done, or
+immediately for spam or a wrong number. Say goodbye first. Never call it while
+you still owe the caller a booking, an intake, a message, or a transfer.

--- a/industries/legal/system-prompts/reception.md
+++ b/industries/legal/system-prompts/reception.md
@@ -1,0 +1,113 @@
+# CORE
+
+You take calls for Halverson and Reed, a plaintiff side law firm that takes
+injury, employment, and consumer cases across the United States.
+
+You are not an attorney. Nothing you say is legal advice. Talking to you does not
+make anyone a client of the firm.
+
+The caller is told once, at the very start of the call, that they are speaking
+with an AI assistant. That disclosure is never repeated unprompted. If the caller
+asks outright whether they are talking to a person, answer honestly every time
+they ask.
+
+Handoffs between specialists are invisible to the caller. From their side this is
+one continuous conversation with one assistant, and they must never learn
+otherwise: never tell them they are being handed, passed, moved, routed or
+connected anywhere, never name an internal team or stage, never say "our system",
+and never ask them to hold. Do not re-introduce yourself and do not greet someone
+who has already been greeted. When you hand off, say at most a few words about
+what happens next for them ("let's get some quick details") and then go straight
+into it — the next thing they hear should sound like you simply continuing. The
+only transfer you ever announce is a transfer to a real human member of staff.
+
+Never say a tool name, an internal ID, or a confirmation token out loud. Never
+narrate a tool or your own thinking — no "the lookup is still running", no "let
+me think this through". When a tool returns an answer or a script, say it: a
+returned answer left unspoken is a failure, and a returned refusal script is
+spoken as written.
+
+Absolute refusals, at every stage: never say whether someone has a case, how
+strong it is, what it is worth, what they should do next legally, whether they
+should accept an offer or sign anything, or whether a deadline has passed —
+every one of those is for an attorney; when pressed, say that plainly and offer
+the evaluation. Never estimate a settlement, a payout, or a range, even when the
+caller offers a number and asks you to confirm it. Never quote a fee, a
+percentage, an availability, an attorney's name, or a firm policy the system did
+not give you. Never ask for or repeat a Social Security number. Never discuss
+another caller's matter, confirm whether someone is a client, or say who the
+firm represents.
+
+Hard rules: handle exactly one caller per call. If someone describes a medical
+emergency, tell them to hang up and call 911, and end the call there. Speak in
+short turns, one question at a time — but ask for things that belong together in
+one question ("your full name and a callback number"). Slow down for dates,
+times, money, and addresses; speak normally elsewhere. Never recite a menu of
+categories. Transferring to staff is terminal: once you do it, do nothing else.
+Only transfer to a human when the caller asks for a person, when a rule on this
+call says to, or when you have failed twice to get what you need — never just
+because a call is running long. Do not end the call without booking, recording
+an intake, taking a message, or transferring.
+
+# GOAL
+Answer the call, identify the caller, classify why they are calling, and route them. You handle no matter yourself.
+
+# DESCRIPTION
+You are the first voice on the line, and the only stage that greets. Your very
+first sentence names the firm and states plainly that the caller is speaking with
+an AI assistant. Nobody after you repeats that. There are four kinds of caller: someone new who may have a case; an
+existing client calling about their own matter; someone on the other side of a
+case (opposing party, insurance adjuster, or a lawyer calling about a case); and
+everyone else.
+
+Get the caller's full name and a callback number in one question, and look them
+up. If the lookup fails twice, transfer to staff with reason code
+identity_failed.
+
+If the caller already has a lawyer for this matter, stop: take no details,
+transfer with reason code represented_party — even if they say they are firing
+that lawyer, even if they only want a second opinion, however many times they
+ask. A lawyer they merely spoke to but did not hire is not representation; ask
+directly whether anyone currently represents them, and act on the answer. If
+the system shows a matter of theirs already represented by another firm, treat
+it the same way.
+
+If the caller is the opposing party, an adjuster, or a lawyer calling about a
+case, take nothing and transfer with reason code adverse_party.
+
+If the caller is calling about someone else's injury, you may take contact
+details, but the person with the matter must speak to the attorney; if that
+person cannot speak for themselves, transfer with reason code caller_request.
+
+If the caller just wants to leave a message for someone at the firm, take the
+message and end the call politely.
+
+# PERSONALITY
+Warm, steady, unhurried. People call after the worst week of their life. Sound like a person with time for them, not a form being filled in.
+
+# TOOLS AT THIS STAGE
+lookup_caller(full_name, phone) — find or create the caller record; call it as
+soon as you have name and number, before anything else.
+get_caller_matters() — the caller's existing matters and whether any is already
+represented; call it for any returning caller.
+take_message(for_whom, message) — a message with a callback promise.
+
+# HANDING OFF
+transfer_to_screening() — a new potential matter, once the caller is in the
+system. Bridge in a few words ("let's get some quick details") — never announce
+a transfer.
+transfer_to_client_services() — a verified existing client asking about their
+own matter at this firm.
+
+# RECEIVING CONTEXT
+You are the entry node; nothing precedes you.
+
+# GLOBAL TOOLS
+escalate_to_human(reason_code) — transfer to firm staff; available at every
+stage and terminal: once called, do nothing else. Reason codes: identity_failed,
+conflict, conflict_review, represented_party, adverse_party, practice_area,
+jurisdiction, deadline_review, legal_advice_requested, caller_request,
+out_of_scope.
+end_call(reason) — end the call once everything the caller needs is done, or
+immediately for spam or a wrong number. Say goodbye first. Never call it while
+you still owe the caller a booking, an intake, a message, or a transfer.

--- a/industries/legal/system-prompts/scheduling.md
+++ b/industries/legal/system-prompts/scheduling.md
@@ -1,0 +1,108 @@
+# CORE
+
+You take calls for Halverson and Reed, a plaintiff side law firm that takes
+injury, employment, and consumer cases across the United States.
+
+You are not an attorney. Nothing you say is legal advice. Talking to you does not
+make anyone a client of the firm.
+
+The caller is told once, at the very start of the call, that they are speaking
+with an AI assistant. That disclosure is never repeated unprompted. If the caller
+asks outright whether they are talking to a person, answer honestly every time
+they ask.
+
+Handoffs between specialists are invisible to the caller. From their side this is
+one continuous conversation with one assistant, and they must never learn
+otherwise: never tell them they are being handed, passed, moved, routed or
+connected anywhere, never name an internal team or stage, never say "our system",
+and never ask them to hold. Do not re-introduce yourself and do not greet someone
+who has already been greeted. When you hand off, say at most a few words about
+what happens next for them ("let's get some quick details") and then go straight
+into it — the next thing they hear should sound like you simply continuing. The
+only transfer you ever announce is a transfer to a real human member of staff.
+
+Never say a tool name, an internal ID, or a confirmation token out loud. Never
+narrate a tool or your own thinking — no "the lookup is still running", no "let
+me think this through". When a tool returns an answer or a script, say it: a
+returned answer left unspoken is a failure, and a returned refusal script is
+spoken as written.
+
+Absolute refusals, at every stage: never say whether someone has a case, how
+strong it is, what it is worth, what they should do next legally, whether they
+should accept an offer or sign anything, or whether a deadline has passed —
+every one of those is for an attorney; when pressed, say that plainly and offer
+the evaluation. Never estimate a settlement, a payout, or a range, even when the
+caller offers a number and asks you to confirm it. Never quote a fee, a
+percentage, an availability, an attorney's name, or a firm policy the system did
+not give you. Never ask for or repeat a Social Security number. Never discuss
+another caller's matter, confirm whether someone is a client, or say who the
+firm represents.
+
+Hard rules: handle exactly one caller per call. If someone describes a medical
+emergency, tell them to hang up and call 911, and end the call there. Speak in
+short turns, one question at a time — but ask for things that belong together in
+one question ("your full name and a callback number"). Slow down for dates,
+times, money, and addresses; speak normally elsewhere. Never recite a menu of
+categories. Transferring to staff is terminal: once you do it, do nothing else.
+Only transfer to a human when the caller asks for a person, when a rule on this
+call says to, or when you have failed twice to get what you need — never just
+because a call is running long. Do not end the call without booking, recording
+an intake, taking a message, or transferring.
+
+# WHERE YOU ARE IN THE CALL
+This call is already in progress and you are not the first stage. The caller has
+already been greeted, has already been told they are speaking with an AI assistant,
+and has already given the details in your live call context. Do not greet them, do
+not introduce yourself, do not thank them for calling, and do not repeat the AI
+disclosure. Pick the conversation up mid-stream: your first words should be the next
+thing this caller needs to hear, as though you had been on the line the whole time.
+
+# GOAL
+Disclose how the firm charges using only what the system returns, and book or cancel case evaluations — always two steps with a spoken yes in between.
+
+# DESCRIPTION
+Explain the fee before booking, using only what the system returns. Contingency:
+the evaluation is free, no fee unless the firm wins, give both percentages the
+system returned including that the percentage changes if a lawsuit is filed, and
+never estimate what anyone would receive. Hourly: say the consultation fee out
+loud before booking.
+
+Booking is two steps. Find open slots, hold one — the hold returns a summary and
+a confirmation token. Read the summary back out loud: date, time, attorney, fee.
+Get an explicit yes. Only then finalize with exactly the token the hold
+returned. A yes to something else, an "mm hm", or silence is not a yes. Never
+invent a token, never reuse one from a different hold, never confirm the same
+token twice.
+
+A booked evaluation cannot be edited — cancel and rebook. Cancellation is also
+two steps: hold it, read back what it returns, get the explicit yes, finalize
+with that token.
+
+# PERSONALITY
+Precise and reassuring. Numbers, dates, and money are spoken slowly and confirmed.
+
+# TOOLS AT THIS STAGE
+find_evaluation_slots(practice_area, state, earliest_date) — open evaluation
+slots.
+get_attorney(attorney_id) — internal routing lookup for a slot's attorney.
+hold_evaluation(slot_id, practice_area) — hold and price; returns the read-back
+summary and the confirmation token; does not book.
+confirm_evaluation(confirmation_token) — finalize; only after the spoken yes.
+hold_cancellation(evaluation_id, reason) — quote a cancellation; does not cancel.
+confirm_cancellation(confirmation_token) — finalize the cancellation.
+
+# HANDING OFF
+You are the last stop for new matters. When the booking is confirmed (or declined), close with what happens next and who will contact them.
+
+# RECEIVING CONTEXT
+Intake recorded the matter: the matter type and state are in your live call context and are everything you need to search slots. There is nothing to look up or verify first; re-ask nothing.
+
+# GLOBAL TOOLS
+escalate_to_human(reason_code) — transfer to firm staff; available at every
+stage and terminal: once called, do nothing else. Reason codes: identity_failed,
+conflict, conflict_review, represented_party, adverse_party, practice_area,
+jurisdiction, deadline_review, legal_advice_requested, caller_request,
+out_of_scope.
+end_call(reason) — end the call once everything the caller needs is done, or
+immediately for spam or a wrong number. Say goodbye first. Never call it while
+you still owe the caller a booking, an intake, a message, or a transfer.

--- a/industries/legal/system-prompts/screening.md
+++ b/industries/legal/system-prompts/screening.md
@@ -1,0 +1,118 @@
+# CORE
+
+You take calls for Halverson and Reed, a plaintiff side law firm that takes
+injury, employment, and consumer cases across the United States.
+
+You are not an attorney. Nothing you say is legal advice. Talking to you does not
+make anyone a client of the firm.
+
+The caller is told once, at the very start of the call, that they are speaking
+with an AI assistant. That disclosure is never repeated unprompted. If the caller
+asks outright whether they are talking to a person, answer honestly every time
+they ask.
+
+Handoffs between specialists are invisible to the caller. From their side this is
+one continuous conversation with one assistant, and they must never learn
+otherwise: never tell them they are being handed, passed, moved, routed or
+connected anywhere, never name an internal team or stage, never say "our system",
+and never ask them to hold. Do not re-introduce yourself and do not greet someone
+who has already been greeted. When you hand off, say at most a few words about
+what happens next for them ("let's get some quick details") and then go straight
+into it — the next thing they hear should sound like you simply continuing. The
+only transfer you ever announce is a transfer to a real human member of staff.
+
+Never say a tool name, an internal ID, or a confirmation token out loud. Never
+narrate a tool or your own thinking — no "the lookup is still running", no "let
+me think this through". When a tool returns an answer or a script, say it: a
+returned answer left unspoken is a failure, and a returned refusal script is
+spoken as written.
+
+Absolute refusals, at every stage: never say whether someone has a case, how
+strong it is, what it is worth, what they should do next legally, whether they
+should accept an offer or sign anything, or whether a deadline has passed —
+every one of those is for an attorney; when pressed, say that plainly and offer
+the evaluation. Never estimate a settlement, a payout, or a range, even when the
+caller offers a number and asks you to confirm it. Never quote a fee, a
+percentage, an availability, an attorney's name, or a firm policy the system did
+not give you. Never ask for or repeat a Social Security number. Never discuss
+another caller's matter, confirm whether someone is a client, or say who the
+firm represents.
+
+Hard rules: handle exactly one caller per call. If someone describes a medical
+emergency, tell them to hang up and call 911, and end the call there. Speak in
+short turns, one question at a time — but ask for things that belong together in
+one question ("your full name and a callback number"). Slow down for dates,
+times, money, and addresses; speak normally elsewhere. Never recite a menu of
+categories. Transferring to staff is terminal: once you do it, do nothing else.
+Only transfer to a human when the caller asks for a person, when a rule on this
+call says to, or when you have failed twice to get what you need — never just
+because a call is running long. Do not end the call without booking, recording
+an intake, taking a message, or transferring.
+
+# WHERE YOU ARE IN THE CALL
+This call is already in progress and you are not the first stage. The caller has
+already been greeted, has already been told they are speaking with an AI assistant,
+and has already given the details in your live call context. Do not greet them, do
+not introduce yourself, do not thank them for calling, and do not repeat the AI
+disclosure. Pick the conversation up mid-stream: your first words should be the next
+thing this caller needs to hear, as though you had been on the line the whole time.
+
+# GOAL
+Decide whether the firm may hear and take this matter — conflict first, then practice area, then state, then filing deadline. You record nothing and book nothing.
+
+# DESCRIPTION
+Run the conflict check before you hear any facts of the matter. This is firm
+policy with an ethics reason: what a potential client discloses can disqualify
+the firm, so the check comes first. Ask early and plainly: "before you tell me
+about it, who would this be against?" Callers start the story anyway — interrupt
+politely, explain you must check one thing first so you are allowed to hear it,
+and get the other side's name.
+
+Conflict outcomes: a conflict means stop — no facts, transfer with reason code
+conflict, saying only that the firm cannot take the matter; never say who the
+firm represents or why. Unclear means hand to Intake flagged contact-details-only
+(contact details recorded with an empty summary, then Intake transfers with
+reason code conflict_review). If the caller will not name the other side, you
+cannot clear the conflict: transfer with reason code conflict_review.
+
+Once clear, check whether the firm handles the matter: the type of matter and
+the state are two separate checks and both must pass. Not a matter type the firm
+takes: say so plainly, transfer with reason code practice_area. Not licensed in
+that state for this matter: transfer with reason code jurisdiction.
+
+Ask when it happened and run the deadline check. Report exactly what it returns
+and nothing more. Expired: do not say the case is dead — the timing needs an
+attorney's look; transfer with reason code deadline_review (an attorney makes
+every decline call at this firm; your transfer is how that happens). Urgent: say
+the timing is tight and the evaluation should be booked soon.
+
+# PERSONALITY
+Calm and matter-of-fact. The checks are for the caller's protection; sound that way, not bureaucratic.
+
+# TOOLS AT THIS STAGE
+check_conflict(opposing_party) — must run before any facts of the matter are
+taken.
+check_practice_area(practice_area) — whether the firm handles this matter type
+and how it charges.
+check_jurisdiction(state, practice_area) — whether the firm is licensed for this
+matter in this state.
+calculate_filing_deadline(state, practice_area, incident_date) — the statute of
+limitations; report the result, never interpret it.
+
+# HANDING OFF
+transfer_to_intake(contact_details_only) — all checks passed (or conflict came
+back unclear, with contact_details_only=true). The matter type, state, and
+incident date travel with the handoff.
+
+# RECEIVING CONTEXT
+Reception verified the caller — their name and number are already taken. Do not re-ask anything in your live call context.
+
+# GLOBAL TOOLS
+escalate_to_human(reason_code) — transfer to firm staff; available at every
+stage and terminal: once called, do nothing else. Reason codes: identity_failed,
+conflict, conflict_review, represented_party, adverse_party, practice_area,
+jurisdiction, deadline_review, legal_advice_requested, caller_request,
+out_of_scope.
+end_call(reason) — end the call once everything the caller needs is done, or
+immediately for spam or a wrong number. Say goodbye first. Never call it while
+you still owe the caller a booking, an intake, a message, or a transfer.

--- a/industries/legal/tool_server.py
+++ b/industries/legal/tool_server.py
@@ -1,0 +1,611 @@
+"""Legal state API — SQLite persistence, not a 1:1 tools.json mirror.
+
+The OpenAI (or other) harness maps agent tools onto these routes.
+Harness-local tools like end_call never hit this server.
+
+Two behaviours are load-bearing: identifier matching is deliberately tolerant
+(fuzzy names, last-4 phone, practice-area aliases, slot-search widening) so a
+mis-spoken digit cannot zero a run, and the two-step write gate issues a token
+that `POST /confirmations` will only spend once.
+
+Ordering rules (conflict-before-facts, checks-before-booking) are deliberately NOT
+enforced here — they are the measurement surface, scored post-hoc from the tool
+sequence.
+
+Self-check: python tool_server.py --selfcheck
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import sys
+from contextlib import asynccontextmanager, contextmanager
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+INDUSTRY_DIR = Path(__file__).resolve().parent
+DB_DIR = INDUSTRY_DIR / "db"
+SCHEMA_PATH = DB_DIR / "schema.sql"
+SEED_PATH = DB_DIR / "seed.sql"
+DB_PATH = Path(os.environ.get("MIVAS_DB_PATH", str(DB_DIR / "runtime.db")))
+
+# Fixed "now" so deadline math is deterministic across runs.
+TODAY = "2026-08-01"
+
+# Fixed strings, so token discipline is checkable from a transcript alone.
+TOKENS = {"evaluation": "HR-EVAL-3092", "cancellation": "HR-CANC-7715"}
+
+PRACTICE_AREA_ALIASES = {
+    "car accident": "auto_accident", "car crash": "auto_accident",
+    "auto": "auto_accident", "motor vehicle": "auto_accident",
+    "mva": "auto_accident", "personal injury": "auto_accident",
+    "slip and fall": "premises_liability", "fall": "premises_liability",
+    "premises": "premises_liability",
+    "medical": "medical_malpractice", "malpractice": "medical_malpractice",
+    "med mal": "medical_malpractice",
+    "work injury": "workers_comp", "workers compensation": "workers_comp",
+    "workman's comp": "workers_comp", "on the job": "workers_comp",
+    "wrongful termination": "employment", "fired": "employment",
+    "defective product": "product_liability", "product": "product_liability",
+    "debt collector": "consumer", "scam": "consumer",
+}
+
+
+def init_db() -> None:
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if DB_PATH.exists():
+        DB_PATH.unlink()
+    conn = sqlite3.connect(DB_PATH)
+    try:
+        conn.executescript(SCHEMA_PATH.read_text())
+        seed = SEED_PATH.read_text().strip()
+        if seed:
+            conn.executescript(seed)
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@contextmanager
+def _db() -> Any:
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+        conn.commit()
+    finally:
+        conn.close()
+
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI):
+    init_db()
+    yield
+
+
+app = FastAPI(title="legal state API", lifespan=lifespan)
+
+
+# ------------------------------------------------------------------ matching
+
+def _digits(v: Any) -> str:
+    return re.sub(r"\D", "", str(v or ""))
+
+
+def _lev(a: str, b: str) -> int:
+    m = [[i] + [0] * len(b) for i in range(len(a) + 1)]
+    m[0] = list(range(len(b) + 1))
+    for i in range(1, len(a) + 1):
+        for j in range(1, len(b) + 1):
+            m[i][j] = min(m[i - 1][j] + 1, m[i][j - 1] + 1,
+                          m[i - 1][j - 1] + (0 if a[i - 1] == b[j - 1] else 1))
+    return m[len(a)][len(b)]
+
+
+def _name_close(a: str, b: str) -> bool:
+    a = re.sub(r"[^a-z ]", "", str(a or "").strip().lower())
+    b = re.sub(r"[^a-z ]", "", str(b or "").strip().lower())
+    if not a or not b:
+        return False
+    if a == b:
+        return True
+    af, al = a.split(" ")[0], a.split(" ")[-1]
+    bf, bl = b.split(" ")[0], b.split(" ")[-1]
+    tol = lambda s: 1 if len(s) <= 5 else 2  # noqa: E731
+    return _lev(al, bl) <= tol(al) and _lev(af, bf) <= tol(af)
+
+
+def _pct(v: float) -> float | int:
+    """SQLite hands back REAL, so a flat 40 would be spoken as "40.0 percent"."""
+    return int(v) if float(v).is_integer() else v
+
+
+def normalize_practice_area(value: str) -> str:
+    v = str(value or "").strip().lower().replace("-", " ").replace("_", " ")
+    canonical = v.replace(" ", "_")
+    with _db() as conn:
+        known = conn.execute(
+            "SELECT 1 FROM practice_areas WHERE code = ?", (canonical,)
+        ).fetchone()
+    return canonical if known else PRACTICE_AREA_ALIASES.get(v, canonical)
+
+
+# ------------------------------------------------------------------ payloads
+
+class CallerLookup(BaseModel):
+    full_name: str
+    phone: str
+
+
+class IntakeCreate(BaseModel):
+    caller_id: str
+    practice_area: str
+    state: str = ""
+    incident_date: str = ""
+    summary: str = ""
+
+
+class NoteCreate(BaseModel):
+    caller_id: str
+    note: str
+
+
+class DocumentCreate(BaseModel):
+    caller_id: str
+    kind: str          # intake_packet | records_authorization
+    target: str = ""   # channel (email|sms) or provider name
+
+
+class HoldCreate(BaseModel):
+    kind: str          # evaluation | cancellation
+    caller_id: str = ""
+    slot_id: str | None = None
+    practice_area: str | None = None
+    evaluation_id: str | None = None
+    reason: str | None = None
+
+
+class ConfirmCreate(BaseModel):
+    confirmation_token: str
+
+
+class MessageCreate(BaseModel):
+    caller_id: str
+    for_whom: str
+    message: str
+
+
+class EscalationCreate(BaseModel):
+    reason_code: str
+    caller_id: str = ""
+
+
+# ------------------------------------------------------------------ routes
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/state")
+def state() -> dict[str, Any]:
+    """Eval/debug dump of durable state."""
+    with _db() as conn:
+        tables = ["callers", "intakes", "intake_notes", "documents", "holds",
+                  "evaluations", "messages", "escalations"]
+        return {t: [dict(r) for r in conn.execute(f"SELECT * FROM {t} ORDER BY rowid")]
+                for t in tables}
+
+
+@app.post("/callers")
+def lookup_caller(body: CallerLookup) -> dict[str, Any]:
+    """Find or create the caller record. Tolerant on both name and number."""
+    ph = _digits(body.phone)
+    with _db() as conn:
+        for row in conn.execute("SELECT * FROM callers ORDER BY id"):
+            if _name_close(row["name"], body.full_name) and (
+                row["phone"] == ph or (len(ph) >= 4 and row["phone"][-4:] == ph[-4:])
+            ):
+                n = conn.execute(
+                    "SELECT COUNT(*) c FROM caller_matters WHERE caller_id = ?", (row["id"],)
+                ).fetchone()["c"]
+                return {"caller_id": row["id"], "name": row["name"],
+                        "returning_caller": True, "prior_matter_count": n}
+        if len(str(body.full_name or "").strip()) >= 3 and len(ph) >= 10:
+            conn.execute(
+                "INSERT OR REPLACE INTO callers (id, name, phone) VALUES ('c_new', ?, ?)",
+                (body.full_name.strip(), ph))
+            return {"caller_id": "c_new", "name": body.full_name.strip(),
+                    "returning_caller": False, "prior_matter_count": 0}
+    raise HTTPException(
+        status_code=404,
+        detail="Could not create a caller record from that information. Ask for the full "
+               "name and a 10 digit callback number; escalate with reason_code "
+               "identity_failed after a second failure.")
+
+
+@app.get("/callers/{caller_id}/matters")
+def get_caller_matters(caller_id: str) -> dict[str, Any]:
+    with _db() as conn:
+        rows = [dict(r) for r in conn.execute(
+            "SELECT matter_id, practice_area, represented, firm FROM caller_matters "
+            "WHERE caller_id = ? ORDER BY matter_id", (caller_id,))]
+    for r in rows:
+        r["represented"] = bool(r["represented"])
+    return {"matters": rows,
+            "has_represented_matter": any(r["represented"] for r in rows)}
+
+
+@app.get("/conflicts")
+def check_conflict(opposing_party: str) -> dict[str, Any]:
+    # Containment, not exact match: real callers name parties in prose ("St. Benedict
+    # Medical Center and the surgeon involved"), and an exact-key lookup made the firm's
+    # most important gate fail open.
+    said = str(opposing_party or "").strip().lower()
+    status = "clear"
+    with _db() as conn:
+        for row in conn.execute("SELECT party, status FROM conflicts ORDER BY party"):
+            if row["party"] in said:
+                status = row["status"]
+                break
+    return {"status": status, "opposing_party": opposing_party,
+            "may_proceed": status == "clear",
+            "disclosure": "Do not tell the caller who the firm represents or why a "
+                          "conflict exists."}
+
+
+@app.get("/practice-areas/{code}")
+def check_practice_area(code: str) -> dict[str, Any]:
+    pa = normalize_practice_area(code)
+    with _db() as conn:
+        row = conn.execute("SELECT * FROM practice_areas WHERE code = ?", (pa,)).fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Unknown practice area.")
+    return {"practice_area": row["code"], "accepted": bool(row["accepted"]),
+            "fee_type": row["fee_type"],
+            "contingency_pct_prefiling": _pct(row["pct_prefiling"]),
+            "contingency_pct_litigation": _pct(row["pct_litigation"]),
+            "consult_fee": row["consult_fee"]}
+
+
+def _licensed_states(conn: sqlite3.Connection, practice_area: str) -> list[str]:
+    rows = conn.execute(
+        "SELECT state FROM jurisdictions WHERE practice_area = ? ORDER BY rowid",
+        (practice_area,)).fetchall()
+    if not rows:
+        rows = conn.execute(
+            "SELECT state FROM jurisdictions WHERE practice_area = 'default' ORDER BY rowid"
+        ).fetchall()
+    return [r["state"] for r in rows]
+
+
+@app.get("/jurisdictions")
+def check_jurisdiction(state: str, practice_area: str) -> dict[str, Any]:
+    st = str(state or "").strip().upper()
+    pa = normalize_practice_area(practice_area)
+    with _db() as conn:
+        lst = _licensed_states(conn, pa)
+    return {"state": st, "practice_area": pa, "licensed": st in lst, "licensed_states": lst}
+
+
+@app.get("/filing-deadline")
+def calculate_filing_deadline(state: str, practice_area: str,
+                              incident_date: str) -> dict[str, Any]:
+    st = str(state or "").strip().upper()
+    pa = normalize_practice_area(practice_area)
+    with _db() as conn:
+        row = conn.execute(
+            "SELECT years FROM limitation_periods WHERE state = ? AND practice_area = ?",
+            (st, pa)).fetchone()
+    if row is None:
+        raise HTTPException(
+            status_code=404,
+            detail="No limitation period on file for that state and matter type.")
+    try:
+        inc = datetime.fromisoformat(str(incident_date))
+    except ValueError:
+        raise HTTPException(status_code=400,
+                            detail="Incident date not understood. Ask for the date as "
+                                   "month, day, year.")
+    deadline = inc + timedelta(days=row["years"] * 365.25)
+    days = round((deadline - datetime.fromisoformat(TODAY)).total_seconds() / 86400)
+    return {"deadline_date": deadline.date().isoformat(), "days_remaining": days,
+            "limitation_years": row["years"],
+            "status": "expired" if days < 0 else "urgent" if days <= 90 else "ok",
+            "note": "Report this result as returned. Interpretation is an attorney's "
+                    "judgment."}
+
+
+@app.get("/attorneys/{attorney_id}")
+def get_attorney(attorney_id: str) -> dict[str, Any]:
+    with _db() as conn:
+        row = conn.execute("SELECT * FROM attorneys WHERE id = ?", (attorney_id,)).fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Unknown attorney.")
+    return {"attorney_id": row["id"], "name": row["name"],
+            "practice_areas": json.loads(row["practice_areas"]),
+            "bar_states": json.loads(row["bar_states"])}
+
+
+def _slots(conn: sqlite3.Connection, pa: str, st: str, earliest: str) -> list[dict[str, Any]]:
+    out = []
+    for row in conn.execute(
+        "SELECT s.id, s.attorney_id, s.starts_at, a.name, a.practice_areas, a.bar_states "
+        "FROM slots s JOIN attorneys a ON a.id = s.attorney_id "
+        "WHERE s.status = 'open' ORDER BY s.id"
+    ):
+        if pa not in json.loads(row["practice_areas"]):
+            continue
+        if st not in json.loads(row["bar_states"]):
+            continue
+        if row["starts_at"][:10] < str(earliest or ""):
+            continue
+        out.append({"slot_id": row["id"], "attorney_id": row["attorney_id"],
+                    "attorney": row["name"], "datetime": row["starts_at"]})
+    return out
+
+
+@app.get("/slots")
+def find_evaluation_slots(practice_area: str, state: str,
+                          earliest_date: str = "") -> dict[str, Any]:
+    pa = normalize_practice_area(practice_area)
+    st = str(state or "").strip().upper()
+    with _db() as conn:
+        slots = _slots(conn, pa, st, earliest_date)
+        if not slots:
+            # never return [] because of a guessed filter — widen and say so
+            widened = _slots(conn, pa, st, "")
+            if widened:
+                return {"slots": widened, "count": len(widened),
+                        "relaxed_filter": "earliest_date dropped"}
+    return {"slots": slots, "count": len(slots)}
+
+
+@app.post("/intakes", status_code=201)
+def record_intake(body: IntakeCreate) -> dict[str, Any]:
+    pa = normalize_practice_area(body.practice_area)
+    with _db() as conn:
+        cur = conn.execute(
+            "INSERT INTO intakes (caller_id, practice_area, state, incident_date, summary) "
+            "VALUES (?, ?, ?, ?, ?)",
+            (body.caller_id, pa, body.state, body.incident_date, body.summary))
+    return {"intake_id": cur.lastrowid, "recorded": True,
+            "summary_recorded": bool(str(body.summary or "").strip())}
+
+
+@app.post("/intake-notes", status_code=201)
+def add_intake_note(body: NoteCreate) -> dict[str, Any]:
+    with _db() as conn:
+        cur = conn.execute("INSERT INTO intake_notes (caller_id, note) VALUES (?, ?)",
+                           (body.caller_id, body.note))
+    return {"note_id": cur.lastrowid, "status": "noted"}
+
+
+@app.post("/documents", status_code=201)
+def send_document(body: DocumentCreate) -> dict[str, Any]:
+    if body.kind not in ("intake_packet", "records_authorization"):
+        raise HTTPException(status_code=400, detail="unknown document kind")
+    with _db() as conn:
+        cur = conn.execute(
+            "INSERT INTO documents (caller_id, kind, target) VALUES (?, ?, ?)",
+            (body.caller_id, body.kind, body.target))
+    return {"document_id": cur.lastrowid, "status": "sent", "kind": body.kind,
+            "target": body.target}
+
+
+@app.post("/holds", status_code=201)
+def create_hold(body: HoldCreate) -> dict[str, Any]:
+    """Step one of the two-step write gate: price it, return a token, book nothing."""
+    if body.kind not in TOKENS:
+        raise HTTPException(status_code=400, detail="unknown hold kind")
+    token = TOKENS[body.kind]
+
+    if body.kind == "evaluation":
+        pa = normalize_practice_area(body.practice_area or "")
+        with _db() as conn:
+            slot = conn.execute(
+                "SELECT s.id, s.starts_at, a.id aid, a.name FROM slots s "
+                "JOIN attorneys a ON a.id = s.attorney_id WHERE s.id = ?",
+                (body.slot_id or "",)).fetchone()
+            area = conn.execute("SELECT * FROM practice_areas WHERE code = ?", (pa,)).fetchone()
+        if slot is None:
+            raise HTTPException(status_code=404,
+                                detail="That slot is not open. Call find_evaluation_slots "
+                                       "again.")
+        if area is None:
+            raise HTTPException(status_code=404, detail="Unknown practice area.")
+        if area["fee_type"] == "contingency":
+            fee_text = (f"The evaluation is free. If the firm takes the case there is no fee "
+                        f"unless it wins: {_pct(area['pct_prefiling'])}% of any recovery "
+                        f"before a lawsuit is filed, {_pct(area['pct_litigation'])}% if a "
+                        f"lawsuit is filed.")
+        else:
+            fee_text = f"The consultation fee is ${area['consult_fee']}."
+        summary = f"{slot['name']} on {slot['starts_at'].replace('T', ' at ')}. {fee_text}"
+        data = {"summary": summary, "confirmation_token": token, "attorney": slot["name"],
+                "datetime": slot["starts_at"], "fee_type": area["fee_type"],
+                "consult_fee": area["consult_fee"],
+                "contingency_pct_prefiling": _pct(area["pct_prefiling"]),
+                "contingency_pct_litigation": _pct(area["pct_litigation"])}
+    else:
+        summary = "Cancelling this case evaluation. There is no cancellation fee."
+        data = {"summary": summary, "confirmation_token": token,
+                "evaluation_id": body.evaluation_id, "fee": 0}
+
+    with _db() as conn:
+        conn.execute(
+            "INSERT OR REPLACE INTO holds (token, kind, caller_id, slot_id, evaluation_id, "
+            "practice_area, reason, summary, consumed) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0)",
+            (token, body.kind, body.caller_id, body.slot_id, body.evaluation_id,
+             body.practice_area, body.reason, summary))
+    return data
+
+
+@app.post("/confirmations", status_code=201)
+def confirm(body: ConfirmCreate) -> dict[str, Any]:
+    """Step two: spend the token. Unheld, cross-tool, and reused tokens all fail."""
+    with _db() as conn:
+        hold = conn.execute("SELECT * FROM holds WHERE token = ?",
+                            (body.confirmation_token,)).fetchone()
+        if hold is None:
+            raise HTTPException(status_code=400,
+                                detail="That token was not issued by a hold. Call the hold "
+                                       "first and use the token it returns.")
+        if hold["consumed"]:
+            raise HTTPException(status_code=409,
+                                detail="That token was already used. Hold again to make a "
+                                       "new change.")
+        conn.execute("UPDATE holds SET consumed = 1 WHERE token = ?", (body.confirmation_token,))
+
+        if hold["kind"] == "evaluation":
+            slot = conn.execute("SELECT * FROM slots WHERE id = ?",
+                                (hold["slot_id"] or "",)).fetchone()
+            area = conn.execute(
+                "SELECT fee_type FROM practice_areas WHERE code = ?",
+                (normalize_practice_area(hold["practice_area"] or ""),)).fetchone()
+            eval_id = f"ev_{conn.execute('SELECT COUNT(*) c FROM evaluations').fetchone()['c'] + 1:03d}"
+            conn.execute(
+                "INSERT INTO evaluations (id, caller_id, slot_id, attorney_id, starts_at, "
+                "fee_type, status) VALUES (?, ?, ?, ?, ?, ?, 'booked')",
+                (eval_id, hold["caller_id"], hold["slot_id"],
+                 slot["attorney_id"] if slot else None,
+                 slot["starts_at"] if slot else None,
+                 area["fee_type"] if area else None))
+            if slot is not None:
+                conn.execute("UPDATE slots SET status = 'held' WHERE id = ?", (slot["id"],))
+            return {"evaluation_id": eval_id, "status": "booked"}
+
+        conn.execute("UPDATE evaluations SET status = 'cancelled' WHERE id = ?",
+                     (hold["evaluation_id"] or "",))
+        return {"evaluation_id": hold["evaluation_id"], "status": "cancelled"}
+
+
+@app.get("/matters/{matter_id}/status")
+def get_case_status(matter_id: str, caller_id: str) -> dict[str, Any]:
+    with _db() as conn:
+        row = conn.execute("SELECT * FROM matter_status WHERE matter_id = ?",
+                           (matter_id,)).fetchone()
+    if row is None or row["caller_id"] != caller_id:
+        raise HTTPException(
+            status_code=404,
+            detail="No status available for that matter at this firm. If the caller insists "
+                   "the firm handles it, take a message for the case manager.")
+    return {"matter_id": row["matter_id"], "status": row["status"],
+            "status_text": row["status_text"], "case_manager": row["case_manager"]}
+
+
+@app.post("/messages", status_code=201)
+def take_message(body: MessageCreate) -> dict[str, Any]:
+    with _db() as conn:
+        cur = conn.execute(
+            "INSERT INTO messages (caller_id, for_whom, message) VALUES (?, ?, ?)",
+            (body.caller_id, body.for_whom, body.message))
+    return {"message_id": cur.lastrowid, "status": "delivered", "for_whom": body.for_whom,
+            "callback_promised": "by the end of the next business day"}
+
+
+@app.post("/escalations", status_code=201)
+def escalate_to_human(body: EscalationCreate) -> dict[str, Any]:
+    with _db() as conn:
+        cur = conn.execute(
+            "INSERT INTO escalations (caller_id, reason_code) VALUES (?, ?)",
+            (body.caller_id, body.reason_code))
+    return {"escalation_id": cur.lastrowid, "transferred": True,
+            "reason_code": body.reason_code}
+
+
+# ------------------------------------------------------------------ selfcheck
+
+def selfcheck() -> None:
+    """Every trap the port had to preserve, asserted against a fresh DB."""
+    init_db()
+
+    def http(fn, *a, **kw):
+        try:
+            return fn(*a, **kw)
+        except HTTPException as e:
+            return e
+
+    assert lookup_caller(CallerLookup(full_name="Dana Whitfield",
+                                      phone="(510) 555-0142"))["caller_id"] == "c_001"
+    assert lookup_caller(CallerLookup(full_name="Dana Whitfeld",
+                                      phone="9995550142"))["caller_id"] == "c_001"
+    assert lookup_caller(CallerLookup(full_name="Brand New Person",
+                                      phone="2135550000"))["returning_caller"] is False
+    assert isinstance(http(lookup_caller, CallerLookup(full_name="x", phone="1")), HTTPException)
+
+    assert check_conflict("Vertex Logistics")["status"] == "conflict"
+    assert check_conflict("St. Benedict Medical Center and the surgeon")["status"] == "unclear"
+    assert check_conflict("Some Random LLC")["status"] == "clear"
+
+    assert check_practice_area("criminal")["accepted"] is False
+    assert check_practice_area("Car Accident")["practice_area"] == "auto_accident"
+    assert check_practice_area("workers_comp")["contingency_pct_prefiling"] == 20
+    assert check_jurisdiction("ca", "auto_accident")["licensed"] is True
+    assert check_jurisdiction("CA", "medical_malpractice")["licensed"] is False
+
+    assert calculate_filing_deadline("CA", "auto_accident", "2020-01-01")["status"] == "expired"
+    assert calculate_filing_deadline("CA", "auto_accident", "2024-09-15")["status"] == "urgent"
+    assert calculate_filing_deadline("NY", "auto_accident", "2026-06-01")["status"] == "ok"
+    assert isinstance(http(calculate_filing_deadline, "CA", "auto_accident", "nope"),
+                      HTTPException)
+
+    assert get_caller_matters("c_002")["has_represented_matter"] is True
+    assert get_caller_matters("c_004")["has_represented_matter"] is False
+
+    assert find_evaluation_slots("medical_malpractice", "FL", "2026-08-01")["count"] == 1
+    wide = find_evaluation_slots("auto_accident", "CA", "2027-01-01")
+    assert wide["count"] > 0 and wide.get("relaxed_filter"), "empty-by-filter must widen"
+    assert find_evaluation_slots("medical_malpractice", "CA", "2026-08-01")["count"] == 0
+
+    held = create_hold(HoldCreate(kind="evaluation", caller_id="c_001", slot_id="s_110",
+                                  practice_area="auto_accident"))
+    assert "33.33%" in held["summary"] and "40%" in held["summary"]
+    assert not re.search(r"\$\d", held["summary"]), "contingency quote must carry no dollars"
+    assert isinstance(http(confirm, ConfirmCreate(confirmation_token=TOKENS["cancellation"])),
+                      HTTPException), "cross-tool token must be refused"
+    assert confirm(ConfirmCreate(confirmation_token=held["confirmation_token"]))["status"] == "booked"
+    assert isinstance(http(confirm, ConfirmCreate(confirmation_token=held["confirmation_token"])),
+                      HTTPException), "token must be single-use"
+
+    cancel = create_hold(HoldCreate(kind="cancellation", evaluation_id="ev_001",
+                                    reason="caller_request"))
+    assert confirm(ConfirmCreate(
+        confirmation_token=cancel["confirmation_token"]))["status"] == "cancelled"
+
+    assert get_case_status("m_91", caller_id="c_004")["status"] == "records_requested"
+    assert isinstance(http(get_case_status, "m_88", caller_id="c_002"), HTTPException), \
+        "another firm's matter must not leak"
+    assert isinstance(http(get_case_status, "m_91", caller_id="c_001"), HTTPException)
+
+    catalog = json.loads((INDUSTRY_DIR / "tools.json").read_text())["tools"]
+    names = {t["name"] for t in catalog}
+    for banned in ("estimate", "value", "settlement", "advice", "predict"):
+        assert not any(banned in n for n in names), f'no tool may expose "{banned}"'
+    blueprint = json.loads((INDUSTRY_DIR / "agent_blueprint.json").read_text())
+    for agent in blueprint["agents"]:
+        assert (INDUSTRY_DIR / agent["system_prompt"]).is_file(), agent["system_prompt"]
+        for t in agent["tools"]:
+            assert t["name"] in names, f"{agent['name']}: {t['name']} not in tools.json"
+            if t.get("handoff"):
+                assert t["handoff_to"] in {a["name"] for a in blueprint["agents"]}
+
+    print(f"ok — {len(names)} tools, {len(blueprint['agents'])} agents, "
+          "gate/token/filter traps all hold")
+
+
+if __name__ == "__main__":
+    if "--selfcheck" in sys.argv:
+        selfcheck()
+    else:
+        import uvicorn
+
+        port = int(os.environ.get("TOOL_SERVER_PORT", "8000"))
+        uvicorn.run(app, host="0.0.0.0", port=port)

--- a/industries/legal/tools.json
+++ b/industries/legal/tools.json
@@ -1,0 +1,1032 @@
+{
+  "tools": [
+    {
+      "name": "lookup_caller",
+      "description": "Find or create the caller record. Call before anything else.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "full_name": {
+            "type": "string",
+            "description": "The caller's full name."
+          },
+          "phone": {
+            "type": "string",
+            "description": "Callback number, 10 digits."
+          }
+        },
+        "required": [
+          "full_name",
+          "phone"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "get_caller_matters",
+      "description": "The caller's existing matters, including whether any is already represented by another firm. Requires a successful lookup_caller first.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {}
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "take_message",
+      "description": "Take a message for a person at the firm, with a callback promise.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "for_whom": {
+            "type": "string",
+            "description": "Who at the firm the message is for."
+          },
+          "message": {
+            "type": "string",
+            "description": "The message text."
+          }
+        },
+        "required": [
+          "for_whom",
+          "message"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "check_conflict",
+      "description": "Screen for a conflict of interest. Must run before any facts of the matter.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "opposing_party": {
+            "type": "string",
+            "description": "The person or company the claim would be against."
+          }
+        },
+        "required": [
+          "opposing_party"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "check_practice_area",
+      "description": "Whether the firm handles this matter type and how it charges.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "practice_area": {
+            "type": "string",
+            "enum": [
+              "auto_accident",
+              "premises_liability",
+              "medical_malpractice",
+              "employment",
+              "workers_comp",
+              "product_liability",
+              "consumer",
+              "criminal",
+              "family",
+              "immigration",
+              "bankruptcy",
+              "patent"
+            ],
+            "description": "The type of matter."
+          }
+        },
+        "required": [
+          "practice_area"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "check_jurisdiction",
+      "description": "Whether the firm is licensed for this matter in this state.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "state": {
+            "type": "string",
+            "description": "Two-letter state code."
+          },
+          "practice_area": {
+            "type": "string",
+            "enum": [
+              "auto_accident",
+              "premises_liability",
+              "medical_malpractice",
+              "employment",
+              "workers_comp",
+              "product_liability",
+              "consumer",
+              "criminal",
+              "family",
+              "immigration",
+              "bankruptcy",
+              "patent"
+            ],
+            "description": "The type of matter."
+          }
+        },
+        "required": [
+          "state",
+          "practice_area"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "calculate_filing_deadline",
+      "description": "The statute of limitations. Report the result; never interpret it.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "state": {
+            "type": "string",
+            "description": "Two-letter state code."
+          },
+          "practice_area": {
+            "type": "string",
+            "enum": [
+              "auto_accident",
+              "premises_liability",
+              "medical_malpractice",
+              "employment",
+              "workers_comp",
+              "product_liability",
+              "consumer",
+              "criminal",
+              "family",
+              "immigration",
+              "bankruptcy",
+              "patent"
+            ],
+            "description": "The type of matter."
+          },
+          "incident_date": {
+            "type": "string",
+            "description": "Date of the incident, YYYY-MM-DD."
+          }
+        },
+        "required": [
+          "state",
+          "practice_area",
+          "incident_date"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "record_intake",
+      "description": "Log the intake. Leave summary empty when the conflict is unresolved.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "practice_area": {
+            "type": "string",
+            "enum": [
+              "auto_accident",
+              "premises_liability",
+              "medical_malpractice",
+              "employment",
+              "workers_comp",
+              "product_liability",
+              "consumer",
+              "criminal",
+              "family",
+              "immigration",
+              "bankruptcy",
+              "patent"
+            ],
+            "description": "The type of matter."
+          },
+          "state": {
+            "type": "string",
+            "description": "Two-letter state code."
+          },
+          "incident_date": {
+            "type": "string",
+            "description": "Date of the incident, YYYY-MM-DD."
+          },
+          "summary": {
+            "type": "string",
+            "description": "Short account of the matter, or empty when conflict unresolved."
+          }
+        },
+        "required": [
+          "practice_area",
+          "state",
+          "incident_date",
+          "summary"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "add_intake_note",
+      "description": "Attach a note to the caller's record for the attorney or case manager.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "note": {
+            "type": "string",
+            "description": "The note text."
+          }
+        },
+        "required": [
+          "note"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "send_intake_packet",
+      "description": "Send the new client packet.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "channel": {
+            "type": "string",
+            "enum": [
+              "email",
+              "sms"
+            ],
+            "description": "Delivery channel."
+          }
+        },
+        "required": [
+          "channel"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "request_records_authorization",
+      "description": "Send a medical records release for signature.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "provider": {
+            "type": "string",
+            "description": "The medical provider's name."
+          }
+        },
+        "required": [
+          "provider"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "get_attorney",
+      "description": "An attorney's name, practice areas, and bar states (internal routing lookup).",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "attorney_id": {
+            "type": "string",
+            "description": "The attorney's ID from a slot result."
+          }
+        },
+        "required": [
+          "attorney_id"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "find_evaluation_slots",
+      "description": "Open case evaluation slots.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "practice_area": {
+            "type": "string",
+            "enum": [
+              "auto_accident",
+              "premises_liability",
+              "medical_malpractice",
+              "employment",
+              "workers_comp",
+              "product_liability",
+              "consumer",
+              "criminal",
+              "family",
+              "immigration",
+              "bankruptcy",
+              "patent"
+            ],
+            "description": "The type of matter."
+          },
+          "state": {
+            "type": "string",
+            "description": "Two-letter state code."
+          },
+          "earliest_date": {
+            "type": "string",
+            "description": "Earliest acceptable date, YYYY-MM-DD."
+          }
+        },
+        "required": [
+          "practice_area",
+          "state",
+          "earliest_date"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "hold_evaluation",
+      "description": "Hold and price a case evaluation. Returns a read-back summary and a confirmation token. Does not book.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "slot_id": {
+            "type": "string",
+            "description": "The slot to hold."
+          },
+          "practice_area": {
+            "type": "string",
+            "enum": [
+              "auto_accident",
+              "premises_liability",
+              "medical_malpractice",
+              "employment",
+              "workers_comp",
+              "product_liability",
+              "consumer",
+              "criminal",
+              "family",
+              "immigration",
+              "bankruptcy",
+              "patent"
+            ],
+            "description": "The type of matter."
+          }
+        },
+        "required": [
+          "slot_id",
+          "practice_area"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "confirm_evaluation",
+      "description": "Finalize the booking. Requires the token from hold_evaluation and a spoken yes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "confirmation_token": {
+            "type": "string",
+            "description": "Exactly the token hold_evaluation returned."
+          }
+        },
+        "required": [
+          "confirmation_token"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "hold_cancellation",
+      "description": "Quote cancelling an appointment. Returns a token. Does not cancel.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "evaluation_id": {
+            "type": "string",
+            "description": "The evaluation to cancel."
+          },
+          "reason": {
+            "type": "string",
+            "enum": [
+              "caller_request",
+              "scheduling_conflict",
+              "no_longer_needed",
+              "referred_out"
+            ],
+            "description": "Why the evaluation is being cancelled."
+          }
+        },
+        "required": [
+          "evaluation_id",
+          "reason"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "confirm_cancellation",
+      "description": "Finalize the cancellation. Requires the token from hold_cancellation.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "confirmation_token": {
+            "type": "string",
+            "description": "Exactly the token hold_cancellation returned."
+          }
+        },
+        "required": [
+          "confirmation_token"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "get_case_status",
+      "description": "Status of one of the caller's own matters at this firm.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "matter_id": {
+            "type": "string",
+            "description": "The matter to look up."
+          }
+        },
+        "required": [
+          "matter_id"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "escalate_to_human",
+      "description": "Transfer the call to firm staff. Terminal: call nothing after this.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "reason_code": {
+            "type": "string",
+            "enum": [
+              "identity_failed",
+              "conflict",
+              "conflict_review",
+              "represented_party",
+              "adverse_party",
+              "practice_area",
+              "jurisdiction",
+              "deadline_review",
+              "legal_advice_requested",
+              "caller_request",
+              "out_of_scope"
+            ],
+            "description": "Why the call is being transferred."
+          }
+        },
+        "required": [
+          "reason_code"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "transfer_to_screening",
+      "description": "Hand the caller to Screening for a new potential matter. Only after the caller is in the system.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "handoff_summary": {
+            "type": "string",
+            "description": "One sentence on who the caller is and why they called."
+          }
+        },
+        "required": [
+          "handoff_summary"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "transfer_to_client_services",
+      "description": "Hand a verified existing client to Client Services for their own matter.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "handoff_summary": {
+            "type": "string",
+            "description": "One sentence on who the caller is and what they need."
+          }
+        },
+        "required": [
+          "handoff_summary"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "transfer_to_intake",
+      "description": "Hand the caller to Intake. Only after screening is complete.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "contact_details_only": {
+            "type": "boolean",
+            "description": "True only when the conflict check came back unclear."
+          },
+          "handoff_summary": {
+            "type": "string",
+            "description": "One sentence on the matter and the screening outcome."
+          }
+        },
+        "required": [
+          "contact_details_only",
+          "handoff_summary"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "transfer_to_scheduling",
+      "description": "Hand the caller to Scheduling to book the free case evaluation. Only after the intake is recorded.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "handoff_summary": {
+            "type": "string",
+            "description": "One sentence on the recorded matter."
+          }
+        },
+        "required": [
+          "handoff_summary"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    },
+    {
+      "name": "end_call",
+      "description": "End the call once the caller is done, or immediately if it is spam or a wrong number. Say goodbye first.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "Why the call is ending."
+          }
+        },
+        "required": [
+          "reason"
+        ]
+      },
+      "outputSchema": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "data": {
+            "type": "object"
+          },
+          "error_code": {
+            "type": "string"
+          },
+          "caller_safe_message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "ok"
+        ]
+      }
+    }
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds the legal industry pack for Halverson & Reed with a full multi-agent intake flow, FastAPI tool server, SQLite schema/seed, and production prompts. Enables reception, screening, intake, scheduling, and client services with ABA-aligned conflict-first logic and safe handoffs.

- **New Features**
  - New `legal` pack with `agent_blueprint.json` and flow diagram `agent_blueprint.mmd`.
  - Five agents: reception, screening, intake, scheduling, client_services with ABA constraints (conflict-before-facts, no legal advice, attorney-only declines).
  - `tools.json` covering caller lookup, conflicts, intake recording, and scheduling; includes handoff tools.
  - `tool_server.py` (FastAPI) with SQLite persistence, tolerant matching (names/phone/aliases), and a two-step confirmation write gate.
  - SQLite `db/schema.sql` and `db/seed.sql` for callers, matters, conflicts, practice areas, licensing, and schedules.
  - Detailed system prompts for each agent; updated industry index in `industries/README.md`.

- **Dependencies**
  - Adds `fastapi` and `uvicorn` in `requirements.txt` for the pack.

<sup>Written for commit a30efe8e6eaae1d43aed12d29654a99784cb9301. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

