### PR TITLE
Generic /tools/{name} dispatch: decouple all harnesses from control-industry

### DIFF
--- a/industries/control-industry/tool_server.py
+++ b/industries/control-industry/tool_server.py
@@ -1,7 +1,8 @@
-"""Control-industry state API — SQLite persistence, not a 1:1 tools.json mirror.
+"""Control-industry state API — SQLite persistence plus a generic tool dispatch.
 
-The OpenAI (or other) harness maps agent tools onto these routes.
-Harness-local tools like end_call never hit this server.
+Harnesses call POST /tools/{tool_name} with {"arguments": {...}} for every
+industry tool; the REST routes stay for evals and debugging (GET /state,
+GET /health). Session tools (end_call) and handoff tools never hit this server.
 """
 
 from __future__ import annotations
@@ -108,6 +109,43 @@ def create_appointment(body: AppointmentCreate) -> Appointment:
     if row is None:
         raise HTTPException(status_code=500, detail="insert failed")
     return Appointment(id=row["id"], date=row["date"], created_at=row["created_at"])
+
+
+# ------------------------------------------------------------------ dispatch
+# POST /tools/{tool_name} {"arguments": {...}} — the industry-agnostic contract
+# every harness speaks. Results use the envelope this industry's tools.json
+# outputSchema declares (here: {"success": ..., ...}).
+
+
+class ToolCall(BaseModel):
+    arguments: dict[str, Any] = Field(default_factory=dict)
+
+
+def _dispatch_schedule_appointment(args: dict[str, Any]) -> dict[str, Any]:
+    created = create_appointment(AppointmentCreate(date=args["date"]))
+    return {"success": True, "date": created.date}
+
+
+DISPATCH = {
+    "schedule_appointment": _dispatch_schedule_appointment,
+}
+
+
+@app.post("/tools/{tool_name}")
+def dispatch_tool(tool_name: str, body: ToolCall) -> dict[str, Any]:
+    handler = DISPATCH.get(tool_name)
+    if handler is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"unknown tool {tool_name!r} — session and handoff tools are "
+            "harness-native and industry tools must be listed in DISPATCH",
+        )
+    try:
+        return handler(dict(body.arguments or {}))
+    except HTTPException as e:
+        return {"success": False, "error": str(e.detail)}
+    except Exception as e:  # soft-fail: a broken tool must not 500 into the call
+        return {"success": False, "error": f"{type(e).__name__}: {e}"}
 
 
 if __name__ == "__main__":

--- a/industries/control-industry/tools.json
+++ b/industries/control-industry/tools.json
@@ -42,12 +42,15 @@
           },
           "date": {
             "type": "string",
-            "description": "Scheduled repair appointment date in MM/DD/YYYY format"
+            "description": "Scheduled repair appointment date in MM/DD/YYYY format (present on success)"
+          },
+          "error": {
+            "type": "string",
+            "description": "Human-readable failure reason (present when success is false)"
           }
         },
         "required": [
-          "success",
-          "date"
+          "success"
         ]
       }
     },

--- a/industries/healthcare/db/schema.sql
+++ b/industries/healthcare/db/schema.sql
@@ -49,3 +49,12 @@ CREATE TABLE IF NOT EXISTS waitlist (
     latest TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
+
+-- Generic sink for dispatch tools with no dedicated table (messages, SMS,
+-- callbacks, transfers, dispositions, ...) so GET /state still shows the write.
+CREATE TABLE IF NOT EXISTS tool_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind TEXT NOT NULL,
+    payload TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);

--- a/industries/healthcare/tool_server.py
+++ b/industries/healthcare/tool_server.py
@@ -13,6 +13,7 @@ backed by the seeded fixtures; their writes land in `tool_events` so GET
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sqlite3
 from contextlib import asynccontextmanager, contextmanager
@@ -63,6 +64,8 @@ async def lifespan(_app: FastAPI):
 
 
 app = FastAPI(title="healthcare state API", lifespan=lifespan)
+
+logger = logging.getLogger(__name__)
 
 
 class AppointmentCreate(BaseModel):
@@ -547,24 +550,78 @@ def _d_find_slots(a: dict[str, Any]) -> dict[str, Any]:
     return {"slots": slots[:max_results], "count": min(len(slots), max_results)}
 
 
+def _resolve_slot(slot_id: str) -> dict[str, Any]:
+    """Recompute the exact same deterministic slot _d_find_slots would have
+    offered for this slot_id, so book_appointment can bind the booking to
+    whatever was actually presented to the caller instead of trusting
+    arbitrary location/provider/start/end supplied alongside the id."""
+    with _db() as conn:
+        for loc in conn.execute("SELECT * FROM locations ORDER BY id"):
+            prov = conn.execute(
+                "SELECT * FROM providers WHERE location_id = ? ORDER BY id LIMIT 1",
+                (loc["id"],),
+            ).fetchone()
+            if prov is None:
+                continue
+            for i, start in enumerate(_SLOT_TIMES):
+                if slot_id == f"slot_{loc['id']}_{i + 1}":
+                    return {
+                        "location_id": loc["id"],
+                        "provider_id": prov["id"],
+                        "start": start,
+                        "end": _iso_plus_minutes(start, 30),
+                    }
+    raise ToolError(
+        "UNKNOWN_SLOT", f"No open slot matches {slot_id!r}. Call find_slots again."
+    )
+
+
 def _d_book_appointment(a: dict[str, Any]) -> dict[str, Any]:
+    slot = _resolve_slot(str(a["slot_id"]))
+    if (
+        str(a["location_id"]) != slot["location_id"]
+        or str(a["provider_id"]) != slot["provider_id"]
+        or str(a["start"]) != slot["start"]
+        or str(a["end"]) != slot["end"]
+    ):
+        raise ToolError(
+            "SLOT_MISMATCH",
+            "That slot no longer matches what was offered — call find_slots again "
+            "and read back the new time before booking.",
+        )
     created = create_appointment(
         AppointmentCreate(
             patient_id=_session.get("patient_id"),
-            location_id=a["location_id"],
-            provider_id=a["provider_id"],
+            location_id=slot["location_id"],
+            provider_id=slot["provider_id"],
             appointment_type_code=a["appointment_type_code"],
-            start=a["start"],
-            end=a["end"],
+            start=slot["start"],
+            end=slot["end"],
             description=a.get("description", ""),
         )
     )
     return {"appointment": created, "status": "booked"}
 
 
+def _owned_appointment(appointment_id: int) -> sqlite3.Row:
+    """An appointment row, scoped to the verified caller — prevents an id from
+    reaching another patient's booking without identity verification."""
+    patient = _patient_row()
+    with _db() as conn:
+        row = conn.execute(
+            "SELECT * FROM appointments WHERE id = ? AND patient_id = ?",
+            (appointment_id, patient["id"]),
+        ).fetchone()
+    if row is None:
+        raise ToolError("NOT_FOUND", "No appointment with that id for this patient.")
+    return row
+
+
 def _d_reschedule_appointment(a: dict[str, Any]) -> dict[str, Any]:
+    appt_id = int(a["appointment_id"])
+    _owned_appointment(appt_id)
     updated = update_appointment(
-        int(a["appointment_id"]),
+        appt_id,
         AppointmentUpdate(start=a["new_start"], end=a["new_end"], status="booked"),
     )
     return {"appointment": updated, "status": "rescheduled", "fee_cents": 0,
@@ -575,10 +632,8 @@ def _d_cancel_appointment(a: dict[str, Any]) -> dict[str, Any]:
     from datetime import datetime
 
     appt_id = int(a["appointment_id"])
-    with _db() as conn:
-        row = conn.execute("SELECT * FROM appointments WHERE id = ?", (appt_id,)).fetchone()
-    if row is None:
-        raise ToolError("NOT_FOUND", "No appointment with that id.")
+    patient = _patient_row()
+    row = _owned_appointment(appt_id)
     cosmetic = row["appointment_type_code"].startswith("COS")
     window_h, fee_cents = (72, 12500) if cosmetic else (24, 5000)
     hours_out = (datetime.fromisoformat(row["start"]) - datetime.fromisoformat(TODAY)).total_seconds() / 3600
@@ -595,9 +650,23 @@ def _d_cancel_appointment(a: dict[str, Any]) -> dict[str, Any]:
             ),
         }
     update_appointment(appt_id, AppointmentUpdate(status="cancelled"))
+    fee_charged_cents = 0
+    if inside_window:
+        fee_charged_cents = fee_cents
+        with _db() as conn:
+            conn.execute(
+                "UPDATE patients SET balance_cents = balance_cents + ? WHERE id = ?",
+                (fee_cents, patient["id"]),
+            )
+        _event(
+            "cancellation_fee",
+            {"patient_id": patient["id"], "appointment_id": appt_id,
+             "fee_cents": fee_cents,
+             "cancellation_reason_code": a["cancellation_reason_code"]},
+        )
     return {
         "status": "cancelled",
-        "fee_charged_cents": fee_cents if inside_window else 0,
+        "fee_charged_cents": fee_charged_cents,
         "cancellation_reason_code": a["cancellation_reason_code"],
         "note": "Offer to rebook or join the waitlist.",
     }
@@ -671,29 +740,59 @@ _ACCEPTED_CARRIERS = {"aetna", "unitedhealthcare", "united healthcare", "cigna",
 _NOT_ACCEPTED_CARRIERS = {"medicaid"}
 
 
+_UNCONFIRMED_SCRIPT = (
+    "I can't confirm that plan over the phone. The insurance team will "
+    "verify it before your visit — I can set up a callback or you can "
+    "text our insurance line."
+)
+
+
 def _d_check_plan_accepted(a: dict[str, Any]) -> dict[str, Any]:
     carrier = str(a["carrier"]).strip().lower()
     loc = _resolve_location(a["location_id"])
+    provider_id = a.get("provider_id")
+    if provider_id:
+        with _db() as conn:
+            prov = conn.execute(
+                "SELECT * FROM providers WHERE id = ?", (provider_id,)
+            ).fetchone()
+        if prov is None or prov["location_id"] != loc["id"]:
+            # Unknown provider/location combo — can't validate the plan against
+            # a provider we can't place, so don't assert coverage either way.
+            return {
+                "accepted": None,
+                "must_not_assert": True,
+                "carrier": a["carrier"],
+                "location": loc["name"],
+                "required_script": _UNCONFIRMED_SCRIPT,
+            }
     with _db() as conn:
         others = [r["name"] for r in conn.execute(
             "SELECT name FROM locations WHERE id != ? ORDER BY id", (loc["id"],))]
-    if carrier in _ACCEPTED_CARRIERS:
-        return {"accepted": True, "must_not_assert": False,
-                "carrier": a["carrier"], "location": loc["name"]}
     if carrier in _NOT_ACCEPTED_CARRIERS:
         return {"accepted": False, "must_not_assert": False,
                 "carrier": a["carrier"], "location": loc["name"],
                 "alternative_locations": others}
+    if carrier in _ACCEPTED_CARRIERS:
+        # We only have a carrier-level acceptance list, no real plan/provider
+        # coverage matrix — a specific plan_name/plan_type can't be validated,
+        # so don't assert accepted for those dimensions.
+        if a.get("plan_name") or a.get("plan_type"):
+            return {
+                "accepted": None,
+                "must_not_assert": True,
+                "carrier": a["carrier"],
+                "location": loc["name"],
+                "required_script": _UNCONFIRMED_SCRIPT,
+            }
+        return {"accepted": True, "must_not_assert": False,
+                "carrier": a["carrier"], "location": loc["name"]}
     return {
         "accepted": None,
         "must_not_assert": True,
         "carrier": a["carrier"],
         "location": loc["name"],
-        "required_script": (
-            "I can't confirm that plan over the phone. The insurance team will "
-            "verify it before your visit — I can set up a callback or you can "
-            "text our insurance line."
-        ),
+        "required_script": _UNCONFIRMED_SCRIPT,
     }
 
 
@@ -709,6 +808,14 @@ def _d_run_eligibility_check(a: dict[str, Any]) -> dict[str, Any]:
             "The payer didn't return eligibility. Say you couldn't get the number — "
             "never guess at a copay.",
         )
+    submitted_carrier = "".join(str(a["carrier"]).strip().lower().split())
+    on_file_carrier = "".join(str(row["carrier"] or "").strip().lower().split())
+    if not on_file_carrier or submitted_carrier != on_file_carrier:
+        raise ToolError(
+            "PAYER_UNAVAILABLE",
+            "The payer didn't return eligibility for that carrier. Say you "
+            "couldn't get the number — never guess at a copay.",
+        )
     return {"copay_cents": 3000, "deductible_remaining_cents": 25000,
             "coinsurance_pct": 20, "plan_active": True, "service_date": a["service_date"]}
 
@@ -717,10 +824,11 @@ def _d_capture_insurance_update(a: dict[str, Any]) -> dict[str, Any]:
     row = _patient_row()
     with _db() as conn:
         conn.execute(
-            "UPDATE patients SET carrier = ?, member_id = ?, plan_name = COALESCE(?, plan_name) "
-            "WHERE id = ?",
-            (a["carrier"], a["member_id"], a.get("group_number"), row["id"]),
+            "UPDATE patients SET carrier = ?, member_id = ? WHERE id = ?",
+            (a["carrier"], a["member_id"], row["id"]),
         )
+    # group_number has no dedicated column — it must never overwrite plan_name;
+    # keep it (and the rest of the update) in the durable event stream instead.
     _event("insurance_update", {"patient_id": row["id"], **a})
     return {"updated": True, "card_upload_link_sent": True,
             "note": "A secure link for card photos was texted."}
@@ -844,12 +952,13 @@ _RX_HARD_STOPS = (
 
 
 def _d_request_rx_refill(a: dict[str, Any]) -> dict[str, Any]:
+    patient = _patient_row()
     med = str(a["medication_name"]).strip().lower()
     for keywords, route, note in _RX_HARD_STOPS:
         if any(k in med for k in keywords):
-            _event("rx_refill_request", {**a, "route": route})
+            _event("rx_refill_request", {"patient_id": patient["id"], **a, "route": route})
             return {"route": route, "hard_stop": True, "approved": False, "note": note}
-    _event("rx_refill_request", {**a, "route": "routed_to_provider"})
+    _event("rx_refill_request", {"patient_id": patient["id"], **a, "route": "routed_to_provider"})
     return {"route": "routed_to_provider", "hard_stop": False, "approved": False,
             "pharmacy_needed": not a.get("pharmacy_name"),
             "note": "The request is with the clinical team; this never approves a refill."}
@@ -868,7 +977,8 @@ def _d_get_results_status(a: dict[str, Any]) -> dict[str, Any]:
 
 
 def _d_create_clinical_message(a: dict[str, Any]) -> dict[str, Any]:
-    event_id = _event("clinical_message", dict(a))
+    patient = _patient_row()
+    event_id = _event("clinical_message", {"patient_id": patient["id"], **a})
     return {"message_id": f"cm_{event_id}", "queued": True,
             "priority": a["priority"], "category": a["category"]}
 
@@ -953,6 +1063,9 @@ def _d_authenticate_for_transfer(a: dict[str, Any]) -> dict[str, Any]:
 
 def _d_transfer_call(a: dict[str, Any]) -> dict[str, Any]:
     dest = str(a.get("destination") or "patient_support_center")
+    if dest not in _TRANSFER_DESTINATIONS:
+        raise ToolError("UNKNOWN_DESTINATION",
+                        f"destination must be one of {sorted(_TRANSFER_DESTINATIONS)}.")
     _event("transfer", {"destination": dest})
     return {"transferred": True, "destination": dest}
 
@@ -1031,9 +1144,13 @@ def dispatch_tool(tool_name: str, body: ToolCall) -> dict[str, Any]:
     except HTTPException as e:
         return {"ok": False, "data": None, "error_code": f"HTTP_{e.status_code}",
                 "patient_safe_message": str(e.detail)}
-    except Exception as e:  # soft-fail: a broken tool must not 500 into the call
+    except Exception:  # soft-fail: a broken tool must not 500 into the call
+        # Diagnostic details (exception type/message, tracebacks, DB errors)
+        # stay server-side; callers only ever hear a fixed safe message.
+        logger.exception("unhandled error dispatching tool %r", tool_name)
         return {"ok": False, "data": None, "error_code": "INVALID_ARGUMENTS",
-                "patient_safe_message": f"{type(e).__name__}: {e}"}
+                "patient_safe_message": "Something went wrong handling that request. "
+                "Please try again or ask for a callback."}
 
 
 if __name__ == "__main__":

--- a/industries/healthcare/tool_server.py
+++ b/industries/healthcare/tool_server.py
@@ -634,6 +634,9 @@ def _d_cancel_appointment(a: dict[str, Any]) -> dict[str, Any]:
     appt_id = int(a["appointment_id"])
     patient = _patient_row()
     row = _owned_appointment(appt_id)
+    if row["status"] == "cancelled":
+        return {"status": "cancelled", "fee_charged_cents": 0,
+                "note": "Already cancelled — no fee charged again."}
     cosmetic = row["appointment_type_code"].startswith("COS")
     window_h, fee_cents = (72, 12500) if cosmetic else (24, 5000)
     hours_out = (datetime.fromisoformat(row["start"]) - datetime.fromisoformat(TODAY)).total_seconds() / 3600

--- a/industries/healthcare/tool_server.py
+++ b/industries/healthcare/tool_server.py
@@ -1,7 +1,13 @@
-"""Healthcare state API — SQLite persistence, not a 1:1 tools.json mirror.
+"""Healthcare state API — SQLite persistence plus a generic tool dispatch.
 
-The OpenAI (or other) harness maps agent tools onto these routes.
-Harness-local tools like end_call never hit this server.
+Harnesses call POST /tools/{tool_name} with {"arguments": {...}} for every
+industry tool; the REST routes stay for evals and debugging (GET /state,
+GET /health). Session tools (end_call) and handoff tools (transfer_to_*)
+never hit this server.
+
+Tools without a dedicated table are minimal deterministic implementations
+backed by the seeded fixtures; their writes land in `tool_events` so GET
+/state still shows them.
 """
 
 from __future__ import annotations
@@ -24,6 +30,7 @@ DB_PATH = Path(os.environ.get("MIVAS_DB_PATH", str(DB_DIR / "runtime.db")))
 
 
 def init_db() -> None:
+    _session.clear()  # dispatch identity pin follows the DB lifecycle
     DB_PATH.parent.mkdir(parents=True, exist_ok=True)
     if DB_PATH.exists():
         DB_PATH.unlink()
@@ -129,12 +136,18 @@ def state() -> dict[str, Any]:
                     "created_at": r["created_at"],
                 }
             )
+        tool_events = [
+            {"id": r["id"], "kind": r["kind"], "payload": json.loads(r["payload"]),
+             "created_at": r["created_at"]}
+            for r in conn.execute("SELECT * FROM tool_events ORDER BY id")
+        ]
     return {
         "patients": patients,
         "locations": locations,
         "providers": providers,
         "appointments": appointments,
         "waitlist": waitlist,
+        "tool_events": tool_events,
     }
 
 
@@ -263,6 +276,764 @@ def join_waitlist(body: WaitlistCreate) -> dict[str, Any]:
         "latest": row["latest"],
         "created_at": row["created_at"],
     }
+
+
+# ------------------------------------------------------------------ dispatch
+# POST /tools/{tool_name} {"arguments": {...}} — the industry-agnostic contract
+# every harness speaks. Wraps everything in the tools.json envelope:
+# {"ok": bool, "data": ..., "error_code": str|null, "patient_safe_message": str|null}.
+# Session (end_call) and handoff (transfer_to_*) tools never land here → 404.
+
+# Fixed "now" so cancellation-window math is deterministic across runs. The
+# seeded MED_FOLLOWUP on 2026-08-20T10:00 is inside the 24 h medical window.
+TODAY = "2026-08-19T12:00:00"
+
+# ponytail: module-level session, one call at a time (benchmark runs are
+# max_concurrent=1); key by call id if that ever changes.
+_session: dict[str, Any] = {}
+
+
+class ToolError(Exception):
+    def __init__(self, code: str, message: str):
+        super().__init__(message)
+        self.code, self.message = code, message
+
+
+def _event(kind: str, payload: dict[str, Any]) -> int:
+    with _db() as conn:
+        cur = conn.execute(
+            "INSERT INTO tool_events (kind, payload) VALUES (?, ?)",
+            (kind, json.dumps(payload)),
+        )
+        event_id = int(cur.lastrowid or 0)
+    return event_id
+
+
+def _patient_row() -> sqlite3.Row:
+    pid = _session.get("patient_id")
+    if not pid or not _session.get("verified"):
+        raise ToolError("NOT_VERIFIED", "Verify the caller's identity first.")
+    with _db() as conn:
+        row = conn.execute("SELECT * FROM patients WHERE id = ?", (pid,)).fetchone()
+    if row is None:
+        raise ToolError("NOT_VERIFIED", "Verify the caller's identity first.")
+    return row
+
+
+def _resolve_location(value: str) -> sqlite3.Row:
+    """Accept a real id OR whatever the caller called the office."""
+    said = str(value or "").strip().lower()
+    with _db() as conn:
+        for row in conn.execute("SELECT * FROM locations ORDER BY id"):
+            if said == row["id"].lower() or said in row["name"].lower() or row["name"].lower() in said:
+                return row
+    raise ToolError("UNKNOWN_LOCATION", f"No office matches {value!r}.")
+
+
+def _iso_plus_minutes(start: str, minutes: int) -> str:
+    from datetime import datetime, timedelta
+
+    return (datetime.fromisoformat(start) + timedelta(minutes=minutes)).isoformat()
+
+
+# --- identity ----------------------------------------------------------------
+
+
+def _d_resolve_inbound_context(a: dict[str, Any]) -> dict[str, Any]:
+    ani = str(a.get("caller_ani") or "").strip()
+    with _db() as conn:
+        patient = conn.execute(
+            "SELECT * FROM patients WHERE phone_e164 = ?", (ani,)
+        ).fetchone() if ani else None
+        office = None
+        if patient and patient["home_office_id"]:
+            office = conn.execute(
+                "SELECT * FROM locations WHERE id = ?", (patient["home_office_id"],)
+            ).fetchone()
+        if office is None:
+            office = conn.execute("SELECT * FROM locations ORDER BY id LIMIT 1").fetchone()
+    return {
+        "office_id": office["id"],
+        "office_name": office["name"],
+        "brand_greeting": "Thank you for calling Straus Dermatology",
+        "known_caller": patient is not None,
+    }
+
+
+_SPANISH = {"hola", "gracias", "buenos", "buenas", "cita", "necesito", "español",
+            "espanol", "habla", "quiero", "por favor"}
+
+
+def _d_detect_language(a: dict[str, Any]) -> dict[str, Any]:
+    words = set(str(a["utterance"]).lower().split())
+    lang = "es" if words & _SPANISH else "en"
+    _session["language"] = lang
+    return {"language": lang, "note": "Switch to this language and stay switched."}
+
+
+def _d_identify_patient(a: dict[str, Any]) -> dict[str, Any]:
+    first = str(a.get("first_name") or "").strip().lower()
+    last = str(a.get("last_name") or "").strip().lower()
+    dob = str(a.get("dob") or "").strip()
+    zip_ = str(a.get("zip") or "").strip()
+    candidates = []
+    with _db() as conn:
+        for row in conn.execute("SELECT * FROM patients ORDER BY id"):
+            if first and row["first_name"].lower() != first:
+                continue
+            if last and row["last_name"].lower() != last:
+                continue
+            if dob and row["dob"] != dob:
+                continue
+            if zip_ and row["zip"] != zip_:
+                continue
+            candidates.append(
+                {
+                    "patient_id": row["id"],
+                    "first_name": row["first_name"],
+                    "last_initial": row["last_name"][:1],
+                    "dob_year": row["dob"][:4],
+                }
+            )
+    if not (first or last or dob or zip_):
+        candidates = []
+    return {"candidates": candidates, "count": len(candidates)}
+
+
+def _d_verify_identity(a: dict[str, Any]) -> dict[str, Any]:
+    if _session.get("verify_failures", 0) >= 3:
+        raise ToolError(
+            "IDENTITY_LOCKED",
+            "Verification is locked after three failures. Offer the front desk or a callback.",
+        )
+    name = str(a["full_name"]).strip().lower().split()
+    dob = str(a["dob"]).strip()
+    second = str(a.get("second_factor") or "").strip()
+    with _db() as conn:
+        for row in conn.execute("SELECT * FROM patients ORDER BY id"):
+            full = f"{row['first_name']} {row['last_name']}".lower().split()
+            if name and name[0] == full[0] and name[-1] == full[-1] and row["dob"] == dob:
+                if second and second != row["zip"] and second != (row["phone_e164"] or "")[-4:]:
+                    break
+                _session.update(patient_id=row["id"], verified=True, verify_failures=0)
+                return {"verified": True, "patient_id": row["id"]}
+    _session["verify_failures"] = _session.get("verify_failures", 0) + 1
+    raise ToolError(
+        "NO_MATCH",
+        "That name and date of birth don't match a record. Re-confirm the spelling "
+        "and date of birth; after a third failure offer the front desk.",
+    )
+
+
+def _d_get_patient_summary(a: dict[str, Any]) -> dict[str, Any]:
+    row = _patient_row()
+    with _db() as conn:
+        upcoming = [
+            _appointment(r)
+            for r in conn.execute(
+                "SELECT * FROM appointments WHERE patient_id = ? AND status = 'booked' "
+                "ORDER BY start",
+                (row["id"],),
+            )
+        ]
+        office = conn.execute(
+            "SELECT name FROM locations WHERE id = ?", (row["home_office_id"],)
+        ).fetchone()
+    member = row["member_id"] or ""
+    return {
+        "patient_id": row["id"],
+        "name": f"{row['first_name']} {row['last_name']}",
+        "language": row["language"],
+        "home_office": office["name"] if office else None,
+        "upcoming_appointments": upcoming,
+        "balance_cents": row["balance_cents"],
+        "insurance": {
+            "carrier": row["carrier"],
+            "plan_name": row["plan_name"],
+            "member_id_last4": member[-4:] if member else None,
+        },
+        "portal_active": False,
+        "open_orders": [],
+        "clinical_flags": [],
+    }
+
+
+# --- scheduling ---------------------------------------------------------------
+
+_VISIT_TYPES = [
+    ({"botox", "filler", "juvederm", "laser", "cosmetic", "microneedling", "peel"},
+     {"appointment_type_code": "COS_CONSULT", "visit_class": "cosmetic",
+      "required_credential": "MD", "duration_min": 30, "urgency": "routine",
+      "constraints": ["cosmetic offices only", "deposit policy applies"]}),
+    ({"mohs", "skin cancer", "melanoma", "biopsy"},
+     {"appointment_type_code": "MOHS_CONSULT", "visit_class": "medical",
+      "required_credential": "MD", "duration_min": 45, "urgency": "urgent",
+      "constraints": ["must be booked with an MD, never a PA"]}),
+    ({"allergy", "allergies", "asthma", "hives", "shot", "immunotherapy"},
+     {"appointment_type_code": "ALLERGY_EVAL", "visit_class": "allergy",
+      "required_credential": "MD", "duration_min": 40, "urgency": "routine",
+      "constraints": ["allergy services carry prep instructions"]}),
+]
+
+
+def _d_classify_visit_request(a: dict[str, Any]) -> dict[str, Any]:
+    text = str(a["reason_text"]).lower()
+    for keywords, spec in _VISIT_TYPES:
+        if any(k in text for k in keywords):
+            return dict(spec)
+    urgent = any(k in text for k in ("bleeding", "spreading", "infected", "severe", "painful"))
+    new = bool(a.get("is_new_patient"))
+    return {
+        "appointment_type_code": "NP_MED" if new else "MED_FOLLOWUP",
+        "visit_class": "medical",
+        "required_credential": "MD_OR_PA",
+        "duration_min": 30 if new else 20,
+        "urgency": "urgent" if urgent else "routine",
+        "constraints": [],
+    }
+
+
+def _d_list_locations(a: dict[str, Any]) -> dict[str, Any]:
+    zip_ = str(a["zip"]).strip()
+    with _db() as conn:
+        rows = [dict(r) for r in conn.execute("SELECT * FROM locations ORDER BY id")]
+    rows.sort(key=lambda r: r["zip"] != zip_)  # exact-zip office first; radius ignored
+    for r in rows:
+        r["offers_cosmetic"] = bool(r["offers_cosmetic"])
+    return {"locations": rows}
+
+
+_SLOT_TIMES = ("2026-08-24T09:00:00", "2026-08-25T11:30:00", "2026-08-26T14:00:00")
+
+
+def _d_find_slots(a: dict[str, Any]) -> dict[str, Any]:
+    """Deterministic open slots per requested office (no slot inventory table —
+    book_appointment carries the full location/provider/start anyway)."""
+    location_ids = [str(x) for x in (a.get("location_ids") or [])]
+    window_start = str(a.get("window_start") or "")
+    window_end = str(a.get("window_end") or "")
+    max_results = int(a.get("max_results") or 6)
+    slots = []
+    with _db() as conn:
+        for loc_id in location_ids:
+            loc = conn.execute("SELECT * FROM locations WHERE id = ?", (loc_id,)).fetchone()
+            if loc is None:
+                try:
+                    loc = _resolve_location(loc_id)
+                except ToolError:
+                    continue
+            prov = conn.execute(
+                "SELECT * FROM providers WHERE location_id = ? ORDER BY id LIMIT 1",
+                (loc["id"],),
+            ).fetchone()
+            if prov is None:
+                continue
+            for i, start in enumerate(_SLOT_TIMES):
+                if window_start and start < window_start:
+                    continue
+                if window_end and start > window_end:
+                    continue
+                slots.append(
+                    {
+                        "slot_id": f"slot_{loc['id']}_{i + 1}",
+                        "location_id": loc["id"],
+                        "location": loc["name"],
+                        "provider_id": prov["id"],
+                        "provider": f"{prov['name']}, {prov['credentials']}",
+                        "start": start,
+                        "end": _iso_plus_minutes(start, 30),
+                    }
+                )
+    return {"slots": slots[:max_results], "count": min(len(slots), max_results)}
+
+
+def _d_book_appointment(a: dict[str, Any]) -> dict[str, Any]:
+    created = create_appointment(
+        AppointmentCreate(
+            patient_id=_session.get("patient_id"),
+            location_id=a["location_id"],
+            provider_id=a["provider_id"],
+            appointment_type_code=a["appointment_type_code"],
+            start=a["start"],
+            end=a["end"],
+            description=a.get("description", ""),
+        )
+    )
+    return {"appointment": created, "status": "booked"}
+
+
+def _d_reschedule_appointment(a: dict[str, Any]) -> dict[str, Any]:
+    updated = update_appointment(
+        int(a["appointment_id"]),
+        AppointmentUpdate(start=a["new_start"], end=a["new_end"], status="booked"),
+    )
+    return {"appointment": updated, "status": "rescheduled", "fee_cents": 0,
+            "note": "Rescheduling never costs anything — say so."}
+
+
+def _d_cancel_appointment(a: dict[str, Any]) -> dict[str, Any]:
+    from datetime import datetime
+
+    appt_id = int(a["appointment_id"])
+    with _db() as conn:
+        row = conn.execute("SELECT * FROM appointments WHERE id = ?", (appt_id,)).fetchone()
+    if row is None:
+        raise ToolError("NOT_FOUND", "No appointment with that id.")
+    cosmetic = row["appointment_type_code"].startswith("COS")
+    window_h, fee_cents = (72, 12500) if cosmetic else (24, 5000)
+    hours_out = (datetime.fromisoformat(row["start"]) - datetime.fromisoformat(TODAY)).total_seconds() / 3600
+    inside_window = hours_out < window_h
+    if inside_window and not a.get("fee_disclosed_and_accepted"):
+        fee = fee_cents // 100
+        return {
+            "status": "fee_disclosure_required",
+            "fee_cents": fee_cents,
+            "required_script": (
+                f"Because this visit is within {window_h} hours, a ${fee} missed-visit "
+                "fee applies if you cancel. Moving it instead is free — would you like "
+                "a different time, or should I still cancel?"
+            ),
+        }
+    update_appointment(appt_id, AppointmentUpdate(status="cancelled"))
+    return {
+        "status": "cancelled",
+        "fee_charged_cents": fee_cents if inside_window else 0,
+        "cancellation_reason_code": a["cancellation_reason_code"],
+        "note": "Offer to rebook or join the waitlist.",
+    }
+
+
+def _d_join_waitlist(a: dict[str, Any]) -> dict[str, Any]:
+    entry = join_waitlist(
+        WaitlistCreate(
+            patient_id=_session.get("patient_id"),
+            appointment_type_code=a["appointment_type_code"],
+            location_ids=[str(x) for x in a["location_ids"]],
+            earliest=a.get("earliest"),
+            latest=a.get("latest"),
+        )
+    )
+    return {"waitlist_entry": entry, "status": "added"}
+
+
+_ALLERGY_SERVICES = {
+    "skin_testing": {"prep": "Stop antihistamines seven days before the visit.",
+                     "observation_min": 0, "linked_visits": []},
+    "patch_testing": {"prep": "Keep your back dry and skip topical steroids on it for a week.",
+                      "observation_min": 0,
+                      "linked_visits": ["48-hour patch read", "96-hour patch read"]},
+    "food_challenge": {"prep": "Come fasting and plan on a four-hour visit.",
+                       "observation_min": 240, "linked_visits": []},
+    "allergy_shot": {"prep": "", "observation_min": 30, "linked_visits": []},
+    "drops_pickup": {"prep": "", "observation_min": 0, "linked_visits": []},
+    "asthma_eval": {"prep": "Hold your rescue inhaler for six hours if you safely can.",
+                    "observation_min": 0, "linked_visits": []},
+    "immunotherapy_buildup": {"prep": "", "observation_min": 30,
+                              "linked_visits": ["weekly buildup visits"]},
+}
+
+
+def _d_schedule_allergy_service(a: dict[str, Any]) -> dict[str, Any]:
+    service = str(a["service"]).strip().lower()
+    spec = _ALLERGY_SERVICES.get(service)
+    if spec is None:
+        raise ToolError("UNKNOWN_SERVICE", f"No allergy service named {a['service']!r}.")
+    loc = _resolve_location(a["location_id"])
+    with _db() as conn:
+        prov = conn.execute(
+            "SELECT * FROM providers WHERE location_id = ? ORDER BY id LIMIT 1", (loc["id"],)
+        ).fetchone()
+    start = str(a.get("window_start") or _SLOT_TIMES[0])
+    created = create_appointment(
+        AppointmentCreate(
+            patient_id=_session.get("patient_id"),
+            location_id=loc["id"],
+            provider_id=prov["id"],
+            appointment_type_code=f"ALLERGY_{service.upper()}",
+            start=start,
+            end=_iso_plus_minutes(start, 30 + spec["observation_min"]),
+            description=f"Allergy service: {service}",
+        )
+    )
+    return {
+        "appointment": created,
+        "prep_instructions": spec["prep"],
+        "observation_minutes_after": spec["observation_min"],
+        "linked_return_visits": spec["linked_visits"],
+        "note": "Say the prep, the observation time, and the linked visits out loud.",
+    }
+
+
+# --- coverage / billing --------------------------------------------------------
+
+_ACCEPTED_CARRIERS = {"aetna", "unitedhealthcare", "united healthcare", "cigna",
+                      "blue cross blue shield", "bcbs", "medicare"}
+_NOT_ACCEPTED_CARRIERS = {"medicaid"}
+
+
+def _d_check_plan_accepted(a: dict[str, Any]) -> dict[str, Any]:
+    carrier = str(a["carrier"]).strip().lower()
+    loc = _resolve_location(a["location_id"])
+    with _db() as conn:
+        others = [r["name"] for r in conn.execute(
+            "SELECT name FROM locations WHERE id != ? ORDER BY id", (loc["id"],))]
+    if carrier in _ACCEPTED_CARRIERS:
+        return {"accepted": True, "must_not_assert": False,
+                "carrier": a["carrier"], "location": loc["name"]}
+    if carrier in _NOT_ACCEPTED_CARRIERS:
+        return {"accepted": False, "must_not_assert": False,
+                "carrier": a["carrier"], "location": loc["name"],
+                "alternative_locations": others}
+    return {
+        "accepted": None,
+        "must_not_assert": True,
+        "carrier": a["carrier"],
+        "location": loc["name"],
+        "required_script": (
+            "I can't confirm that plan over the phone. The insurance team will "
+            "verify it before your visit — I can set up a callback or you can "
+            "text our insurance line."
+        ),
+    }
+
+
+def _d_run_eligibility_check(a: dict[str, Any]) -> dict[str, Any]:
+    with _db() as conn:
+        row = conn.execute(
+            "SELECT * FROM patients WHERE member_id = ? AND dob = ?",
+            (str(a["member_id"]).strip(), str(a["dob"]).strip()),
+        ).fetchone()
+    if row is None:
+        raise ToolError(
+            "PAYER_UNAVAILABLE",
+            "The payer didn't return eligibility. Say you couldn't get the number — "
+            "never guess at a copay.",
+        )
+    return {"copay_cents": 3000, "deductible_remaining_cents": 25000,
+            "coinsurance_pct": 20, "plan_active": True, "service_date": a["service_date"]}
+
+
+def _d_capture_insurance_update(a: dict[str, Any]) -> dict[str, Any]:
+    row = _patient_row()
+    with _db() as conn:
+        conn.execute(
+            "UPDATE patients SET carrier = ?, member_id = ?, plan_name = COALESCE(?, plan_name) "
+            "WHERE id = ?",
+            (a["carrier"], a["member_id"], a.get("group_number"), row["id"]),
+        )
+    _event("insurance_update", {"patient_id": row["id"], **a})
+    return {"updated": True, "card_upload_link_sent": True,
+            "note": "A secure link for card photos was texted."}
+
+
+def _line_items(balance_cents: int) -> list[dict[str, Any]]:
+    items = []
+    remainder = balance_cents
+    if balance_cents >= 5000:
+        items.append({"line_item_id": "li_noshow", "description": "Missed-visit fee",
+                      "amount_cents": 5000})
+        remainder -= 5000
+    if remainder > 0:
+        items.append({"line_item_id": "li_visit", "description": "Office visit balance",
+                      "amount_cents": remainder})
+    return items
+
+
+def _d_get_account_balance(a: dict[str, Any]) -> dict[str, Any]:
+    row = _patient_row()
+    return {"balance_cents": row["balance_cents"], "line_items": _line_items(row["balance_cents"])}
+
+
+_CHARGE_SCRIPTS = {
+    "li_noshow": ("That fifty dollar charge is the missed-visit fee from a visit that "
+                  "was cancelled inside the notice window. If you believe it shouldn't "
+                  "apply, I can open a review with the billing team."),
+    "li_visit": ("That charge is the portion of your visit your insurance applied to "
+                 "your deductible or copay after the claim processed."),
+}
+
+
+def _d_explain_charge(a: dict[str, Any]) -> dict[str, Any]:
+    script = _CHARGE_SCRIPTS.get(str(a["line_item_id"]))
+    if script is None:
+        raise ToolError("UNKNOWN_LINE_ITEM", "No approved explanation for that line item — "
+                                             "open a billing callback instead.")
+    return {"line_item_id": a["line_item_id"], "approved_script": script}
+
+
+def _d_send_payment_link(a: dict[str, Any]) -> dict[str, Any]:
+    _event("payment_link", dict(a))
+    return {"sent": True, "channel": "sms", "mobile_e164": a["mobile_e164"],
+            "amount_cents": a.get("amount_cents")}
+
+
+def _d_offer_financing(a: dict[str, Any]) -> dict[str, Any]:
+    amount = int(a["amount_cents"])
+    eligible = amount >= 25000
+    return {"eligible": eligible, "provider": "CareCredit",
+            "note": None if eligible else "CareCredit is offered for balances over $250."}
+
+
+def _d_request_fee_waiver(a: dict[str, Any]) -> dict[str, Any]:
+    _event("fee_waiver_request", dict(a))
+    return {"review_opened": True, "sla": "two business days",
+            "spoken_commitment": ("The billing team will review that fee and get back "
+                                  "to you within two business days.")}
+
+
+# --- cosmetic -------------------------------------------------------------------
+
+_COSMETIC_QUOTES = {
+    "botox": {"low_cents": 30000, "high_cents": 60000},
+    "filler": {"low_cents": 60000, "high_cents": 120000},
+    "chemical_peel": {"low_cents": 20000, "high_cents": 40000},
+    "microneedling": {"low_cents": 35000, "high_cents": 70000},
+}
+
+_COSMETIC_POLICY_LINES = [
+    "A $125 deposit holds the consult.",
+    "You can move or cancel it free of charge up to 72 hours before.",
+    "Inside 72 hours the deposit is forfeited.",
+    "Any remaining balance for treatment is due at the visit.",
+]
+
+
+def _d_quote_cosmetic_service(a: dict[str, Any]) -> dict[str, Any]:
+    service = str(a["service"]).strip().lower().replace(" ", "_")
+    rng = _COSMETIC_QUOTES.get(service)
+    if rng:
+        return {"service": a["service"], "price_range": rng,
+                "note": "You may say this range and must add that the consult settles the number."}
+    return {"service": a["service"], "price_range": None,
+            "note": "Pricing depends on the treatment plan — never invent or estimate a number."}
+
+
+def _d_book_cosmetic_consult(a: dict[str, Any]) -> dict[str, Any]:
+    if not a.get("policy_acknowledged"):
+        return {"status": "policy_disclosure_required",
+                "policy_lines": _COSMETIC_POLICY_LINES,
+                "note": "Say all four lines, get a real yes, then call again with true."}
+    loc = _resolve_location(a["location_id"])
+    if not loc["offers_cosmetic"]:
+        raise ToolError("COSMETIC_NOT_OFFERED", f"{loc['name']} does not do cosmetic work.")
+    start = a["start"]
+    created = create_appointment(
+        AppointmentCreate(
+            patient_id=_session.get("patient_id"),
+            location_id=loc["id"],
+            provider_id=a["provider_id"],
+            appointment_type_code="COS_CONSULT",
+            start=start,
+            end=_iso_plus_minutes(start, 30),
+            description="Cosmetic consult: " + ", ".join(a.get("service_interest") or []),
+        )
+    )
+    return {"appointment": created, "status": "booked", "deposit_cents": 12500}
+
+
+# --- clinical -------------------------------------------------------------------
+
+_RX_HARD_STOPS = (
+    ({"isotretinoin", "accutane"}, "isotretinoin_program",
+     "Isotretinoin refills require the monthly program visit — offer to book it."),
+    ({"tramadol", "xanax", "adderall", "oxycodone", "codeine"}, "controlled_substance",
+     "Controlled medications are never refilled by phone — the prescriber must see them."),
+    ({"dupixent", "humira", "skyrizi", "biologic"}, "biologic_coordinator",
+     "Biologics route to the biologic coordinator, who will call back."),
+)
+
+
+def _d_request_rx_refill(a: dict[str, Any]) -> dict[str, Any]:
+    med = str(a["medication_name"]).strip().lower()
+    for keywords, route, note in _RX_HARD_STOPS:
+        if any(k in med for k in keywords):
+            _event("rx_refill_request", {**a, "route": route})
+            return {"route": route, "hard_stop": True, "approved": False, "note": note}
+    _event("rx_refill_request", {**a, "route": "routed_to_provider"})
+    return {"route": "routed_to_provider", "hard_stop": False, "approved": False,
+            "pharmacy_needed": not a.get("pharmacy_name"),
+            "note": "The request is with the clinical team; this never approves a refill."}
+
+
+def _d_get_results_status(a: dict[str, Any]) -> dict[str, Any]:
+    order = str(a.get("order_type") or "test")
+    return {
+        "status": "resulted_pending_review",
+        "approved_script": (
+            f"Your {order} results are in and are with the clinical team for review. "
+            "A clinician will reach out — I can't read results over the phone, but I "
+            "can send the team a message."
+        ),
+    }
+
+
+def _d_create_clinical_message(a: dict[str, Any]) -> dict[str, Any]:
+    event_id = _event("clinical_message", dict(a))
+    return {"message_id": f"cm_{event_id}", "queued": True,
+            "priority": a["priority"], "category": a["category"]}
+
+
+# --- practice / plumbing ----------------------------------------------------------
+
+_KB = [
+    ({"hour", "open", "close"}, "hours",
+     "Offices are open 8am to 5pm Monday through Friday, and Park Avenue is open "
+     "9am to 1pm on Saturdays."),
+    ({"park", "parking", "direction", "subway", "train"}, "directions",
+     "Park Avenue is at 36th and Park, a block from the 6 train; there is a garage "
+     "next door. Brooklyn Heights is two blocks from Borough Hall."),
+    ({"portal", "login", "password"}, "portal",
+     "The patient portal is portal.strausderm.example; activation links arrive by "
+     "text and expire after 72 hours."),
+    ({"fee", "cancel", "cancellation", "no-show", "missed"}, "fees",
+     "Cancellations need 24 hours notice for medical visits and 72 for cosmetic; the "
+     "missed-visit fee is $50 medical and $125 cosmetic."),
+    ({"treat", "service", "condition"}, "services",
+     "Straus treats medical, surgical, and cosmetic dermatology plus allergy testing "
+     "and immunotherapy."),
+]
+
+
+def _d_search_practice_kb(a: dict[str, Any]) -> dict[str, Any]:
+    words = set(str(a["query"]).lower().replace("?", " ").split())
+    for keywords, source, answer in _KB:
+        if words & keywords:
+            return {"source": source, "answer": answer}
+    return {"source": None, "answer": None,
+            "note": "No grounded source — do not make one up."}
+
+
+_SMS_TEMPLATES = {"appointment_confirmation", "portal_activation", "payment_link",
+                  "insurance_card_upload", "directions", "cosmetic_deposit"}
+
+
+def _d_send_sms(a: dict[str, Any]) -> dict[str, Any]:
+    if a["template_id"] not in _SMS_TEMPLATES:
+        raise ToolError("UNKNOWN_TEMPLATE",
+                        f"template_id must be one of {sorted(_SMS_TEMPLATES)}.")
+    _event("sms", dict(a))
+    return {"sent": True, "template_id": a["template_id"], "mobile_e164": a["mobile_e164"]}
+
+
+def _d_send_portal_activation(a: dict[str, Any]) -> dict[str, Any]:
+    channel = str(a.get("channel") or "sms")
+    _event("portal_activation", {"channel": channel})
+    return {"sent": True, "channel": channel, "expires": "72 hours"}
+
+
+_CALLBACK_QUEUES = {"billing", "clinical", "front_desk", "cosmetic", "records"}
+
+
+def _d_create_callback_task(a: dict[str, Any]) -> dict[str, Any]:
+    if a["queue"] not in _CALLBACK_QUEUES:
+        raise ToolError("UNKNOWN_QUEUE", f"queue must be one of {sorted(_CALLBACK_QUEUES)}.")
+    sla_hours = {"stat": 1, "urgent": 4}.get(str(a.get("priority") or ""), 24)
+    event_id = _event("callback_task", dict(a))
+    sla_text = "one hour" if sla_hours == 1 else f"{sla_hours} hours"
+    return {
+        "task_id": f"cb_{event_id}",
+        "queue": a["queue"],
+        "sla_hours": sla_hours,
+        "spoken_commitment": (
+            f"Someone from the {a['queue'].replace('_', ' ')} team will call you back at "
+            f"{a['callback_number']} within {sla_text}."
+        ),
+    }
+
+
+_TRANSFER_DESTINATIONS = {"patient_support_center", "billing_team", "location_front_desk",
+                          "cosmetic_coordinator", "clinical_triage", "records", "on_call"}
+
+
+def _d_authenticate_for_transfer(a: dict[str, Any]) -> dict[str, Any]:
+    return {"authenticated": bool(_session.get("verified")),
+            "patient_id": _session.get("patient_id"),
+            "transfer_packet": dict(a)}
+
+
+def _d_transfer_call(a: dict[str, Any]) -> dict[str, Any]:
+    dest = str(a.get("destination") or "patient_support_center")
+    _event("transfer", {"destination": dest})
+    return {"transferred": True, "destination": dest}
+
+
+def _d_transfer_to_human(a: dict[str, Any]) -> dict[str, Any]:
+    dest = str(a["destination"])
+    if dest not in _TRANSFER_DESTINATIONS:
+        raise ToolError("UNKNOWN_DESTINATION",
+                        f"destination must be one of {sorted(_TRANSFER_DESTINATIONS)}.")
+    _event("transfer", dict(a))
+    return {"transferred": True, "destination": dest}
+
+
+def _d_log_call_disposition(a: dict[str, Any]) -> dict[str, Any]:
+    _event("call_disposition", dict(a))
+    return {"logged": True}
+
+
+DISPATCH = {
+    "resolve_inbound_context": _d_resolve_inbound_context,
+    "detect_language": _d_detect_language,
+    "identify_patient": _d_identify_patient,
+    "verify_identity": _d_verify_identity,
+    "get_patient_summary": _d_get_patient_summary,
+    "list_locations": _d_list_locations,
+    "classify_visit_request": _d_classify_visit_request,
+    "find_slots": _d_find_slots,
+    "book_appointment": _d_book_appointment,
+    "reschedule_appointment": _d_reschedule_appointment,
+    "cancel_appointment": _d_cancel_appointment,
+    "join_waitlist": _d_join_waitlist,
+    "schedule_allergy_service": _d_schedule_allergy_service,
+    "check_plan_accepted": _d_check_plan_accepted,
+    "run_eligibility_check": _d_run_eligibility_check,
+    "capture_insurance_update": _d_capture_insurance_update,
+    "get_account_balance": _d_get_account_balance,
+    "explain_charge": _d_explain_charge,
+    "send_payment_link": _d_send_payment_link,
+    "offer_financing": _d_offer_financing,
+    "request_fee_waiver": _d_request_fee_waiver,
+    "quote_cosmetic_service": _d_quote_cosmetic_service,
+    "book_cosmetic_consult": _d_book_cosmetic_consult,
+    "request_rx_refill": _d_request_rx_refill,
+    "get_results_status": _d_get_results_status,
+    "create_clinical_message": _d_create_clinical_message,
+    "search_practice_kb": _d_search_practice_kb,
+    "send_sms": _d_send_sms,
+    "send_portal_activation": _d_send_portal_activation,
+    "create_callback_task": _d_create_callback_task,
+    "authenticate_for_transfer": _d_authenticate_for_transfer,
+    "transfer_call": _d_transfer_call,
+    "log_call_disposition": _d_log_call_disposition,
+    "transfer_to_human": _d_transfer_to_human,
+}
+
+
+class ToolCall(BaseModel):
+    arguments: dict[str, Any] = Field(default_factory=dict)
+
+
+@app.post("/tools/{tool_name}")
+def dispatch_tool(tool_name: str, body: ToolCall) -> dict[str, Any]:
+    handler = DISPATCH.get(tool_name)
+    if handler is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"unknown tool {tool_name!r} — session and handoff tools are "
+            "harness-native and industry tools must be listed in DISPATCH",
+        )
+    try:
+        data = handler(dict(body.arguments or {}))
+        return {"ok": True, "data": data, "error_code": None, "patient_safe_message": None}
+    except ToolError as e:
+        return {"ok": False, "data": None, "error_code": e.code,
+                "patient_safe_message": e.message}
+    except HTTPException as e:
+        return {"ok": False, "data": None, "error_code": f"HTTP_{e.status_code}",
+                "patient_safe_message": str(e.detail)}
+    except Exception as e:  # soft-fail: a broken tool must not 500 into the call
+        return {"ok": False, "data": None, "error_code": "INVALID_ARGUMENTS",
+                "patient_safe_message": f"{type(e).__name__}: {e}"}
 
 
 if __name__ == "__main__":

--- a/industries/legal/tool_server.py
+++ b/industries/legal/tool_server.py
@@ -59,6 +59,7 @@ PRACTICE_AREA_ALIASES = {
 
 
 def init_db() -> None:
+    _session.clear()  # dispatch caller pin follows the DB lifecycle
     DB_PATH.parent.mkdir(parents=True, exist_ok=True)
     if DB_PATH.exists():
         DB_PATH.unlink()
@@ -521,6 +522,93 @@ def escalate_to_human(body: EscalationCreate) -> dict[str, Any]:
             "reason_code": body.reason_code}
 
 
+# ------------------------------------------------------------------ dispatch
+# POST /tools/{tool_name} {"arguments": {...}} — the industry-agnostic contract
+# every harness speaks. Wraps the REST handlers above in the tools.json envelope:
+# {"ok": bool, "data": ..., "error_code": str|null, "caller_safe_message": str|null}.
+# Session (end_call) and handoff (transfer_to_*) tools never land here → 404.
+
+# tools.json industry tools carry no caller_id — lookup_caller pins the caller
+# for the rest of the call. ponytail: module-level session, one call at a time
+# (benchmark runs are max_concurrent=1); key by call id if that ever changes.
+_session: dict[str, str] = {}
+
+
+def _cid() -> str:
+    return _session.get("caller_id", "")
+
+
+def _d_lookup_caller(a: dict[str, Any]) -> dict[str, Any]:
+    result = lookup_caller(CallerLookup(**a))
+    _session["caller_id"] = result["caller_id"]
+    return result
+
+
+DISPATCH = {
+    "lookup_caller": _d_lookup_caller,
+    "get_caller_matters": lambda a: get_caller_matters(_cid()),
+    "take_message": lambda a: take_message(
+        MessageCreate(caller_id=_cid(), for_whom=a["for_whom"], message=a["message"])
+    ),
+    "check_conflict": lambda a: check_conflict(a["opposing_party"]),
+    "check_practice_area": lambda a: check_practice_area(a["practice_area"]),
+    "check_jurisdiction": lambda a: check_jurisdiction(a["state"], a["practice_area"]),
+    "calculate_filing_deadline": lambda a: calculate_filing_deadline(
+        a["state"], a["practice_area"], a["incident_date"]
+    ),
+    "record_intake": lambda a: record_intake(IntakeCreate(caller_id=_cid(), **a)),
+    "add_intake_note": lambda a: add_intake_note(NoteCreate(caller_id=_cid(), note=a["note"])),
+    "send_intake_packet": lambda a: send_document(
+        DocumentCreate(caller_id=_cid(), kind="intake_packet", target=a.get("channel", ""))
+    ),
+    "request_records_authorization": lambda a: send_document(
+        DocumentCreate(caller_id=_cid(), kind="records_authorization", target=a.get("provider", ""))
+    ),
+    "get_attorney": lambda a: get_attorney(a["attorney_id"]),
+    "find_evaluation_slots": lambda a: find_evaluation_slots(
+        a["practice_area"], a["state"], a.get("earliest_date", "")
+    ),
+    "hold_evaluation": lambda a: create_hold(
+        HoldCreate(kind="evaluation", caller_id=_cid(), slot_id=a["slot_id"],
+                   practice_area=a["practice_area"])
+    ),
+    "confirm_evaluation": lambda a: confirm(ConfirmCreate(**a)),
+    "hold_cancellation": lambda a: create_hold(
+        HoldCreate(kind="cancellation", caller_id=_cid(),
+                   evaluation_id=a["evaluation_id"], reason=a.get("reason"))
+    ),
+    "confirm_cancellation": lambda a: confirm(ConfirmCreate(**a)),
+    "get_case_status": lambda a: get_case_status(a["matter_id"], caller_id=_cid()),
+    "escalate_to_human": lambda a: escalate_to_human(
+        EscalationCreate(reason_code=a["reason_code"], caller_id=_cid())
+    ),
+}
+
+
+class ToolCall(BaseModel):
+    arguments: dict[str, Any] = {}
+
+
+@app.post("/tools/{tool_name}")
+def dispatch_tool(tool_name: str, body: ToolCall) -> dict[str, Any]:
+    handler = DISPATCH.get(tool_name)
+    if handler is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"unknown tool {tool_name!r} — session and handoff tools are "
+            "harness-native and industry tools must be listed in DISPATCH",
+        )
+    try:
+        data = handler(dict(body.arguments or {}))
+        return {"ok": True, "data": data, "error_code": None, "caller_safe_message": None}
+    except HTTPException as e:
+        return {"ok": False, "data": None, "error_code": f"HTTP_{e.status_code}",
+                "caller_safe_message": str(e.detail)}
+    except Exception as e:  # soft-fail: a broken tool must not 500 into the call
+        return {"ok": False, "data": None, "error_code": "INVALID_ARGUMENTS",
+                "caller_safe_message": f"{type(e).__name__}: {e}"}
+
+
 # ------------------------------------------------------------------ selfcheck
 
 def selfcheck() -> None:
@@ -597,8 +685,44 @@ def selfcheck() -> None:
             if t.get("handoff"):
                 assert t["handoff_to"] in {a["name"] for a in blueprint["agents"]}
 
+    # dispatch route: every non-handoff non-session tool is callable, unknown
+    # names 404, and the guards survive the envelope.
+    init_db()
+    flags: dict[str, dict] = {}
+    for agent in blueprint["agents"]:
+        for t in agent["tools"]:
+            flags.setdefault(t["name"], t)
+    dispatchable = {n for n in names
+                    if not flags.get(n, {}).get("handoff") and not flags.get(n, {}).get("session")}
+    assert dispatchable == set(DISPATCH), (dispatchable ^ set(DISPATCH))
+
+    d = dispatch_tool("lookup_caller", ToolCall(
+        arguments={"full_name": "Dana Whitfield", "phone": "5105550142"}))
+    assert d["ok"] and d["data"]["caller_id"] == "c_001", d
+    d = dispatch_tool("get_caller_matters", ToolCall())
+    assert d["ok"] and isinstance(d["data"]["matters"], list), "session caller must pin"
+    assert isinstance(http(dispatch_tool, "not_a_tool", ToolCall()), HTTPException)
+    assert isinstance(http(dispatch_tool, "end_call", ToolCall()), HTTPException), \
+        "session tools must not be dispatchable"
+    assert isinstance(http(dispatch_tool, "transfer_to_intake", ToolCall()), HTTPException), \
+        "handoff tools must not be dispatchable"
+    # guard preserved through dispatch: cross-tool token still refused, single-use held
+    held = dispatch_tool("hold_evaluation", ToolCall(
+        arguments={"slot_id": "s_110", "practice_area": "auto_accident"}))
+    assert held["ok"], held
+    bad = dispatch_tool("confirm_evaluation", ToolCall(
+        arguments={"confirmation_token": TOKENS["cancellation"]}))
+    assert bad["ok"] is False and bad["error_code"] and bad["caller_safe_message"], bad
+    good = dispatch_tool("confirm_evaluation", ToolCall(
+        arguments={"confirmation_token": held["data"]["confirmation_token"]}))
+    assert good["ok"] and good["data"]["status"] == "booked", good
+    reuse = dispatch_tool("confirm_evaluation", ToolCall(
+        arguments={"confirmation_token": held["data"]["confirmation_token"]}))
+    assert reuse["ok"] is False, "token must stay single-use through dispatch"
+
     print(f"ok — {len(names)} tools, {len(blueprint['agents'])} agents, "
-          "gate/token/filter traps all hold")
+          "gate/token/filter traps all hold, dispatch covers "
+          f"{len(DISPATCH)} tools")
 
 
 if __name__ == "__main__":

--- a/industries/legal/tool_server.py
+++ b/industries/legal/tool_server.py
@@ -535,7 +535,10 @@ _session: dict[str, str] = {}
 
 
 def _cid() -> str:
-    return _session.get("caller_id", "")
+    caller_id = _session.get("caller_id")
+    if not caller_id:
+        raise HTTPException(status_code=400, detail="Identify the caller first.")
+    return caller_id
 
 
 def _d_lookup_caller(a: dict[str, Any]) -> dict[str, Any]:
@@ -559,14 +562,14 @@ DISPATCH = {
     "record_intake": lambda a: record_intake(IntakeCreate(caller_id=_cid(), **a)),
     "add_intake_note": lambda a: add_intake_note(NoteCreate(caller_id=_cid(), note=a["note"])),
     "send_intake_packet": lambda a: send_document(
-        DocumentCreate(caller_id=_cid(), kind="intake_packet", target=a.get("channel", ""))
+        DocumentCreate(caller_id=_cid(), kind="intake_packet", target=a["channel"])
     ),
     "request_records_authorization": lambda a: send_document(
-        DocumentCreate(caller_id=_cid(), kind="records_authorization", target=a.get("provider", ""))
+        DocumentCreate(caller_id=_cid(), kind="records_authorization", target=a["provider"])
     ),
     "get_attorney": lambda a: get_attorney(a["attorney_id"]),
     "find_evaluation_slots": lambda a: find_evaluation_slots(
-        a["practice_area"], a["state"], a.get("earliest_date", "")
+        a["practice_area"], a["state"], a["earliest_date"]
     ),
     "hold_evaluation": lambda a: create_hold(
         HoldCreate(kind="evaluation", caller_id=_cid(), slot_id=a["slot_id"],
@@ -575,7 +578,7 @@ DISPATCH = {
     "confirm_evaluation": lambda a: confirm(ConfirmCreate(**a)),
     "hold_cancellation": lambda a: create_hold(
         HoldCreate(kind="cancellation", caller_id=_cid(),
-                   evaluation_id=a["evaluation_id"], reason=a.get("reason"))
+                   evaluation_id=a["evaluation_id"], reason=a["reason"])
     ),
     "confirm_cancellation": lambda a: confirm(ConfirmCreate(**a)),
     "get_case_status": lambda a: get_case_status(a["matter_id"], caller_id=_cid()),

--- a/industries/legal/tool_server.py
+++ b/industries/legal/tool_server.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 INDUSTRY_DIR = Path(__file__).resolve().parent
 DB_DIR = INDUSTRY_DIR / "db"
@@ -589,7 +589,7 @@ DISPATCH = {
 
 
 class ToolCall(BaseModel):
-    arguments: dict[str, Any] = {}
+    arguments: dict[str, Any] = Field(default_factory=dict)
 
 
 @app.post("/tools/{tool_name}")

--- a/industries/travel/tool_server.py
+++ b/industries/travel/tool_server.py
@@ -483,8 +483,15 @@ COMMIT_STATUS = {"change": "changed", "cancellation": "cancelled", "seat": "assi
 
 
 @app.post("/confirmations", status_code=201)
-def confirm(body: ConfirmCreate, expected_kind: str | None = None) -> dict[str, Any]:
+def confirm(body: ConfirmCreate) -> dict[str, Any]:
     """Step two: spend the token. Unheld, cross-tool, and reused tokens all fail."""
+    return _confirm(body, expected_kind=None)
+
+
+def _confirm(body: ConfirmCreate, *, expected_kind: str | None) -> dict[str, Any]:
+    """Internal dispatch helper: same as `confirm`, but also rejects a token
+    minted by a different operation. Not a REST route — `expected_kind` is a
+    dispatch-only guard, never a public query parameter."""
     with _db() as conn:
         hold = conn.execute("SELECT * FROM holds WHERE token = ?",
                             (body.confirmation_token,)).fetchone()
@@ -572,11 +579,11 @@ DISPATCH = {
     "quote_seat": lambda a: _quote("seat", a),
     "quote_bag": lambda a: _quote("bag", a),
     "quote_payment": lambda a: _quote("payment", a),
-    "confirm_change": lambda a: confirm(ConfirmCreate(**a), expected_kind="change"),
-    "confirm_cancellation": lambda a: confirm(ConfirmCreate(**a), expected_kind="cancellation"),
-    "confirm_seat": lambda a: confirm(ConfirmCreate(**a), expected_kind="seat"),
-    "confirm_bag": lambda a: confirm(ConfirmCreate(**a), expected_kind="bag"),
-    "confirm_payment": lambda a: confirm(ConfirmCreate(**a), expected_kind="payment"),
+    "confirm_change": lambda a: _confirm(ConfirmCreate(**a), expected_kind="change"),
+    "confirm_cancellation": lambda a: _confirm(ConfirmCreate(**a), expected_kind="cancellation"),
+    "confirm_seat": lambda a: _confirm(ConfirmCreate(**a), expected_kind="seat"),
+    "confirm_bag": lambda a: _confirm(ConfirmCreate(**a), expected_kind="bag"),
+    "confirm_payment": lambda a: _confirm(ConfirmCreate(**a), expected_kind="payment"),
     "send_itinerary": lambda a: send_itinerary(ItineraryCreate(**a)),
     "add_reservation_note": lambda a: add_reservation_note(NoteCreate(**a)),
     "escalate_to_human": lambda a: escalate_to_human(EscalationCreate(**a)),
@@ -608,8 +615,9 @@ def dispatch_tool(tool_name: str, body: ToolCall) -> dict[str, Any]:
                 "error_code": detail.get("error_code", f"HTTP_{e.status_code}"),
                 "caller_safe_message": message}
     except Exception as e:  # soft-fail: a broken tool must not 500 into the call
-        logging.getLogger(__name__).exception(
-            "tool dispatch failed for %r with arguments %r", tool_name, body.arguments)
+        # Log only the tool name and exception, not the arguments — they can carry
+        # confirmation codes and caller-provided notes that shouldn't sit in logs.
+        logging.getLogger(__name__).exception("tool dispatch failed for %r", tool_name)
         return {"ok": False, "data": None, "error_code": "INVALID_ARGUMENTS",
                 "caller_safe_message": "I couldn't process those details. Please check "
                 "the information and try again."}

--- a/industries/travel/tool_server.py
+++ b/industries/travel/tool_server.py
@@ -535,6 +535,77 @@ def escalate_to_human(body: EscalationCreate) -> dict[str, Any]:
             "reason_code": body.reason_code}
 
 
+# ------------------------------------------------------------------ dispatch
+# POST /tools/{tool_name} {"arguments": {...}} — the industry-agnostic contract
+# every harness speaks. Wraps the REST handlers above in the tools.json envelope:
+# {"ok": bool, "data": ..., "error_code": str|null, "caller_safe_message": str|null}.
+# Session (end_call) and handoff (transfer_to_*) tools never land here → 404.
+
+
+def _quote(kind: str, a: dict[str, Any]) -> dict[str, Any]:
+    return create_hold(HoldCreate(kind=kind, **a))
+
+
+DISPATCH = {
+    "find_reservation": lambda a: find_reservation(ReservationFind(**a)),
+    "get_reservation": lambda a: get_reservation(a["confirmation_code"]),
+    "get_traveler_list": lambda a: get_traveler_list(a["confirmation_code"]),
+    "get_fare_rules": lambda a: get_fare_rules(a["confirmation_code"]),
+    "get_flight_status": lambda a: get_flight_status(a["flight_number"], a.get("date", "")),
+    "search_flights": lambda a: search_flights(
+        a["origin"], a["destination"], a["earliest_date"], a.get("cabin", "main")
+    ),
+    "get_seat_map": lambda a: get_seat_map(
+        a["flight_number"], a.get("date", ""), a.get("cabin", "")
+    ),
+    "get_bag_allowance": lambda a: get_bag_allowance(a["confirmation_code"]),
+    "get_credit_balance": lambda a: get_credit_balance(a["summit_number"]),
+    "get_summit_status": lambda a: get_summit_status(a["summit_number"]),
+    "quote_change": lambda a: _quote("change", a),
+    "quote_cancellation": lambda a: _quote("cancellation", a),
+    "quote_seat": lambda a: _quote("seat", a),
+    "quote_bag": lambda a: _quote("bag", a),
+    "quote_payment": lambda a: _quote("payment", a),
+    "confirm_change": lambda a: confirm(ConfirmCreate(**a)),
+    "confirm_cancellation": lambda a: confirm(ConfirmCreate(**a)),
+    "confirm_seat": lambda a: confirm(ConfirmCreate(**a)),
+    "confirm_bag": lambda a: confirm(ConfirmCreate(**a)),
+    "confirm_payment": lambda a: confirm(ConfirmCreate(**a)),
+    "send_itinerary": lambda a: send_itinerary(ItineraryCreate(**a)),
+    "add_reservation_note": lambda a: add_reservation_note(NoteCreate(**a)),
+    "escalate_to_human": lambda a: escalate_to_human(EscalationCreate(**a)),
+}
+
+
+class ToolCall(BaseModel):
+    arguments: dict[str, Any] = {}
+
+
+@app.post("/tools/{tool_name}")
+def dispatch_tool(tool_name: str, body: ToolCall) -> dict[str, Any]:
+    handler = DISPATCH.get(tool_name)
+    if handler is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"unknown tool {tool_name!r} — session and handoff tools are "
+            "harness-native and industry tools must be listed in DISPATCH",
+        )
+    try:
+        data = handler(dict(body.arguments or {}))
+        return {"ok": True, "data": data, "error_code": None, "caller_safe_message": None}
+    except HTTPException as e:
+        detail = e.detail if isinstance(e.detail, dict) else {"message": str(e.detail)}
+        message = detail.get("message", "")
+        if detail.get("suggested_action"):
+            message = f"{message} {detail['suggested_action']}".strip()
+        return {"ok": False, "data": None,
+                "error_code": detail.get("error_code", f"HTTP_{e.status_code}"),
+                "caller_safe_message": message}
+    except Exception as e:  # soft-fail: a broken tool must not 500 into the call
+        return {"ok": False, "data": None, "error_code": "INVALID_ARGUMENTS",
+                "caller_safe_message": f"{type(e).__name__}: {e}"}
+
+
 # ------------------------------------------------------------------ selfcheck
 
 def selfcheck() -> None:
@@ -637,8 +708,37 @@ def selfcheck() -> None:
         for q in [n for n in owned if n.startswith("quote_")]:
             assert f"confirm_{q.removeprefix('quote_')}" in owned, f"{agent['name']}: {q}"
 
+    # dispatch route: every non-handoff non-session tool is callable, unknown
+    # names 404, and the fare guards survive the envelope.
+    init_db()
+    flags: dict[str, dict] = {}
+    for agent in blueprint["agents"]:
+        for t in agent["tools"]:
+            flags.setdefault(t["name"], t)
+    dispatchable = {n for n in names
+                    if not flags.get(n, {}).get("handoff") and not flags.get(n, {}).get("session")}
+    assert dispatchable == set(DISPATCH), (dispatchable ^ set(DISPATCH))
+
+    d = dispatch_tool("find_reservation", ToolCall(
+        arguments={"last_name": "Solberg", "confirmation_code": "RT2LKD"}))
+    assert d["ok"] and d["data"]["verified"], d
+    saver = dispatch_tool("quote_change", ToolCall(
+        arguments={"confirmation_code": "QK4TZP", "new_flight": "CX119"}))
+    assert saver["ok"] is False and saver["error_code"] == "SAVER_NOT_CHANGEABLE", saver
+    try:
+        dispatch_tool("not_a_tool", ToolCall())
+        raise AssertionError("unknown tool must 404")
+    except HTTPException as e:
+        assert e.status_code == 404
+    for native in ("end_call", "transfer_to_ticketing"):
+        try:
+            dispatch_tool(native, ToolCall())
+            raise AssertionError(f"{native} must not be dispatchable")
+        except HTTPException as e:
+            assert e.status_code == 404
+
     print(f"ok — {len(names)} tools, {len(agents)} agents, fare ladder / waiver / token "
-          "traps all hold")
+          f"traps all hold, dispatch covers {len(DISPATCH)} tools")
 
 
 if __name__ == "__main__":

--- a/industries/travel/tool_server.py
+++ b/industries/travel/tool_server.py
@@ -20,6 +20,7 @@ Self-check: python tool_server.py --selfcheck
 from __future__ import annotations
 
 import json
+import logging
 import os
 import re
 import sqlite3
@@ -482,7 +483,7 @@ COMMIT_STATUS = {"change": "changed", "cancellation": "cancelled", "seat": "assi
 
 
 @app.post("/confirmations", status_code=201)
-def confirm(body: ConfirmCreate) -> dict[str, Any]:
+def confirm(body: ConfirmCreate, expected_kind: str | None = None) -> dict[str, Any]:
     """Step two: spend the token. Unheld, cross-tool, and reused tokens all fail."""
     with _db() as conn:
         hold = conn.execute("SELECT * FROM holds WHERE token = ?",
@@ -493,6 +494,11 @@ def confirm(body: ConfirmCreate) -> dict[str, Any]:
         if hold["consumed"]:
             raise _fail(409, "TOKEN_ALREADY_USED", "That token was already used.",
                         "Quote it again and read the new summary back.")
+        if expected_kind is not None and hold["kind"] != expected_kind:
+            raise _fail(409, "TOKEN_KIND_MISMATCH",
+                        "That token was minted by a different operation.",
+                        "Quote the operation you actually want to confirm and use "
+                        "the token that quote returns.")
         conn.execute("UPDATE holds SET consumed = 1 WHERE token = ?",
                      (body.confirmation_token,))
         conn.execute("INSERT INTO commits (kind, confirmation_code, detail) VALUES (?, ?, ?)",
@@ -566,11 +572,11 @@ DISPATCH = {
     "quote_seat": lambda a: _quote("seat", a),
     "quote_bag": lambda a: _quote("bag", a),
     "quote_payment": lambda a: _quote("payment", a),
-    "confirm_change": lambda a: confirm(ConfirmCreate(**a)),
-    "confirm_cancellation": lambda a: confirm(ConfirmCreate(**a)),
-    "confirm_seat": lambda a: confirm(ConfirmCreate(**a)),
-    "confirm_bag": lambda a: confirm(ConfirmCreate(**a)),
-    "confirm_payment": lambda a: confirm(ConfirmCreate(**a)),
+    "confirm_change": lambda a: confirm(ConfirmCreate(**a), expected_kind="change"),
+    "confirm_cancellation": lambda a: confirm(ConfirmCreate(**a), expected_kind="cancellation"),
+    "confirm_seat": lambda a: confirm(ConfirmCreate(**a), expected_kind="seat"),
+    "confirm_bag": lambda a: confirm(ConfirmCreate(**a), expected_kind="bag"),
+    "confirm_payment": lambda a: confirm(ConfirmCreate(**a), expected_kind="payment"),
     "send_itinerary": lambda a: send_itinerary(ItineraryCreate(**a)),
     "add_reservation_note": lambda a: add_reservation_note(NoteCreate(**a)),
     "escalate_to_human": lambda a: escalate_to_human(EscalationCreate(**a)),
@@ -602,8 +608,11 @@ def dispatch_tool(tool_name: str, body: ToolCall) -> dict[str, Any]:
                 "error_code": detail.get("error_code", f"HTTP_{e.status_code}"),
                 "caller_safe_message": message}
     except Exception as e:  # soft-fail: a broken tool must not 500 into the call
+        logging.getLogger(__name__).exception(
+            "tool dispatch failed for %r with arguments %r", tool_name, body.arguments)
         return {"ok": False, "data": None, "error_code": "INVALID_ARGUMENTS",
-                "caller_safe_message": f"{type(e).__name__}: {e}"}
+                "caller_safe_message": "I couldn't process those details. Please check "
+                "the information and try again."}
 
 
 # ------------------------------------------------------------------ selfcheck

--- a/industries/travel/tool_server.py
+++ b/industries/travel/tool_server.py
@@ -31,7 +31,7 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 INDUSTRY_DIR = Path(__file__).resolve().parent
 DB_DIR = INDUSTRY_DIR / "db"
@@ -584,7 +584,7 @@ DISPATCH = {
 
 
 class ToolCall(BaseModel):
-    arguments: dict[str, Any] = {}
+    arguments: dict[str, Any] = Field(default_factory=dict)
 
 
 @app.post("/tools/{tool_name}")

--- a/tests/test_tool_server.py
+++ b/tests/test_tool_server.py
@@ -126,6 +126,24 @@ def _dispatch_args(industry: str, spec: dict[str, Any]) -> tuple[dict[str, Any],
     return _sample_args(spec), False
 
 
+# Some known-good tools only succeed once a prerequisite tool has seeded session
+# state (e.g. healthcare's get_patient_summary/explain_charge need verify_identity
+# to have run first). Listed explicitly so the smoke test's dispatch order doesn't
+# silently depend on tools.json's declaration order.
+_DISPATCH_BEFORE: dict[str, list[str]] = {
+    "healthcare": ["verify_identity"],
+}
+
+
+def _ordered_tools(industry: str, tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Reorder `tools` so each name in _DISPATCH_BEFORE[industry] comes first,
+    in that order, ahead of everything else (original order otherwise)."""
+    first = [n for n in _DISPATCH_BEFORE.get(industry, []) if any(t["name"] == n for t in tools)]
+    by_name = {t["name"]: t for t in tools}
+    rest = [t for t in tools if t["name"] not in first]
+    return [by_name[n] for n in first] + rest
+
+
 def test_dispatch_every_industry_tool() -> None:
     for industry in INDUSTRIES:
         with _load_tool_server(industry) as module:
@@ -139,7 +157,7 @@ def test_dispatch_every_industry_tool() -> None:
 
                 assert client.post("/tools/not_a_real_tool", json={"arguments": {}}).status_code == 404
 
-                for spec in tools:
+                for spec in _ordered_tools(industry, tools):
                     name = spec["name"]
                     entry = flags.get(name, {})
                     args, must_succeed = _dispatch_args(industry, spec)

--- a/tests/test_tool_server.py
+++ b/tests/test_tool_server.py
@@ -92,6 +92,16 @@ def test_dispatch_every_industry_tool() -> None:
                 # each industry's declared envelope: ok/data/... or success/...
                 assert "ok" in body or "success" in body, f"{industry}/{name}: {body}"
 
+            # reverse direction: no DISPATCH entry without a tools.json tool
+            declared = {
+                spec["name"]
+                for spec in tools
+                if not (flags.get(spec["name"], {}).get("session")
+                        or flags.get(spec["name"], {}).get("handoff"))
+            }
+            orphans = set(module.DISPATCH) - declared
+            assert not orphans, f"{industry}: DISPATCH entries not in tools.json: {sorted(orphans)}"
+
 
 def test_control_industry_rest_and_dispatch() -> None:
     module = _load_tool_server("control-industry")

--- a/tests/test_tool_server.py
+++ b/tests/test_tool_server.py
@@ -12,6 +12,7 @@ import json
 import os
 import sys
 import tempfile
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -21,19 +22,29 @@ ROOT = Path(__file__).resolve().parents[1]
 INDUSTRIES = ("control-industry", "healthcare", "legal", "travel")
 
 
+@contextmanager
 def _load_tool_server(industry: str):
     """Import industries/<industry>/tool_server.py under a unique module name,
-    pointing MIVAS_DB_PATH at a throwaway file (DB_PATH is read at import)."""
-    os.environ["MIVAS_DB_PATH"] = str(
-        Path(tempfile.mkdtemp(prefix=f"mivas-{industry}-")) / "runtime.db"
-    )
-    path = ROOT / "industries" / industry / "tool_server.py"
-    name = f"tool_server_{industry.replace('-', '_')}"
-    spec = importlib.util.spec_from_file_location(name, path)
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[name] = module
-    spec.loader.exec_module(module)
-    return module
+    pointing MIVAS_DB_PATH at a temp file (DB_PATH is read at import).
+    Restores the previous MIVAS_DB_PATH value and deletes the temp dir on exit."""
+    original = os.environ.get("MIVAS_DB_PATH")
+    with tempfile.TemporaryDirectory(prefix=f"mivas-{industry}-") as tmp:
+        os.environ["MIVAS_DB_PATH"] = str(Path(tmp) / "runtime.db")
+        try:
+            name = f"tool_server_{industry.replace('-', '_')}"
+            if name in sys.modules:
+                del sys.modules[name]
+            path = ROOT / "industries" / industry / "tool_server.py"
+            spec = importlib.util.spec_from_file_location(name, path)
+            module = importlib.util.module_from_spec(spec)
+            sys.modules[name] = module
+            spec.loader.exec_module(module)
+            yield module
+        finally:
+            if original is None:
+                os.environ.pop("MIVAS_DB_PATH", None)
+            else:
+                os.environ["MIVAS_DB_PATH"] = original
 
 
 def _tool_flags(industry: str) -> dict[str, dict[str, Any]]:
@@ -66,46 +77,99 @@ def _sample_args(spec: dict[str, Any]) -> dict[str, Any]:
     return {name: _sample_value(name, props[name]) for name in schema.get("required") or []}
 
 
+# Curated sample argument sets for tools that should return ok/success == True.
+# This is a targeted smoke signal: a regressed handler that always soft-fails will
+# fail these assertions even though the generic floor below still passes.
+_KNOWN_GOOD_ARGS: dict[str, dict[str, dict[str, Any]]] = {
+    "control-industry": {
+        "schedule_appointment": {"date": "08/15/2026"},
+    },
+    "legal": {
+        "lookup_caller": {"full_name": "Dana Whitfield", "phone": "5105550142"},
+        "check_practice_area": {"practice_area": "auto_accident"},
+        "calculate_filing_deadline": {
+            "state": "CA",
+            "practice_area": "auto_accident",
+            "incident_date": "2024-09-15",
+        },
+        "find_evaluation_slots": {
+            "practice_area": "auto_accident",
+            "state": "CA",
+            "earliest_date": "2026-08-01",
+        },
+        "get_attorney": {"attorney_id": "a_10"},
+    },
+    "healthcare": {
+        "resolve_inbound_context": {"caller_ani": "+12125550100"},
+        "verify_identity": {"full_name": "Jordan Lee", "dob": "1990-04-12"},
+        "get_patient_summary": {},
+        "find_slots": {"location_ids": ["loc_park_ave"]},
+        "explain_charge": {"line_item_id": "li_noshow"},
+        "search_practice_kb": {"query": "open"},
+    },
+    "travel": {
+        "find_reservation": {"last_name": "Solberg", "confirmation_code": "RT2LKD"},
+        "get_reservation": {"confirmation_code": "RT2LKD"},
+        "search_flights": {"origin": "ORD", "destination": "SEA", "earliest_date": "2026-08-09"},
+        "get_flight_status": {"flight_number": "CX771", "date": "2026-08-09"},
+        "get_credit_balance": {"summit_number": "SC2019773"},
+    },
+}
+
+
+def _dispatch_args(industry: str, spec: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    """Return the arguments and whether this tool must return ok/success == True."""
+    name = spec["name"]
+    known = _KNOWN_GOOD_ARGS.get(industry, {})
+    if name in known:
+        return known[name], True
+    return _sample_args(spec), False
+
+
 def test_dispatch_every_industry_tool() -> None:
     for industry in INDUSTRIES:
-        module = _load_tool_server(industry)
-        tools = json.loads(
-            (ROOT / "industries" / industry / "tools.json").read_text()
-        )["tools"]
-        flags = _tool_flags(industry)
-        with TestClient(module.app) as client:
-            assert client.get("/health").status_code == 200, industry
-            assert client.get("/state").status_code == 200, industry
+        with _load_tool_server(industry) as module:
+            tools = json.loads(
+                (ROOT / "industries" / industry / "tools.json").read_text()
+            )["tools"]
+            flags = _tool_flags(industry)
+            with TestClient(module.app) as client:
+                assert client.get("/health").status_code == 200, industry
+                assert client.get("/state").status_code == 200, industry
 
-            assert client.post("/tools/not_a_real_tool", json={"arguments": {}}).status_code == 404
+                assert client.post("/tools/not_a_real_tool", json={"arguments": {}}).status_code == 404
 
-            for spec in tools:
-                name = spec["name"]
-                entry = flags.get(name, {})
-                resp = client.post(f"/tools/{name}", json={"arguments": _sample_args(spec)})
-                if entry.get("session") or entry.get("handoff"):
-                    assert resp.status_code == 404, f"{industry}/{name} must stay harness-native"
-                    continue
-                assert resp.status_code == 200, f"{industry}/{name}: {resp.text[:200]}"
-                body = resp.json()
-                assert isinstance(body, dict), f"{industry}/{name}"
-                # each industry's declared envelope: ok/data/... or success/...
-                assert "ok" in body or "success" in body, f"{industry}/{name}: {body}"
+                for spec in tools:
+                    name = spec["name"]
+                    entry = flags.get(name, {})
+                    args, must_succeed = _dispatch_args(industry, spec)
+                    resp = client.post(f"/tools/{name}", json={"arguments": args})
+                    if entry.get("session") or entry.get("handoff"):
+                        assert resp.status_code == 404, f"{industry}/{name} must stay harness-native"
+                        continue
+                    assert resp.status_code == 200, f"{industry}/{name}: {resp.text[:200]}"
+                    body = resp.json()
+                    assert isinstance(body, dict), f"{industry}/{name}"
+                    # floor: every dispatchable tool returns the industry envelope
+                    assert "ok" in body or "success" in body, f"{industry}/{name}: {body}"
+                    if must_succeed:
+                        assert body.get("ok") is True or body.get("success") is True, (
+                            f"{industry}/{name} must succeed with known-good args: {body}"
+                        )
 
-            # reverse direction: no DISPATCH entry without a tools.json tool
-            declared = {
-                spec["name"]
-                for spec in tools
-                if not (flags.get(spec["name"], {}).get("session")
-                        or flags.get(spec["name"], {}).get("handoff"))
-            }
-            orphans = set(module.DISPATCH) - declared
-            assert not orphans, f"{industry}: DISPATCH entries not in tools.json: {sorted(orphans)}"
+                # reverse direction: no DISPATCH entry without a tools.json tool
+                declared = {
+                    spec["name"]
+                    for spec in tools
+                    if not (flags.get(spec["name"], {}).get("session")
+                            or flags.get(spec["name"], {}).get("handoff"))
+                }
+                orphans = set(module.DISPATCH) - declared
+                assert not orphans, f"{industry}: DISPATCH entries not in tools.json: {sorted(orphans)}"
 
 
 def test_control_industry_rest_and_dispatch() -> None:
-    module = _load_tool_server("control-industry")
-    with TestClient(module.app) as client:
+    with _load_tool_server("control-industry") as module, TestClient(module.app) as client:
         assert client.get("/health").json() == {"status": "ok"}
         assert client.get("/state").json() == {"appointments": []}
         assert client.get("/appointments").json() == []
@@ -128,8 +192,7 @@ def test_control_industry_rest_and_dispatch() -> None:
 
 
 def test_legal_guards_survive_dispatch() -> None:
-    module = _load_tool_server("legal")
-    with TestClient(module.app) as client:
+    with _load_tool_server("legal") as module, TestClient(module.app) as client:
         def tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
             resp = client.post(f"/tools/{name}", json={"arguments": args})
             assert resp.status_code == 200, resp.text
@@ -151,8 +214,7 @@ def test_legal_guards_survive_dispatch() -> None:
 
 
 def test_healthcare_flow_through_dispatch() -> None:
-    module = _load_tool_server("healthcare")
-    with TestClient(module.app) as client:
+    with _load_tool_server("healthcare") as module, TestClient(module.app) as client:
         def tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
             resp = client.post(f"/tools/{name}", json={"arguments": args})
             assert resp.status_code == 200, resp.text
@@ -193,8 +255,7 @@ def test_healthcare_flow_through_dispatch() -> None:
 
 
 def test_travel_guards_survive_dispatch() -> None:
-    module = _load_tool_server("travel")
-    with TestClient(module.app) as client:
+    with _load_tool_server("travel") as module, TestClient(module.app) as client:
         def tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
             resp = client.post(f"/tools/{name}", json={"arguments": args})
             assert resp.status_code == 200, resp.text

--- a/tests/test_tool_server.py
+++ b/tests/test_tool_server.py
@@ -1,42 +1,213 @@
-"""Automated smoke tests for control-industry state API + SQLite."""
+"""Smoke tests for every industry state API + the generic /tools/{name} dispatch.
+
+The invariant: every non-handoff, non-session tool in an industry's tools.json
+is dispatchable via POST /tools/{name} {"arguments": {...}} and answers with
+that industry's declared envelope; session/handoff/unknown names 404.
+"""
 
 from __future__ import annotations
 
+import importlib.util
+import json
+import os
 import sys
+import tempfile
 from pathlib import Path
+from typing import Any
 
 from fastapi.testclient import TestClient
 
 ROOT = Path(__file__).resolve().parents[1]
-sys.path.insert(0, str(ROOT / "industries" / "control-industry"))
-
-from tool_server import app  # noqa: E402
+INDUSTRIES = ("control-industry", "healthcare", "legal", "travel")
 
 
-def test_create_appointment() -> None:
-    with TestClient(app) as client:
+def _load_tool_server(industry: str):
+    """Import industries/<industry>/tool_server.py under a unique module name,
+    pointing MIVAS_DB_PATH at a throwaway file (DB_PATH is read at import)."""
+    os.environ["MIVAS_DB_PATH"] = str(
+        Path(tempfile.mkdtemp(prefix=f"mivas-{industry}-")) / "runtime.db"
+    )
+    path = ROOT / "industries" / industry / "tool_server.py"
+    name = f"tool_server_{industry.replace('-', '_')}"
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _tool_flags(industry: str) -> dict[str, dict[str, Any]]:
+    bp = json.loads((ROOT / "industries" / industry / "agent_blueprint.json").read_text())
+    flags: dict[str, dict[str, Any]] = {}
+    for agent in bp["agents"]:
+        for t in agent["tools"]:
+            flags.setdefault(t["name"], t)
+    return flags
+
+
+def _sample_value(name: str, prop: dict[str, Any]) -> Any:
+    t = prop.get("type", "string")
+    if t == "boolean":
+        return False
+    if t in ("integer", "number"):
+        return 1
+    if t == "array":
+        return []
+    if t == "object":
+        return {}
+    if "date" in name or name in ("start", "end", "earliest", "latest", "dob"):
+        return "2026-08-01"
+    return "test"
+
+
+def _sample_args(spec: dict[str, Any]) -> dict[str, Any]:
+    schema = spec.get("inputSchema") or {}
+    props = schema.get("properties") or {}
+    return {name: _sample_value(name, props[name]) for name in schema.get("required") or []}
+
+
+def test_dispatch_every_industry_tool() -> None:
+    for industry in INDUSTRIES:
+        module = _load_tool_server(industry)
+        tools = json.loads(
+            (ROOT / "industries" / industry / "tools.json").read_text()
+        )["tools"]
+        flags = _tool_flags(industry)
+        with TestClient(module.app) as client:
+            assert client.get("/health").status_code == 200, industry
+            assert client.get("/state").status_code == 200, industry
+
+            assert client.post("/tools/not_a_real_tool", json={"arguments": {}}).status_code == 404
+
+            for spec in tools:
+                name = spec["name"]
+                entry = flags.get(name, {})
+                resp = client.post(f"/tools/{name}", json={"arguments": _sample_args(spec)})
+                if entry.get("session") or entry.get("handoff"):
+                    assert resp.status_code == 404, f"{industry}/{name} must stay harness-native"
+                    continue
+                assert resp.status_code == 200, f"{industry}/{name}: {resp.text[:200]}"
+                body = resp.json()
+                assert isinstance(body, dict), f"{industry}/{name}"
+                # each industry's declared envelope: ok/data/... or success/...
+                assert "ok" in body or "success" in body, f"{industry}/{name}: {body}"
+
+
+def test_control_industry_rest_and_dispatch() -> None:
+    module = _load_tool_server("control-industry")
+    with TestClient(module.app) as client:
         assert client.get("/health").json() == {"status": "ok"}
         assert client.get("/state").json() == {"appointments": []}
         assert client.get("/appointments").json() == []
 
         created = client.post("/appointments", json={"date": "08/15/2026"})
         assert created.status_code == 201
-        body = created.json()
-        assert body["date"] == "08/15/2026"
-        assert "id" in body
+        assert created.json()["date"] == "08/15/2026"
+
+        dispatched = client.post(
+            "/tools/schedule_appointment", json={"arguments": {"date": "08/16/2026"}}
+        )
+        assert dispatched.status_code == 200
+        assert dispatched.json() == {"success": True, "date": "08/16/2026"}
 
         state = client.get("/state").json()
-        assert len(state["appointments"]) == 1
-        assert state["appointments"][0]["date"] == "08/15/2026"
+        assert [a["date"] for a in state["appointments"]] == ["08/15/2026", "08/16/2026"]
+
+        # session tools stay harness-native
+        assert client.post("/tools/end_call", json={"arguments": {"reason": "done"}}).status_code == 404
 
 
-def test_no_tools_mirror_routes() -> None:
-    with TestClient(app) as client:
-        assert client.post("/tools/schedule_appointment", json={"date": "08/15/2026"}).status_code == 404
-        assert client.post("/tools/end_call", json={"reason": "done"}).status_code == 404
+def test_legal_guards_survive_dispatch() -> None:
+    module = _load_tool_server("legal")
+    with TestClient(module.app) as client:
+        def tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
+            resp = client.post(f"/tools/{name}", json={"arguments": args})
+            assert resp.status_code == 200, resp.text
+            return resp.json()
+
+        found = tool("lookup_caller", {"full_name": "Dana Whitfield", "phone": "5105550142"})
+        assert found["ok"] and found["data"]["caller_id"] == "c_001"
+        # caller pinned server-side: no caller_id in the tool signature
+        matters = tool("get_caller_matters", {})
+        assert matters["ok"] and isinstance(matters["data"]["matters"], list)
+
+        held = tool("hold_evaluation", {"slot_id": "s_110", "practice_area": "auto_accident"})
+        assert held["ok"], held
+        token = held["data"]["confirmation_token"]
+        assert tool("confirm_evaluation", {"confirmation_token": "made-up"})["ok"] is False
+        assert tool("confirm_evaluation", {"confirmation_token": token})["data"]["status"] == "booked"
+        reuse = tool("confirm_evaluation", {"confirmation_token": token})
+        assert reuse["ok"] is False and reuse["error_code"], "token must stay single-use"
+
+
+def test_healthcare_flow_through_dispatch() -> None:
+    module = _load_tool_server("healthcare")
+    with TestClient(module.app) as client:
+        def tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
+            resp = client.post(f"/tools/{name}", json={"arguments": args})
+            assert resp.status_code == 200, resp.text
+            return resp.json()
+
+        # identity gate: summary before verification fails safe
+        locked = tool("get_patient_summary", {})
+        assert locked["ok"] is False and locked["error_code"] == "NOT_VERIFIED"
+
+        verified = tool("verify_identity", {"full_name": "Jordan Lee", "dob": "1990-04-12"})
+        assert verified["ok"] and verified["data"]["patient_id"] == "pat_jordan_lee"
+        summary = tool("get_patient_summary", {})
+        assert summary["ok"] and summary["data"]["balance_cents"] == 12500
+
+        # cancellation fee gate: seeded appt is inside the 24 h medical window
+        first = tool("cancel_appointment",
+                     {"appointment_id": "1", "cancellation_reason_code": "patient_request"})
+        assert first["data"]["status"] == "fee_disclosure_required", first
+        second = tool("cancel_appointment",
+                      {"appointment_id": "1", "cancellation_reason_code": "patient_request",
+                       "fee_disclosed_and_accepted": True})
+        assert second["data"]["status"] == "cancelled"
+        assert second["data"]["fee_charged_cents"] == 5000
+
+        # a fixture-backed write lands in durable state
+        slots = tool("find_slots", {"location_ids": ["loc_park_ave"]})
+        assert slots["ok"] and slots["data"]["count"] > 0
+        slot = slots["data"]["slots"][0]
+        booked = tool("book_appointment", {
+            "slot_id": slot["slot_id"], "appointment_type_code": "MED_FOLLOWUP",
+            "location_id": slot["location_id"], "provider_id": slot["provider_id"],
+            "start": slot["start"], "end": slot["end"], "description": "follow-up",
+        })
+        assert booked["ok"], booked
+        state = client.get("/state").json()
+        assert any(a["status"] == "booked" and a["start"] == slot["start"]
+                   for a in state["appointments"])
+
+
+def test_travel_guards_survive_dispatch() -> None:
+    module = _load_tool_server("travel")
+    with TestClient(module.app) as client:
+        def tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
+            resp = client.post(f"/tools/{name}", json={"arguments": args})
+            assert resp.status_code == 200, resp.text
+            return resp.json()
+
+        found = tool("find_reservation", {"last_name": "Solberg", "confirmation_code": "RT2LKD"})
+        assert found["ok"] and found["data"]["verified"]
+
+        saver = tool("quote_change", {"confirmation_code": "QK4TZP", "new_flight": "CX119"})
+        assert saver["ok"] is False and saver["error_code"] == "SAVER_NOT_CHANGEABLE"
+
+        quote = tool("quote_change", {"confirmation_code": "HB9WQM", "new_flight": "CX404"})
+        assert quote["ok"], quote
+        token = quote["data"]["confirmation_token"]
+        assert tool("confirm_change", {"confirmation_token": token})["data"]["status"] == "changed"
+        reuse = tool("confirm_change", {"confirmation_token": token})
+        assert reuse["ok"] is False and reuse["error_code"] == "TOKEN_ALREADY_USED"
 
 
 if __name__ == "__main__":
-    test_create_appointment()
-    test_no_tools_mirror_routes()
+    test_dispatch_every_industry_tool()
+    test_control_industry_rest_and_dispatch()
+    test_legal_guards_survive_dispatch()
+    test_healthcare_flow_through_dispatch()
+    test_travel_guards_survive_dispatch()
     print("ok test_tool_server")

--- a/voice-agent-harnesses/README.md
+++ b/voice-agent-harnesses/README.md
@@ -1,3 +1,37 @@
 # voice-agent-harnesses
 
 Harnesses that load an industry `agent_blueprint.json` into a runnable multi-agent voice runtime.
+
+## Tool dispatch contract (industry-agnostic)
+
+Harnesses are dumb pipes for industry tools. Each one reads the industry's
+`tools.json` + `agent_blueprint.json`, registers every non-handoff, non-session
+tool generically, and on invocation POSTs
+
+```
+POST {TOOL_SERVER_URL}/tools/{name}
+{"arguments": { ...model-supplied args... }}
+```
+
+to the industry tool server, returning the JSON response to the model verbatim.
+The server answers with the envelope its `tools.json` `outputSchema` declares
+(e.g. `{"ok": bool, "data": ..., "error_code": ..., "<caller|patient>_safe_message": ...}`;
+control-industry uses `{"success": ..., ...}`). An unknown tool name is a 404.
+
+Tool kinds, from the blueprint entry's flags:
+
+- **industry** (default): dispatched to `POST /tools/{name}` as above. No
+  per-tool handler code in any harness.
+- **handoff** (`handoff: true`): harness/provider-native (LiveKit agent switch,
+  Vapi squad handoff, Retell state edge, ElevenLabs `transfer_to_agent`, soft
+  prompt handoff on fixed-config sessions). Never hits the tool server.
+- **session** (`session: true`, e.g. `end_call`): harness-native; ends the
+  session with the harness's delayed-close/farewell behavior. Never hits the
+  tool server.
+
+The industry's REST routes (`GET /health`, `GET /state`, the domain routes)
+remain for evals and debugging — harnesses only speak `/tools/{name}`.
+
+Platform harnesses (vapi/retell/bland/cartesia) receive tool invocations as
+provider webhooks on `{PUBLIC_URL}/tool/{name}` and forward them to
+`POST {TOOL_SERVER_URL}/tools/{name}` unchanged.

--- a/voice-agent-harnesses/assemblyai/harness.py
+++ b/voice-agent-harnesses/assemblyai/harness.py
@@ -53,6 +53,23 @@ def load_blueprint(industry_dir: str | Path) -> dict[str, Any]:
     }
 
 
+def _multiagent_note(bp: dict[str, Any]) -> str:
+    """Soft-handoff note: the session's tool list is fixed at connect, so every
+    agent's tools are visible — the prompt has to hold the role boundary."""
+    handoffs = sorted(
+        {t["name"] for a in bp["agents"].values() for t in a["tools"] if t.get("handoff")}
+    )
+    if not handoffs:
+        return ""
+    return (
+        "\n\n# Multi-agent note\n"
+        f"Start as the {bp['start']} agent. Tools belonging to other agents are "
+        f"visible to you; only use another agent's tools after the matching handoff "
+        f"tool ({', '.join(handoffs)}) has succeeded and you have adopted that "
+        "agent's role."
+    )
+
+
 def _tool_decl(spec: dict) -> dict[str, Any]:
     schema = dict(spec.get("inputSchema") or {"type": "object"})
     schema.setdefault("properties", {})
@@ -79,13 +96,8 @@ def session_config(
             tools.append(_tool_decl(bp["catalog"][name]))
 
     start = bp["agents"][bp["start"]]
-    # note soft-handoff: scheduler tools are visible; prompt still starts as receptionist
-    instruction = (
-        start["instructions"]
-        + "\n\n# Multi-agent note\n"
-        "Start as the receptionist. Only call schedule_appointment after "
-        "handoff_to_scheduler has succeeded and you have adopted the scheduler role."
-    )
+    # note soft-handoff: other agents' tools are visible; prompt still starts as bp["start"]
+    instruction = start["instructions"] + _multiagent_note(bp)
     return {
         "system_prompt": instruction,
         "greeting": greeting or os.environ.get("ASSEMBLYAI_GREETING", DEFAULT_GREETING),
@@ -98,12 +110,20 @@ def session_config(
     }
 
 
-async def _post_appointment(date: str) -> dict[str, Any]:
+def _tool_entry(bp: dict[str, Any], agent: str, name: str) -> dict[str, Any] | None:
+    """The blueprint entry for a tool, preferring the current agent's copy."""
+    for owner in [agent] + [a for a in bp["agents"] if a != agent]:
+        for t in bp["agents"][owner]["tools"]:
+            if t["name"] == name:
+                return t
+    return None
+
+
+async def _dispatch(name: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Generic dispatch: POST /tools/{name}; the server's envelope is the result."""
     async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.post(f"{TOOL_SERVER_URL}/appointments", json={"date": date})
-        resp.raise_for_status()
-        body = resp.json()
-    return {"success": True, "date": body["date"]}
+        resp = await client.post(f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args})
+        return resp.json()
 
 
 async def _execute_tool(
@@ -112,31 +132,26 @@ async def _execute_tool(
     bp: dict[str, Any],
     state: dict[str, Any],
 ) -> tuple[dict[str, Any], bool]:
-    """Execute a tool. Returns (result, should_end_call)."""
-    if name == "handoff_to_scheduler":
-        target = None
-        for t in bp["agents"][state["agent"]]["tools"]:
-            if t["name"] == name and t.get("handoff"):
-                target = t.get("handoff_to")
-                break
+    """Execute a tool. Returns (result, should_end_call). Handoff and session
+    tools are harness-native; every other tool dispatches to the tool server."""
+    entry = _tool_entry(bp, state["agent"], name)
+    if entry is not None and entry.get("handoff"):
+        target = entry.get("handoff_to")
         if not target or target not in bp["agents"]:
             return {"success": False, "error": "unknown handoff target"}, False
         state["agent"] = target
-        sched = bp["agents"][target]
+        agent = bp["agents"][target]
         return {
             "success": True,
             "role": target,
-            "instructions": sched["instructions"],
-            "note": "You are now the scheduler. Follow the instructions field exactly.",
+            "instructions": agent["instructions"],
+            "note": f"You are now the {target} agent. Follow the instructions field exactly.",
         }, False
 
-    if name == "schedule_appointment":
-        return await _post_appointment(args["date"]), False
-
-    if name == "end_call":
+    if entry is not None and entry.get("session"):
         return {"success": True}, True
 
-    return {"success": False, "error": f"unknown tool {name}"}, False
+    return await _dispatch(name, args), False
 
 
 async def run_tool(
@@ -151,7 +166,8 @@ async def run_tool(
     from report import finish_tool_span, tool_span
     with tool_span(name, args, call_id=call_id) as span:
         result, stop = await _execute_tool(name, args, bp, state)
-        finish_tool_span(span, result, ok=bool(result.get("success")))
+        ok = bool(result.get("ok", result.get("success", True)))
+        finish_tool_span(span, result, ok=ok)
         return result, stop
 
 

--- a/voice-agent-harnesses/bland/harness.py
+++ b/voice-agent-harnesses/bland/harness.py
@@ -397,16 +397,30 @@ async def session_ws_url(agent_id: str) -> str:
     return f"{WS_BASE}?agent={agent_id}&token={token}"
 
 
+def _tool_flags(name: str) -> dict[str, Any]:
+    """Blueprint flags for a tool (handoff/session), from the INDUSTRY env."""
+    global _FLAGS
+    if _FLAGS is None:
+        bp = load_blueprint(os.environ.get("INDUSTRY", "control-industry"))
+        _FLAGS = {}
+        for entry in bp["agents"].values():
+            for t in entry["tools"]:
+                _FLAGS.setdefault(t["name"], t)
+    return _FLAGS.get(name, {})
+
+
+_FLAGS: dict[str, dict[str, Any]] | None = None
+
+
 async def _execute_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
-    """Industry tools hit the tool server; the handoff node has no state to write."""
-    if name == "schedule_appointment":
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            resp = await client.post(f"{TOOL_SERVER_URL}/appointments", json={"date": args["date"]})
-            resp.raise_for_status()
-            return {"success": True, "date": resp.json()["date"]}
-    if name == "handoff_to_scheduler":
+    """Industry tools dispatch to POST /tools/{name}; handoff webhook nodes have
+    no server state to write and session tools stay harness-native."""
+    flags = _tool_flags(name)
+    if flags.get("handoff") or flags.get("session"):
         return {"success": True}
-    return {"success": False, "error": f"unknown tool {name}"}
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args})
+        return resp.json()
 
 
 async def run_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
@@ -415,7 +429,7 @@ async def run_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
     with tool_span(name, args) as span:
         try:
             result = await _execute_tool(name, args)
-            ok = bool(result.get("success"))
+            ok = bool(result.get("ok", result.get("success", True)))
         except Exception as e:
             result, ok = {"success": False, "error": f"{type(e).__name__}: {e}"}, False
         finish_tool_span(span, result, ok=ok)

--- a/voice-agent-harnesses/cartesia/harness.py
+++ b/voice-agent-harnesses/cartesia/harness.py
@@ -154,6 +154,7 @@ async def _execute_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
     """Generic dispatch: POST /tools/{name}; the server's envelope is the result."""
     async with httpx.AsyncClient(timeout=30.0) as client:
         resp = await client.post(f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args})
+        resp.raise_for_status()
         return resp.json()
 
 

--- a/voice-agent-harnesses/cartesia/harness.py
+++ b/voice-agent-harnesses/cartesia/harness.py
@@ -151,10 +151,12 @@ def ensure_agent(industry_dir: str | Path, *, public_url: str | None = None) -> 
 
 
 async def _execute_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
-    """Generic dispatch: POST /tools/{name}; the server's envelope is the result."""
+    """Generic dispatch: POST /tools/{name}; the server's envelope is the result.
+    A 404 for an unknown/non-dispatchable tool has no `ok`/`success` key, so
+    run_tool's `default=False` fallback (not an exception here) is what turns
+    it into a failure, matching how the other harnesses handle the same case."""
     async with httpx.AsyncClient(timeout=30.0) as client:
         resp = await client.post(f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args})
-        resp.raise_for_status()
         return resp.json()
 
 
@@ -165,7 +167,7 @@ async def run_tool(name: str, args: dict[str, Any], *, call_id: str | None = Non
     with tool_span(name, args, call_id=call_id) as span:
         try:
             result = await _execute_tool(name, args)
-            ok = bool(result.get("ok", result.get("success", True)))
+            ok = bool(result.get("ok", result.get("success", False)))
             finish_tool_span(span, result, ok=ok)
             return result
         except Exception as e:

--- a/voice-agent-harnesses/cartesia/harness.py
+++ b/voice-agent-harnesses/cartesia/harness.py
@@ -5,11 +5,11 @@ plus a generated `line_agent/blueprint.json` (the deployed runtime has no repo).
 `ensure_agent()` deploys that directory with the `cartesia` CLI and caches the
 resulting agent id in `.agents.json`.
 
-Tools run provider-side: `schedule_appointment` is an `http_server_tool` inside
-the Line agent that POSTs to `{TOOL_BASE_URL}/tool/schedule_appointment`, i.e.
-back into `adapters/chirp.py`. That webhook is what emits the `execute_tool`
-span and forwards to the industry tool server, so `run_tool` here is the
-webhook's body — nothing calls it from the audio path.
+Tools run provider-side: each industry tool is an `http_server_tool` inside
+the Line agent that POSTs to `{TOOL_BASE_URL}/tool/<name>`, i.e. back into
+`adapters/chirp.py`. That webhook is what emits the `execute_tool` span and
+forwards verbatim to the industry tool server's POST /tools/{name} dispatch,
+so `run_tool` here is the webhook's body — nothing calls it from the audio path.
 
 The tunnel URL is ephemeral, so `ensure_agent()` re-pushes `TOOL_BASE_URL` with
 `cartesia env set` on every chirp boot; `get_agent` reads it per call, so a new
@@ -150,18 +150,11 @@ def ensure_agent(industry_dir: str | Path, *, public_url: str | None = None) -> 
     raise SystemExit(f"cartesia deployment for {agent_id} never became Ready")
 
 
-async def _post_appointment(date: str) -> dict[str, Any]:
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.post(f"{TOOL_SERVER_URL}/appointments", json={"date": date})
-        resp.raise_for_status()
-        body = resp.json()
-    return {"success": True, "date": body["date"]}
-
-
 async def _execute_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
-    if name == "schedule_appointment":
-        return await _post_appointment(args["date"])
-    return {"success": False, "error": f"unknown tool {name}"}
+    """Generic dispatch: POST /tools/{name}; the server's envelope is the result."""
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args})
+        return resp.json()
 
 
 async def run_tool(name: str, args: dict[str, Any], *, call_id: str | None = None) -> dict[str, Any]:
@@ -171,7 +164,8 @@ async def run_tool(name: str, args: dict[str, Any], *, call_id: str | None = Non
     with tool_span(name, args, call_id=call_id) as span:
         try:
             result = await _execute_tool(name, args)
-            finish_tool_span(span, result, ok=True)
+            ok = bool(result.get("ok", result.get("success", True)))
+            finish_tool_span(span, result, ok=ok)
             return result
         except Exception as e:
             err = {"success": False, "error": f"{type(e).__name__}: {e}"}

--- a/voice-agent-harnesses/deepgram/harness.py
+++ b/voice-agent-harnesses/deepgram/harness.py
@@ -57,6 +57,23 @@ def load_blueprint(industry_dir: str | Path) -> dict[str, Any]:
     }
 
 
+def _multiagent_note(bp: dict[str, Any]) -> str:
+    """Soft-handoff note: the session's tool list is fixed at connect, so every
+    agent's tools are visible — the prompt has to hold the role boundary."""
+    handoffs = sorted(
+        {t["name"] for a in bp["agents"].values() for t in a["tools"] if t.get("handoff")}
+    )
+    if not handoffs:
+        return ""
+    return (
+        "\n\n# Multi-agent note\n"
+        f"Start as the {bp['start']} agent. Tools belonging to other agents are "
+        f"visible to you; only use another agent's tools after the matching handoff "
+        f"tool ({', '.join(handoffs)}) has succeeded and you have adopted that "
+        "agent's role."
+    )
+
+
 def _function_spec(spec: dict) -> dict[str, Any]:
     """tools.json inputSchema → Deepgram's `functions[].parameters` shape."""
     raw = dict(spec.get("inputSchema") or {"type": "object"})
@@ -88,13 +105,8 @@ def settings_payload(bp: dict[str, Any], model: str | None = None) -> dict[str, 
             functions.append(_function_spec(bp["catalog"][name]))
 
     start = bp["agents"][bp["start"]]
-    # note soft-handoff: scheduler tools are visible; prompt still starts as receptionist
-    prompt = (
-        start["instructions"]
-        + "\n\n# Multi-agent note\n"
-        "Start as the receptionist. Only call schedule_appointment after "
-        "handoff_to_scheduler has succeeded and you have adopted the scheduler role."
-    )
+    # note soft-handoff: other agents' tools are visible; prompt still starts as bp["start"]
+    prompt = start["instructions"] + _multiagent_note(bp)
 
     return {
         "type": "Settings",
@@ -116,12 +128,20 @@ def settings_payload(bp: dict[str, Any], model: str | None = None) -> dict[str, 
     }
 
 
-async def _post_appointment(date: str) -> dict[str, Any]:
+def _tool_entry(bp: dict[str, Any], agent: str, name: str) -> dict[str, Any] | None:
+    """The blueprint entry for a tool, preferring the current agent's copy."""
+    for owner in [agent] + [a for a in bp["agents"] if a != agent]:
+        for t in bp["agents"][owner]["tools"]:
+            if t["name"] == name:
+                return t
+    return None
+
+
+async def _dispatch(name: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Generic dispatch: POST /tools/{name}; the server's envelope is the result."""
     async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.post(f"{TOOL_SERVER_URL}/appointments", json={"date": date})
-        resp.raise_for_status()
-        body = resp.json()
-    return {"success": True, "date": body["date"]}
+        resp = await client.post(f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args})
+        return resp.json()
 
 
 async def _execute_tool(
@@ -130,31 +150,26 @@ async def _execute_tool(
     bp: dict[str, Any],
     state: dict[str, Any],
 ) -> tuple[dict[str, Any], bool]:
-    """Execute a tool. Returns (result, should_end_call)."""
-    if name == "handoff_to_scheduler":
-        target = None
-        for t in bp["agents"][state["agent"]]["tools"]:
-            if t["name"] == name and t.get("handoff"):
-                target = t.get("handoff_to")
-                break
+    """Execute a tool. Returns (result, should_end_call). Handoff and session
+    tools are harness-native; every other tool dispatches to the tool server."""
+    entry = _tool_entry(bp, state["agent"], name)
+    if entry is not None and entry.get("handoff"):
+        target = entry.get("handoff_to")
         if not target or target not in bp["agents"]:
             return {"success": False, "error": "unknown handoff target"}, False
         state["agent"] = target
-        sched = bp["agents"][target]
+        agent = bp["agents"][target]
         return {
             "success": True,
             "role": target,
-            "instructions": sched["instructions"],
-            "note": "You are now the scheduler. Follow the instructions field exactly.",
+            "instructions": agent["instructions"],
+            "note": f"You are now the {target} agent. Follow the instructions field exactly.",
         }, False
 
-    if name == "schedule_appointment":
-        return await _post_appointment(args["date"]), False
-
-    if name == "end_call":
+    if entry is not None and entry.get("session"):
         return {"success": True}, True
 
-    return {"success": False, "error": f"unknown tool {name}"}, False
+    return await _dispatch(name, args), False
 
 
 async def run_tool(
@@ -169,7 +184,8 @@ async def run_tool(
     from report import finish_tool_span, tool_span
     with tool_span(name, args, call_id=call_id) as span:
         result, stop = await _execute_tool(name, args, bp, state)
-        finish_tool_span(span, result, ok=bool(result.get("success")))
+        ok = bool(result.get("ok", result.get("success", True)))
+        finish_tool_span(span, result, ok=ok)
         return result, stop
 
 

--- a/voice-agent-harnesses/elevenlabs/harness.py
+++ b/voice-agent-harnesses/elevenlabs/harness.py
@@ -4,8 +4,8 @@ Multi-agent is native, not soft: each blueprint agent is a persisted ElevenLabs
 agent, and the receptionist hands off via the `transfer_to_agent` system tool
 (server-side, no harness-side handoff/routing). `end_call` is likewise the
 `end_call` system tool — the harness never executes it. `ensure_agents` creates
-(or reuses cached) agent IDs; `run_tool` only ever runs client tools such as
-`schedule_appointment`.
+(or reuses cached) agent IDs; `run_tool` only ever runs client tools, which it
+forwards generically to the industry tool server's POST /tools/{name} dispatch.
 """
 
 from __future__ import annotations
@@ -318,20 +318,13 @@ async def get_signed_url(agent_id: str) -> str:
         return r.json()["signed_url"]
 
 
-async def _post_appointment(date: str) -> dict[str, Any]:
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.post(f"{TOOL_SERVER_URL}/appointments", json={"date": date})
-        resp.raise_for_status()
-        body = resp.json()
-    return {"success": True, "date": body["date"]}
-
-
 async def _execute_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
-    """Execute a client tool. `end_call`/`transfer_to_agent` are ElevenLabs system
-    tools — they never reach the harness as a `client_tool_call`."""
-    if name == "schedule_appointment":
-        return await _post_appointment(args["date"])
-    return {"success": False, "error": f"unknown tool {name}"}
+    """Execute a client tool by dispatching to POST /tools/{name}; the server's
+    envelope goes back to the model verbatim. `end_call`/`transfer_to_agent` are
+    ElevenLabs system tools — they never reach the harness as a `client_tool_call`."""
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args})
+        return resp.json()
 
 
 async def run_tool(
@@ -349,7 +342,8 @@ async def run_tool(
     with tool_span(name, args, call_id=call_id) as span:
         try:
             result = await _execute_tool(name, args)
-            finish_tool_span(span, result, ok=True)
+            ok = bool(result.get("ok", result.get("success", True)))
+            finish_tool_span(span, result, ok=ok)
             return result
         except Exception as e:
             err = {"success": False, "error": f"{type(e).__name__}: {e}"}
@@ -405,7 +399,7 @@ async def run_session(industry_dir: str | Path, model: str) -> None:
                         dict(call.get("parameters") or {}),
                         call_id=call.get("tool_call_id"),
                     )
-                    is_error = not bool(result.get("success", True))
+                    is_error = not bool(result.get("ok", result.get("success", True)))
                     print(f"tool {call.get('tool_name')} error={is_error}", flush=True)
                     await ws.send(
                         json.dumps(

--- a/voice-agent-harnesses/elevenlabs/harness.py
+++ b/voice-agent-harnesses/elevenlabs/harness.py
@@ -350,7 +350,7 @@ async def run_tool(
     with tool_span(name, args, call_id=call_id) as span:
         try:
             result = await _execute_tool(name, args)
-            ok = bool(result.get("ok", result.get("success", True)))
+            ok = bool(result.get("ok", result.get("success", False)))
             finish_tool_span(span, result, ok=ok)
             return result
         except Exception as e:
@@ -407,7 +407,7 @@ async def run_session(industry_dir: str | Path, model: str) -> None:
                         dict(call.get("parameters") or {}),
                         call_id=call.get("tool_call_id"),
                     )
-                    is_error = not bool(result.get("ok", result.get("success", True)))
+                    is_error = not bool(result.get("ok", result.get("success", False)))
                     print(f"tool {call.get('tool_name')} error={is_error}", flush=True)
                     await ws.send(
                         json.dumps(

--- a/voice-agent-harnesses/elevenlabs/harness.py
+++ b/voice-agent-harnesses/elevenlabs/harness.py
@@ -320,11 +320,19 @@ async def get_signed_url(agent_id: str) -> str:
 
 async def _execute_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
     """Execute a client tool by dispatching to POST /tools/{name}; the server's
-    envelope goes back to the model verbatim. `end_call`/`transfer_to_agent` are
-    ElevenLabs system tools — they never reach the harness as a `client_tool_call`."""
+    envelope goes back to the model. `end_call`/`transfer_to_agent` are ElevenLabs
+    system tools — they never reach the harness as a `client_tool_call`.
+
+    After the envelope migration some industries report outcomes with `ok`
+    instead of `success`. Normalize a missing `success` key from `ok` so the
+    Chirp bridge's ElevenLabs error check uses the same fallback as
+    `run_session` and correctly marks guarded/policy failures as errors."""
     async with httpx.AsyncClient(timeout=30.0) as client:
         resp = await client.post(f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args})
-        return resp.json()
+        result = resp.json()
+        if isinstance(result, dict) and "success" not in result and "ok" in result:
+            result["success"] = result["ok"]
+        return result
 
 
 async def run_tool(

--- a/voice-agent-harnesses/gemini/harness.py
+++ b/voice-agent-harnesses/gemini/harness.py
@@ -169,6 +169,14 @@ async def _execute_tool(
     if local is not None and local.get("session"):
         return {"success": True}, True
 
+    # A handoff/session tool still visible from a *previous* agent (Gemini can
+    # keep offering it post-handoff) must stay harness-native and fail here,
+    # not fall through to the tool server — it isn't a dispatchable tool and a
+    # 404 there would wrongly read as a successful call in the trace.
+    visible = _tool_entry(bp, state["agent"], name)
+    if local is None and visible is not None and (visible.get("handoff") or visible.get("session")):
+        return {"success": False, "error": "tool unavailable for current agent"}, False
+
     # Industry (dispatchable) tools: fall back across all agents so shared
     # tools remain reachable regardless of which agent is currently active.
     return await _dispatch(name, args), False

--- a/voice-agent-harnesses/gemini/harness.py
+++ b/voice-agent-harnesses/gemini/harness.py
@@ -109,9 +109,24 @@ def live_config(bp: dict[str, Any], *, voice: str = "Puck") -> types.LiveConnect
     )
 
 
-def _tool_entry(bp: dict[str, Any], agent: str, name: str) -> dict[str, Any] | None:
-    """The blueprint entry for a tool, preferring the current agent's copy."""
-    for owner in [agent] + [a for a in bp["agents"] if a != agent]:
+def _tool_entry(bp: dict[str, Any], agent: str, name: str,
+                *, local_only: bool = False) -> dict[str, Any] | None:
+    """The blueprint entry for a tool.
+
+    When *local_only* is True the search is restricted to *agent*'s own tool
+    list — this is the correct scope for handoff and session tools, which must
+    never resolve against a different agent.  Industry (dispatchable) tools may
+    fall back across all agents because the Gemini Live tool list is fixed at
+    connect time and every agent's tools are visible.
+    """
+    for t in bp["agents"][agent]["tools"]:
+        if t["name"] == name:
+            return t
+    if local_only:
+        return None
+    for owner in bp["agents"]:
+        if owner == agent:
+            continue
         for t in bp["agents"][owner]["tools"]:
             if t["name"] == name:
                 return t
@@ -133,9 +148,13 @@ async def _execute_tool(
 ) -> tuple[dict[str, Any], bool]:
     """Execute a tool. Returns (result, should_end_call). Handoff and session
     tools are harness-native; every other tool dispatches to the tool server."""
-    entry = _tool_entry(bp, state["agent"], name)
-    if entry is not None and entry.get("handoff"):
-        target = entry.get("handoff_to")
+
+    # Handoff / session tools must belong to the *current* agent — never fall
+    # back to another agent's tool table, otherwise a post-handoff agent could
+    # re-trigger the previous agent's handoff.
+    local = _tool_entry(bp, state["agent"], name, local_only=True)
+    if local is not None and local.get("handoff"):
+        target = local.get("handoff_to")
         if not target or target not in bp["agents"]:
             return {"success": False, "error": "unknown handoff target"}, False
         state["agent"] = target
@@ -147,9 +166,11 @@ async def _execute_tool(
             "note": f"You are now the {target} agent. Follow the instructions field exactly.",
         }, False
 
-    if entry is not None and entry.get("session"):
+    if local is not None and local.get("session"):
         return {"success": True}, True
 
+    # Industry (dispatchable) tools: fall back across all agents so shared
+    # tools remain reachable regardless of which agent is currently active.
     return await _dispatch(name, args), False
 
 

--- a/voice-agent-harnesses/gemini/harness.py
+++ b/voice-agent-harnesses/gemini/harness.py
@@ -47,6 +47,23 @@ def load_blueprint(industry_dir: str | Path) -> dict[str, Any]:
     }
 
 
+def _multiagent_note(bp: dict[str, Any]) -> str:
+    """Soft-handoff note: the Live config's tool list is fixed at connect, so every
+    agent's tools are visible — the prompt has to hold the role boundary."""
+    handoffs = sorted(
+        {t["name"] for a in bp["agents"].values() for t in a["tools"] if t.get("handoff")}
+    )
+    if not handoffs:
+        return ""
+    return (
+        "\n\n# Multi-agent note\n"
+        f"Start as the {bp['start']} agent. Tools belonging to other agents are "
+        f"visible to you; only use another agent's tools after the matching handoff "
+        f"tool ({', '.join(handoffs)}) has succeeded and you have adopted that "
+        "agent's role."
+    )
+
+
 def _decl(spec: dict) -> types.FunctionDeclaration:
     # Gemini Live rejects JSON-Schema keys like additionalProperties.
     raw = dict(spec.get("inputSchema") or {})
@@ -78,13 +95,8 @@ def live_config(bp: dict[str, Any], *, voice: str = "Puck") -> types.LiveConnect
             decls.append(_decl(bp["catalog"][name]))
 
     start = bp["agents"][bp["start"]]
-    # note soft-handoff: scheduler tools are visible; prompt still starts as receptionist
-    instruction = (
-        start["instructions"]
-        + "\n\n# Multi-agent note\n"
-        "Start as the receptionist. Only call schedule_appointment after "
-        "handoff_to_scheduler has succeeded and you have adopted the scheduler role."
-    )
+    # note soft-handoff: other agents' tools are visible; prompt still starts as bp["start"]
+    instruction = start["instructions"] + _multiagent_note(bp)
     return types.LiveConnectConfig(
         response_modalities=[types.Modality.AUDIO],
         speech_config=types.SpeechConfig(
@@ -97,12 +109,20 @@ def live_config(bp: dict[str, Any], *, voice: str = "Puck") -> types.LiveConnect
     )
 
 
-async def _post_appointment(date: str) -> dict[str, Any]:
+def _tool_entry(bp: dict[str, Any], agent: str, name: str) -> dict[str, Any] | None:
+    """The blueprint entry for a tool, preferring the current agent's copy."""
+    for owner in [agent] + [a for a in bp["agents"] if a != agent]:
+        for t in bp["agents"][owner]["tools"]:
+            if t["name"] == name:
+                return t
+    return None
+
+
+async def _dispatch(name: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Generic dispatch: POST /tools/{name}; the server's envelope is the result."""
     async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.post(f"{TOOL_SERVER_URL}/appointments", json={"date": date})
-        resp.raise_for_status()
-        body = resp.json()
-    return {"success": True, "date": body["date"]}
+        resp = await client.post(f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args})
+        return resp.json()
 
 
 async def _execute_tool(
@@ -111,31 +131,26 @@ async def _execute_tool(
     bp: dict[str, Any],
     state: dict[str, Any],
 ) -> tuple[dict[str, Any], bool]:
-    """Execute a tool. Returns (result, should_end_call)."""
-    if name == "handoff_to_scheduler":
-        target = None
-        for t in bp["agents"][state["agent"]]["tools"]:
-            if t["name"] == name and t.get("handoff"):
-                target = t.get("handoff_to")
-                break
+    """Execute a tool. Returns (result, should_end_call). Handoff and session
+    tools are harness-native; every other tool dispatches to the tool server."""
+    entry = _tool_entry(bp, state["agent"], name)
+    if entry is not None and entry.get("handoff"):
+        target = entry.get("handoff_to")
         if not target or target not in bp["agents"]:
             return {"success": False, "error": "unknown handoff target"}, False
         state["agent"] = target
-        sched = bp["agents"][target]
+        agent = bp["agents"][target]
         return {
             "success": True,
             "role": target,
-            "instructions": sched["instructions"],
-            "note": "You are now the scheduler. Follow the instructions field exactly.",
+            "instructions": agent["instructions"],
+            "note": f"You are now the {target} agent. Follow the instructions field exactly.",
         }, False
 
-    if name == "schedule_appointment":
-        return await _post_appointment(args["date"]), False
-
-    if name == "end_call":
+    if entry is not None and entry.get("session"):
         return {"success": True}, True
 
-    return {"success": False, "error": f"unknown tool {name}"}, False
+    return await _dispatch(name, args), False
 
 
 async def run_tool(
@@ -150,7 +165,8 @@ async def run_tool(
     from report import finish_tool_span, tool_span
     with tool_span(name, args, call_id=call_id) as span:
         result, stop = await _execute_tool(name, args, bp, state)
-        finish_tool_span(span, result, ok=bool(result.get("success")))
+        ok = bool(result.get("ok", result.get("success", True)))
+        finish_tool_span(span, result, ok=ok)
         return result, stop
 
 

--- a/voice-agent-harnesses/livekit/README.md
+++ b/voice-agent-harnesses/livekit/README.md
@@ -125,8 +125,10 @@ actual per expected tool (`handoff_to_scheduler`, `schedule_appointment`).
     session for activity" lines and no "reusing realtime session";
   * `generate_reply()` is still rejected, so the model cannot open a turn on its
     own. An ElevenLabs TTS is attached so `session.say()` can deliver the two
-    scripted lines (the call greeting and `harness.SCHEDULER_OPENER`, which is step
-    1 of `scheduler.md` verbatim); every other turn is native Gemini audio.
+    scripted lines: the call greeting, and (on handoff) a first line derived from
+    the target agent's own prompt via `harness._derive_opener` (step 1 of that
+    agent's own flow, e.g. `scheduler.md`, when it has one, else a generic,
+    blueprint-neutral line); every other turn is native Gemini audio.
 * **OpenAI Realtime reuses the socket, by design.** Its capabilities are all
   mutable, so LiveKit keeps the WebSocket and re-pushes the scheduler's
   instructions and tool list with a `session.update` (`_start_session`, `rt_reused`

--- a/voice-agent-harnesses/livekit/cascaded/agent.py
+++ b/voice-agent-harnesses/livekit/cascaded/agent.py
@@ -42,6 +42,6 @@ if __name__ == "__main__":
     harness.serve(
         AGENT_NAME,
         build_session=build_session,
-        build_agent=lambda bp, hangup: harness.Receptionist(bp, hangup),
+        build_agent=lambda bp, hangup: harness.BlueprintAgent(bp, bp["start"], hangup),
         model=MODEL,
     )

--- a/voice-agent-harnesses/livekit/gemini-flash-live-3.1/agent.py
+++ b/voice-agent-harnesses/livekit/gemini-flash-live-3.1/agent.py
@@ -11,10 +11,12 @@ not running two of them, so this runtime does a real agent handoff by giving eac
   `llm.session()` and logs "created new realtime session for activity".
 * the fresh session has no active socket yet, so `update_instructions`/`update_tools`
   land on `_opts`/`_tools` and `_build_connect_config` sends them as the connect-time
-  `system_instruction` and `tools` — the scheduler prompt and *only* the scheduler's
-  tools reach the model.
+  `system_instruction` and `tools` — the target agent's own prompt and *only* that
+  agent's tools reach the model.
 * `generate_reply()` is still rejected, so the ElevenLabs TTS delivers the two
-  scripted lines (call greeting, scheduler opener); every other turn is Gemini audio.
+  scripted lines: the call greeting, and (on handoff) a first line derived from the
+  target agent's own prompt (`harness._derive_opener`); every other turn is Gemini
+  audio.
 
     python gemini-flash-live-3.1/agent.py dev
 """
@@ -61,14 +63,15 @@ def build_session(_bp: dict[str, Any]) -> AgentSession:
 def build_agent(bp: dict[str, Any], hangup: asyncio.Event) -> harness.BlueprintAgent:
     # llm_factory gives every agent its own RealtimeModel, which is what makes a
     # handoff open a second Gemini Live session instead of reusing the first.
-    # `opener` is the scripted first line for handoff targets, since 3.1 rejects
-    # generate_reply().
+    # `scripted_opener=True` because 3.1 rejects generate_reply(): each handoff
+    # target derives its own scripted first line from its own prompt (see
+    # `harness._derive_opener`) rather than reusing one literal for every target.
     return harness.BlueprintAgent(
         bp,
         bp["start"],
         hangup,
         llm_factory=lambda name: _model(bp["agents"][name]["instructions"]),
-        opener=harness.SCHEDULER_OPENER,
+        scripted_opener=True,
     )
 
 

--- a/voice-agent-harnesses/livekit/gemini-flash-live-3.1/agent.py
+++ b/voice-agent-harnesses/livekit/gemini-flash-live-3.1/agent.py
@@ -58,17 +58,17 @@ def build_session(_bp: dict[str, Any]) -> AgentSession:
     )
 
 
-def build_agent(bp: dict[str, Any], hangup: asyncio.Event) -> harness.Receptionist:
-    return harness.Receptionist(
+def build_agent(bp: dict[str, Any], hangup: asyncio.Event) -> harness.BlueprintAgent:
+    # llm_factory gives every agent its own RealtimeModel, which is what makes a
+    # handoff open a second Gemini Live session instead of reusing the first.
+    # `opener` is the scripted first line for handoff targets, since 3.1 rejects
+    # generate_reply().
+    return harness.BlueprintAgent(
         bp,
+        bp["start"],
         hangup,
-        llm=_model(bp["agents"]["receptionist"]["instructions"]),
-        make_scheduler=lambda: harness.Scheduler(
-            bp,
-            hangup,
-            llm=_model(bp["agents"]["scheduler"]["instructions"]),
-            opener=harness.SCHEDULER_OPENER,
-        ),
+        llm_factory=lambda name: _model(bp["agents"][name]["instructions"]),
+        opener=harness.SCHEDULER_OPENER,
     )
 
 

--- a/voice-agent-harnesses/livekit/harness.py
+++ b/voice-agent-harnesses/livekit/harness.py
@@ -27,6 +27,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 from pathlib import Path
 from typing import Any, Callable
 
@@ -51,10 +52,34 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 TOOL_SERVER_URL = os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
 INDUSTRY = os.environ.get("INDUSTRY", "control-industry")
 GREETING = "Welcome to Bluejay's Repair Services!"
-# step 1 of system-prompts/scheduler.md, verbatim. Only used by runtimes whose model
-# rejects generate_reply() (see BlueprintAgent.on_enter); every other turn is
-# model-generated.
-SCHEDULER_OPENER = "Hey, when do you want to schedule your repair appointment?"
+# Matches *step 1* of an agent's own flow, e.g.
+# `1. Ask: "Hey, when do you want to schedule your repair appointment?"` in
+# system-prompts/scheduler.md. Anchored to step 1 specifically (not any numbered
+# `Ask:`/`Say:` line) so this doesn't pick up an unrelated mid-prompt instruction,
+# e.g. a later "call 911, then say ..." escalation step. Used to give handoff
+# targets a target-specific opener on runtimes whose model rejects
+# generate_reply() (see BlueprintAgent.on_enter and `_derive_opener` below); every
+# other turn is model-generated.
+_OPENER_RE = re.compile(r'(?:^|\n)\s*1\.\s*(?:Ask|Say):\s*"([^"]+)"', re.IGNORECASE)
+# Last-resort opener when an agent's prompt has no quoted `Ask:`/`Say:` line to pull
+# from. Deliberately industry- and blueprint-neutral so it never announces another
+# agent's task (e.g. a scheduling line) on a target that doesn't do that job.
+GENERIC_OPENER = "Okay, I can help you with that."
+
+
+def _derive_opener(instructions: str) -> str:
+    """Pull a natural, spoken opening line out of `instructions` for `session.say()`.
+
+    Every `BlueprintAgent` derives its *own* opener from its *own* prompt, so a
+    handoff target never inherits another agent's scripted line (e.g. Gemini Live
+    used to open every handoff with the control-industry scheduler's "when do you
+    want to schedule your repair appointment?" line regardless of which agent, or
+    industry, it had actually landed on).
+    """
+    match = _OPENER_RE.search(instructions)
+    return match.group(1) if match else GENERIC_OPENER
+
+
 # Seconds of *silence* the agent must reach after `end_call` before we tear the room
 # down. This was a flat sleep, which deleted the room mid-farewell on gpt-realtime-2.1
 # (see README "Hanging up waits for silence"). Same env knobs as the pipecat harness.
@@ -122,7 +147,10 @@ async def run_tool(name: str, args: dict[str, Any], *, local: bool = False) -> d
     with report.tool_span(name, args) as span:
         try:
             result = await _execute(name, args, local=local)
-            ok = bool(result.get("ok", result.get("success", True)))
+            # default to False, not True: a 404/error envelope from POST /tools/{name}
+            # (e.g. an unknown tool name) has neither `ok` nor `success`, and treating
+            # that as a successful call would hide the failure from the trace.
+            ok = bool(result.get("ok", result.get("success", False)))
         except Exception as e:  # soft-fail: the call (and its trace) must still finish
             result, ok = {"success": False, "error": f"{type(e).__name__}: {e}"}, False
         report.finish_tool_span(span, result, ok=ok)
@@ -146,7 +174,7 @@ def _blueprint_tools(
     agent_name: str,
     hangup: asyncio.Event,
     llm_factory: Callable[[str], Any] | None,
-    opener: str | None,
+    scripted_opener: bool,
 ) -> list[Any]:
     """One agent's blueprint tools as LiveKit raw function tools.
 
@@ -155,6 +183,12 @@ def _blueprint_tools(
     transfer on top of the incoming agent's own opener — the blueprint forbids
     that, and the two overlapping turns let the caller's "okay, thank you" land
     on the new agent as "I'm done" -> end_call before anything is booked.
+
+    `scripted_opener` only says whether *this runtime's model* rejects
+    generate_reply() and therefore needs its handoff targets to speak a scripted
+    first line at all; it carries no agent-specific text. Each target derives its
+    own opener from its own prompt (see `BlueprintAgent.on_enter`/`_derive_opener`)
+    so a handoff never announces another agent's task.
     """
     tools: list[Any] = []
     for t in bp["agents"][agent_name]["tools"]:
@@ -175,7 +209,9 @@ def _blueprint_tools(
                     await run_tool(tool_name, dict(raw_arguments), local=True)
                     return BlueprintAgent(
                         bp, target, hangup,
-                        llm_factory=llm_factory, opener=opener, entered_by_handoff=True,
+                        llm_factory=llm_factory,
+                        scripted_opener=scripted_opener,
+                        entered_by_handoff=True,
                     )
                 return _handoff
 
@@ -208,9 +244,14 @@ class BlueprintAgent(Agent):
     the two activities share the *same* model object, so a fresh instance means
     a fresh provider session configured with this agent's prompt and tools.
 
-    `opener` is a scripted first line for handoff targets on runtimes whose
-    model rejects generate_reply() (mutable_chat_context=False); everyone else
-    model-generates the opener. The start agent's greeting is `run_call`'s job.
+    `scripted_opener=True` means this runtime's model rejects generate_reply()
+    (mutable_chat_context=False), so a handoff target must speak a scripted first
+    line via `session.say()` instead; everyone else model-generates the opener.
+    That scripted line is always derived from *this* agent's own instructions
+    (`_derive_opener`), never inherited from whichever agent handed off to it — a
+    flat, runtime-wide literal here would put another agent's task in this one's
+    mouth on any blueprint with more than one possible handoff target. The start
+    agent's greeting is `run_call`'s job, not this one's.
     """
 
     def __init__(
@@ -220,17 +261,18 @@ class BlueprintAgent(Agent):
         hangup: asyncio.Event,
         *,
         llm_factory: Callable[[str], Any] | None = None,
-        opener: str | None = None,
+        scripted_opener: bool = False,
         entered_by_handoff: bool = False,
     ):
+        instructions = bp["agents"][name]["instructions"]
         llm: NotGivenOr[Any] = llm_factory(name) if llm_factory else NOT_GIVEN
         super().__init__(
-            instructions=bp["agents"][name]["instructions"],
+            instructions=instructions,
             llm=llm,
-            tools=_blueprint_tools(bp, name, hangup, llm_factory, opener),
+            tools=_blueprint_tools(bp, name, hangup, llm_factory, scripted_opener),
         )
         self.agent_name = name
-        self._opener = opener
+        self._opener = _derive_opener(instructions) if scripted_opener else None
         self._entered_by_handoff = entered_by_handoff
 
     async def on_enter(self) -> None:

--- a/voice-agent-harnesses/livekit/harness.py
+++ b/voice-agent-harnesses/livekit/harness.py
@@ -1,10 +1,11 @@
-"""control-industry blueprint → LiveKit Agents, shared by all three runtimes.
+"""industry blueprint → LiveKit Agents, shared by all three runtimes.
 
 LiveKit runs our code, so unlike the Vapi/Retell/Bland/Cartesia harnesses there is
 no tool webhook and no tunnel: every tool body runs in this process and is wrapped
-directly in an `execute_tool` span. Multi-agent handoff is in-framework — the
-receptionist's `handoff_to_scheduler` returns the `Scheduler` agent instance — so
-the handoff is a real, timed tool call rather than a provider-internal jump.
+directly in an `execute_tool` span. Industry tools dispatch generically to the
+tool server's POST /tools/{name} route. Multi-agent handoff is in-framework — a
+handoff tool returns the target `BlueprintAgent` instance — so the handoff is a
+real, timed tool call rather than a provider-internal jump.
 
 Transport is native Bluejay `LIVEKIT` dispatch: Bluejay creates the room, mints a
 token with a `RoomAgentDispatch` for our `agent_name`, and puts
@@ -38,7 +39,6 @@ from livekit.agents import (
     JobContext,
     JobExecutorType,
     NotGivenOr,
-    RunContext,
     cli,
     function_tool,
 )
@@ -52,7 +52,8 @@ TOOL_SERVER_URL = os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").rst
 INDUSTRY = os.environ.get("INDUSTRY", "control-industry")
 GREETING = "Welcome to Bluejay's Repair Services!"
 # step 1 of system-prompts/scheduler.md, verbatim. Only used by runtimes whose model
-# rejects generate_reply() (see Scheduler.on_enter); every other turn is model-generated.
+# rejects generate_reply() (see BlueprintAgent.on_enter); every other turn is
+# model-generated.
 SCHEDULER_OPENER = "Hey, when do you want to schedule your repair appointment?"
 # Seconds of *silence* the agent must reach after `end_call` before we tear the room
 # down. This was a flat sleep, which deleted the room mid-farewell on gpt-realtime-2.1
@@ -100,25 +101,28 @@ def load_blueprint(industry_dir: str | Path = INDUSTRY) -> dict[str, Any]:
 # ── tools (in-process, each under an execute_tool span) ──────────────────────
 
 
-async def _execute(name: str, args: dict[str, Any]) -> dict[str, Any]:
-    if name == "schedule_appointment":
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            r = await client.post(f"{TOOL_SERVER_URL}/appointments", json={"date": args["date"]})
-            r.raise_for_status()
-            return {"success": True, "date": r.json()["date"]}
-    if name in ("handoff_to_scheduler", "end_call"):
-        # harness-local: no industry state to mutate, the span is the artifact
+async def _execute(name: str, args: dict[str, Any], *, local: bool) -> dict[str, Any]:
+    if local:
+        # harness-native (handoff / session): no industry state to mutate,
+        # the span is the artifact
         return {"success": True}
-    return {"success": False, "error": f"unknown tool {name}"}
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        r = await client.post(f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args})
+        return r.json()
 
 
-async def run_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
-    """Run one blueprint tool under an `execute_tool` span. Never raises."""
+async def run_tool(name: str, args: dict[str, Any], *, local: bool = False) -> dict[str, Any]:
+    """Run one blueprint tool under an `execute_tool` span. Never raises.
+
+    `local=True` marks harness-native tools (handoffs, session tools); everything
+    else dispatches to POST {TOOL_SERVER_URL}/tools/{name} and returns the
+    server's envelope verbatim.
+    """
     offset = report.call_offset_ms()
     with report.tool_span(name, args) as span:
         try:
-            result = await _execute(name, args)
-            ok = True
+            result = await _execute(name, args, local=local)
+            ok = bool(result.get("ok", result.get("success", True)))
         except Exception as e:  # soft-fail: the call (and its trace) must still finish
             result, ok = {"success": False, "error": f"{type(e).__name__}: {e}"}, False
         report.finish_tool_span(span, result, ok=ok)
@@ -126,104 +130,116 @@ async def run_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
-async def _end_call(reason: str, hangup: asyncio.Event) -> dict[str, Any]:
-    result = await run_tool("end_call", {"reason": reason})
-    hangup.set()
-    return result
-
-
 # ── agents ───────────────────────────────────────────────────────────────────
 
 
-class Scheduler(Agent):
-    """Books the appointment. Reached by handoff from the receptionist.
+def _param_schema(spec: dict[str, Any]) -> dict[str, Any]:
+    raw = dict(spec.get("inputSchema") or {})
+    schema: dict[str, Any] = {"type": "object", "properties": dict(raw.get("properties") or {})}
+    if raw.get("required"):
+        schema["required"] = list(raw["required"])
+    return schema
 
-    `llm` is the per-agent model override. Passing a distinct instance is what makes
-    the handoff a real switch on models that cannot be mutated mid-session: LiveKit
-    only carries the realtime session across a handoff when the two activities share
-    the *same* model object, so a fresh instance means a fresh provider session
-    configured with this agent's prompt and this agent's tools.
+
+def _blueprint_tools(
+    bp: dict[str, Any],
+    agent_name: str,
+    hangup: asyncio.Event,
+    llm_factory: Callable[[str], Any] | None,
+    opener: str | None,
+) -> list[Any]:
+    """One agent's blueprint tools as LiveKit raw function tools.
+
+    Handoffs return the target `BlueprintAgent` and nothing else: any non-Agent
+    output sets reply_required, which makes the outgoing agent announce the
+    transfer on top of the incoming agent's own opener — the blueprint forbids
+    that, and the two overlapping turns let the caller's "okay, thank you" land
+    on the new agent as "I'm done" -> end_call before anything is booked.
+    """
+    tools: list[Any] = []
+    for t in bp["agents"][agent_name]["tools"]:
+        name = t["name"]
+        spec = bp["catalog"].get(name) or {}
+        raw = {
+            "name": name,
+            "description": spec.get(
+                "description",
+                f"Hand off to the {t.get('handoff_to')} agent." if t.get("handoff") else name,
+            ),
+            "parameters": _param_schema(spec),
+        }
+
+        if t.get("handoff"):
+            def _make_handoff(tool_name: str, target: str):
+                async def _handoff(raw_arguments: dict[str, Any]) -> Agent:
+                    await run_tool(tool_name, dict(raw_arguments), local=True)
+                    return BlueprintAgent(
+                        bp, target, hangup,
+                        llm_factory=llm_factory, opener=opener, entered_by_handoff=True,
+                    )
+                return _handoff
+
+            tools.append(function_tool(_make_handoff(name, t["handoff_to"]), raw_schema=raw))
+        elif t.get("session"):
+            def _make_session(tool_name: str):
+                async def _session_tool(raw_arguments: dict[str, Any]) -> dict[str, Any]:
+                    result = await run_tool(tool_name, dict(raw_arguments), local=True)
+                    hangup.set()
+                    return result
+                return _session_tool
+
+            tools.append(function_tool(_make_session(name), raw_schema=raw))
+        else:
+            def _make_industry(tool_name: str):
+                async def _industry(raw_arguments: dict[str, Any]) -> dict[str, Any]:
+                    return await run_tool(tool_name, dict(raw_arguments))
+                return _industry
+
+            tools.append(function_tool(_make_industry(name), raw_schema=raw))
+    return tools
+
+
+class BlueprintAgent(Agent):
+    """One blueprint agent: its own prompt, its own tools, generic dispatch.
+
+    `llm_factory(agent_name)` gives each agent its own model instance, which is
+    what makes a handoff a real switch on models that cannot be mutated
+    mid-session: LiveKit only carries the realtime session across a handoff when
+    the two activities share the *same* model object, so a fresh instance means
+    a fresh provider session configured with this agent's prompt and tools.
+
+    `opener` is a scripted first line for handoff targets on runtimes whose
+    model rejects generate_reply() (mutable_chat_context=False); everyone else
+    model-generates the opener. The start agent's greeting is `run_call`'s job.
     """
 
     def __init__(
         self,
         bp: dict[str, Any],
+        name: str,
         hangup: asyncio.Event,
         *,
-        llm: NotGivenOr[Any] = NOT_GIVEN,
+        llm_factory: Callable[[str], Any] | None = None,
         opener: str | None = None,
+        entered_by_handoff: bool = False,
     ):
-        super().__init__(instructions=bp["agents"]["scheduler"]["instructions"], llm=llm)
-        self._hangup = hangup
+        llm: NotGivenOr[Any] = llm_factory(name) if llm_factory else NOT_GIVEN
+        super().__init__(
+            instructions=bp["agents"][name]["instructions"],
+            llm=llm,
+            tools=_blueprint_tools(bp, name, hangup, llm_factory, opener),
+        )
+        self.agent_name = name
         self._opener = opener
+        self._entered_by_handoff = entered_by_handoff
 
     async def on_enter(self) -> None:
-        # generate_reply() is rejected by realtime models with mutable_chat_context=False
-        # (google plugin, any "3.1" model); those runtimes pass `opener` and the session
-        # TTS speaks the scheduler's scripted first line instead.
+        if not self._entered_by_handoff:
+            return  # the call-opening greeting is run_call's job
         if self._opener:
             self.session.say(self._opener)
         else:
             self.session.generate_reply()
-
-    @function_tool
-    async def schedule_appointment(self, context: RunContext, date: str) -> dict[str, Any]:
-        """Schedule a repair appointment and store it in the database.
-
-        Args:
-            date: Repair appointment date in MM/DD/YYYY format
-        """
-        return await run_tool("schedule_appointment", {"date": date})
-
-    @function_tool
-    async def end_call(self, context: RunContext, reason: str) -> dict[str, Any]:
-        """End the call once the caller is done, or immediately if it is spam or a
-        wrong number. Say goodbye first.
-
-        Args:
-            reason: Why the call is ending
-        """
-        return await _end_call(reason, self._hangup)
-
-
-class Receptionist(Agent):
-    """Greets, then hands off in-framework by returning the Scheduler instance."""
-
-    def __init__(
-        self,
-        bp: dict[str, Any],
-        hangup: asyncio.Event,
-        *,
-        llm: NotGivenOr[Any] = NOT_GIVEN,
-        make_scheduler: Callable[[], Agent] | None = None,
-    ):
-        super().__init__(instructions=bp["agents"]["receptionist"]["instructions"], llm=llm)
-        self._hangup = hangup
-        # runtimes whose model can't be mutated mid-session pass a factory that gives the
-        # Scheduler its own model instance; everyone else shares the session's.
-        self._make_scheduler = make_scheduler or (lambda: Scheduler(bp, hangup))
-
-    @function_tool
-    async def handoff_to_scheduler(self, context: RunContext) -> Agent:
-        """Hand off the caller to the Bluejay's Repair Services scheduler agent."""
-        await run_tool("handoff_to_scheduler", {})
-        # return the Agent and nothing else: any non-Agent output sets
-        # reply_required, which makes the receptionist announce the transfer
-        # ("I'll connect you with our scheduler") on top of the scheduler's own
-        # opener. The blueprint forbids that, and the two overlapping turns let the
-        # caller's "okay, thank you" land on the scheduler as "I'm done" -> end_call
-        # before anything is booked.
-        return self._make_scheduler()
-
-    @function_tool
-    async def end_call(self, context: RunContext, reason: str) -> dict[str, Any]:
-        """End the call once the caller is done, or immediately if it is spam or a
-        wrong number. Say goodbye first.
-
-        Args:
-            reason: Why the call is ending
-        """
-        return await _end_call(reason, self._hangup)
 
 
 # ── job plumbing ─────────────────────────────────────────────────────────────

--- a/voice-agent-harnesses/livekit/openai-realtime-2.1/agent.py
+++ b/voice-agent-harnesses/livekit/openai-realtime-2.1/agent.py
@@ -35,6 +35,6 @@ if __name__ == "__main__":
     harness.serve(
         AGENT_NAME,
         build_session=build_session,
-        build_agent=lambda bp, hangup: harness.Receptionist(bp, hangup),
+        build_agent=lambda bp, hangup: harness.BlueprintAgent(bp, bp["start"], hangup),
         model=MODEL,
     )

--- a/voice-agent-harnesses/livekit/test_harness.py
+++ b/voice-agent-harnesses/livekit/test_harness.py
@@ -18,7 +18,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from livekit.agents import llm as lk_llm
 
 import harness
-from harness import Receptionist, Scheduler, load_blueprint, sim_result_id_from_job_metadata
+from harness import BlueprintAgent, load_blueprint, sim_result_id_from_job_metadata
 
 
 def test_sim_result_id() -> None:
@@ -51,25 +51,38 @@ def test_real_handoff() -> None:
     bp = load_blueprint("control-industry")
     hangup = asyncio.Event()
 
-    receptionist_model = object()  # stands in for a per-agent RealtimeModel instance
-    scheduler_model = object()
-    receptionist = Receptionist(
-        bp,
-        hangup,
-        llm=receptionist_model,
-        make_scheduler=lambda: Scheduler(bp, hangup, llm=scheduler_model, opener="hi"),
+    models: dict[str, object] = {}  # stand-ins for per-agent RealtimeModel instances
+
+    def llm_factory(name: str) -> object:
+        return models.setdefault(name, object())
+
+    receptionist = BlueprintAgent(
+        bp, "receptionist", hangup, llm_factory=llm_factory, opener="hi"
     )
     assert _tool_names(receptionist) == {"handoff_to_scheduler", "end_call"}
     assert receptionist.instructions == bp["agents"]["receptionist"]["instructions"]
 
-    scheduler = asyncio.run(receptionist.handoff_to_scheduler(None))
-    assert isinstance(scheduler, Scheduler)
+    handoff = lk_llm.ToolContext(receptionist.tools).get_function_tool("handoff_to_scheduler")
+    scheduler = asyncio.run(handoff(raw_arguments={}))
+    assert isinstance(scheduler, BlueprintAgent)
+    assert scheduler.agent_name == "scheduler"
     assert _tool_names(scheduler) == {"schedule_appointment", "end_call"}
     assert scheduler.instructions == bp["agents"]["scheduler"]["instructions"]
     # each agent carries its own model => LiveKit cannot reuse the realtime session
-    assert receptionist.llm is receptionist_model
-    assert scheduler.llm is scheduler_model
+    assert receptionist.llm is models["receptionist"]
+    assert scheduler.llm is models["scheduler"]
     assert scheduler.llm is not receptionist.llm
+
+
+def test_generic_industries() -> None:
+    """Every shipped industry builds without per-tool harness handlers, and each
+    agent only carries its own blueprint tools."""
+    for industry in ("healthcare", "legal", "travel"):
+        bp = load_blueprint(industry)
+        hangup = asyncio.Event()
+        start = BlueprintAgent(bp, bp["start"], hangup)
+        expected = {t["name"] for t in bp["agents"][bp["start"]]["tools"]}
+        assert _tool_names(start) == expected, (industry, _tool_names(start) ^ expected)
 
 
 def test_await_farewell() -> None:
@@ -99,5 +112,6 @@ if __name__ == "__main__":
     test_sim_result_id()
     test_blueprint()
     test_real_handoff()
+    test_generic_industries()
     test_await_farewell()
     print("ok")

--- a/voice-agent-harnesses/livekit/test_harness.py
+++ b/voice-agent-harnesses/livekit/test_harness.py
@@ -57,7 +57,7 @@ def test_real_handoff() -> None:
         return models.setdefault(name, object())
 
     receptionist = BlueprintAgent(
-        bp, "receptionist", hangup, llm_factory=llm_factory, opener="hi"
+        bp, "receptionist", hangup, llm_factory=llm_factory, scripted_opener=True
     )
     assert _tool_names(receptionist) == {"handoff_to_scheduler", "end_call"}
     assert receptionist.instructions == bp["agents"]["receptionist"]["instructions"]
@@ -68,6 +68,9 @@ def test_real_handoff() -> None:
     assert scheduler.agent_name == "scheduler"
     assert _tool_names(scheduler) == {"schedule_appointment", "end_call"}
     assert scheduler.instructions == bp["agents"]["scheduler"]["instructions"]
+    # scripted_opener propagates as a capability flag, but the actual spoken line is
+    # derived from the *target's own* prompt, not inherited verbatim from the caller.
+    assert scheduler._opener == "Hey, when do you want to schedule your repair appointment?"
     # each agent carries its own model => LiveKit cannot reuse the realtime session
     assert receptionist.llm is models["receptionist"]
     assert scheduler.llm is models["scheduler"]

--- a/voice-agent-harnesses/openai/harness.py
+++ b/voice-agent-harnesses/openai/harness.py
@@ -1,13 +1,13 @@
 """Shared blueprint → RealtimeRunner builder for OpenAI Realtime harnesses.
 
 Tool kinds (from agent_blueprint.json):
-  - industry (default): harness maps the tool onto the industry state API
-    (e.g. schedule_appointment → POST /appointments)
+  - industry (default): the harness is a dumb pipe — every industry tool is
+    POSTed to {TOOL_SERVER_URL}/tools/{name} with {"arguments": {...}} and the
+    server's JSON envelope goes back to the model verbatim
   - handoff: provider handoff API
   - session: harness-local tool (e.g. end_call); then close the realtime session
 
-The industry tool_server is a state/DB API — not a 1:1 tools.json mirror.
-Session tools never hit it.
+Session and handoff tools never hit the tool server.
 
 Callers must pass a mutable context into RealtimeRunner.run and stash the
 session on it (`context["session"] = session`) so session tools can hang up.
@@ -31,33 +31,21 @@ TOOL_SERVER_URL = os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").rst
 # Let farewell audio finish before tearing down Realtime after end_call.
 END_CALL_CLOSE_DELAY_S = float(os.environ.get("MIVAS_END_CALL_CLOSE_DELAY_S", "2.5"))
 
-# Industry tools: name → call state API and shape the tools.json result.
-IndustryMapper = Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]
-
 # Session tools: name → harness-local side effect (no state API).
 SessionMapper = Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]
 
 
-async def _post_json(path: str, body: dict[str, Any]) -> dict[str, Any]:
+async def dispatch_industry_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
+    """Generic dispatch: POST /tools/{name}; the server's envelope is the result."""
     async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.post(f"{TOOL_SERVER_URL}{path}", json=body)
-        resp.raise_for_status()
+        resp = await client.post(f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args})
         return resp.json()
-
-
-async def _schedule_appointment_via_api(args: dict[str, Any]) -> dict[str, Any]:
-    created = await _post_json("/appointments", {"date": args["date"]})
-    return {"success": True, "date": created["date"]}
 
 
 async def _end_call_local(args: dict[str, Any]) -> dict[str, Any]:
     _ = args.get("reason", "")
     return {"success": True}
 
-
-INDUSTRY_TOOL_HANDLERS: dict[str, IndustryMapper] = {
-    "schedule_appointment": _schedule_appointment_via_api,
-}
 
 SESSION_TOOL_HANDLERS: dict[str, SessionMapper] = {
     "end_call": _end_call_local,
@@ -111,12 +99,8 @@ def _fn_tool(spec: dict, *, session_tool: bool = False) -> FunctionTool:
                 "(session tools are harness-native, not state API routes)"
             )
     else:
-        handler = INDUSTRY_TOOL_HANDLERS.get(name)
-        if handler is None:
-            raise KeyError(
-                f"no harness industry handler for tool {name!r} "
-                "(map it to a state API call in INDUSTRY_TOOL_HANDLERS)"
-            )
+        async def handler(args: dict[str, Any]) -> dict[str, Any]:
+            return await dispatch_industry_tool(name, args)
 
     async def on_invoke(tool_ctx: Any, raw: str) -> str:
         args = json.loads(raw or "{}")
@@ -246,6 +230,11 @@ if __name__ == "__main__":
         start, agents = build_agents("control-industry")
         assert any(t.name == "end_call" for t in start.tools)
         assert any(t.name == "schedule_appointment" for t in agents["scheduler"].tools)
+
+        # every shipped industry builds without per-tool harness handlers
+        for industry in ("healthcare", "legal", "travel"):
+            ind_start, ind_agents = build_agents(industry)
+            assert ind_agents, industry
         print(f"ok session tools start={start.name} agents={list(agents)}")
 
     asyncio.run(_check())

--- a/voice-agent-harnesses/pipecat/harness.py
+++ b/voice-agent-harnesses/pipecat/harness.py
@@ -1,8 +1,9 @@
 """Blueprint → Pipecat services, tools and nodes, for three runtimes.
 
-Pipecat runs our code, so the industry tools are plain Python coroutines wrapped
-in `report.tool_span` — all three (`handoff_to_scheduler`, `schedule_appointment`,
-`end_call`) produce real `execute_tool` spans, no untimeable gaps.
+Pipecat runs our code, so every blueprint tool is a plain Python coroutine wrapped
+in `report.tool_span` — handoffs, session tools (`end_call`) and industry tools all
+produce real `execute_tool` spans, no untimeable gaps. Industry tools dispatch
+generically to the tool server's POST /tools/{name} route.
 
 The handoff is a real agent switch in every runtime, not a prompt injection: each
 blueprint agent gets its own prompt and its own tool set, and `handoff_to_scheduler`
@@ -136,34 +137,42 @@ def tool_server_url() -> str:
     return os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
 
 
+def _tool_entry(bp: dict[str, Any], agent: str, name: str) -> dict[str, Any] | None:
+    """The blueprint entry for a tool, preferring the current agent's copy."""
+    for owner in [agent] + [a for a in bp["agents"] if a != agent]:
+        for t in bp["agents"][owner]["tools"]:
+            if t["name"] == name:
+                return t
+    return None
+
+
 async def _execute_tool(
     name: str, args: dict[str, Any], bp: dict[str, Any], state: dict[str, Any]
 ) -> tuple[dict[str, Any], bool]:
     """Run a blueprint tool. Returns (result, should_end_call).
 
-    A handoff only resolves and records the target here; moving the call is the
+    Handoff and session tools are harness-native; every other tool is POSTed to
+    {TOOL_SERVER_URL}/tools/{name} and the server's envelope is the result. A
+    handoff only resolves and records the target here; moving the call is the
     caller's job, because *how* you move it is a runtime property (a Flows node
     transition, or an `LLMSwitcher` swap to the target agent's own S2S session).
     """
-    if name == "handoff_to_scheduler":
+    entry = _tool_entry(bp, state["agent"], name)
+    if entry is not None and entry.get("handoff"):
         target = handoff_target(bp, state["agent"], name)
         if not target:
             return {"success": False, "error": "unknown handoff target"}, False
         state["agent"] = target
         return {"success": True, "role": target}, False
 
-    if name == "schedule_appointment":
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            resp = await client.post(
-                f"{tool_server_url()}/appointments", json={"date": args["date"]}
-            )
-            resp.raise_for_status()
-            return {"success": True, "date": resp.json()["date"]}, False
-
-    if name == "end_call":
+    if entry is not None and entry.get("session"):
         return {"success": True}, True
 
-    return {"success": False, "error": f"unknown tool {name}"}, False
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(
+            f"{tool_server_url()}/tools/{name}", json={"arguments": args}
+        )
+        return resp.json(), False
 
 
 async def run_tool(
@@ -180,7 +189,7 @@ async def run_tool(
     with tool_span(name, args, call_id=call_id) as span:
         try:
             result, stop = await _execute_tool(name, args, bp, state)
-            ok = bool(result.get("success"))
+            ok = bool(result.get("ok", result.get("success", True)))
         except Exception as e:  # noqa: BLE001 — a dead tool must not kill the call
             result, stop, ok = {"success": False, "error": f"{type(e).__name__}: {e}"}, False, False
         finish_tool_span(span, result, ok=ok)

--- a/voice-agent-harnesses/retell/harness.py
+++ b/voice-agent-harnesses/retell/harness.py
@@ -6,11 +6,11 @@ them (Retell exposes the transition to the model as `transition_to_scheduler`,
 server-side — the harness never routes it). `end_call` is the built-in
 `{type: "end_call"}` tool, also server-side.
 
-Only `schedule_appointment` reaches us, and it does so as an HTTPS callback:
-Retell tools are *platform* tools, so the tool `url` points back at the chirp
-process (`{PUBLIC_URL}/tool/schedule_appointment`). The tunnel URL is ephemeral,
-so `ensure_agent` re-PATCHes the tool URLs on every boot; the cached llm/agent
-ids in `.agents.json` survive.
+Industry tools reach us as HTTPS callbacks: Retell tools are *platform* tools,
+so each tool `url` points back at the chirp process (`{PUBLIC_URL}/tool/<name>`),
+which forwards verbatim to the industry tool server's POST /tools/{name}
+dispatch. The tunnel URL is ephemeral, so `ensure_agent` re-PATCHes the tool
+URLs on every boot; the cached llm/agent ids in `.agents.json` survive.
 """
 
 from __future__ import annotations
@@ -333,22 +333,21 @@ async def report_platform_tools(call_id: str, bp: dict[str, Any]) -> list[str]:
 
 
 async def _execute_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
-    if name == "schedule_appointment":
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            resp = await client.post(f"{TOOL_SERVER_URL}/appointments", json={"date": args["date"]})
-            resp.raise_for_status()
-            return {"success": True, "date": resp.json()["date"]}
-    return {"success": False, "error": f"unknown tool {name}"}
+    """Generic dispatch: POST /tools/{name}; the server's envelope is the result."""
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args})
+        return resp.json()
 
 
 async def run_tool(name: str, args: dict[str, Any], *, call_id: str | None = None) -> dict[str, Any]:
     """Execute a webhook tool under a GenAI execute_tool span. Never raises — a tool
     failure becomes `{success: false, error: ...}` so the call (and OTel tree) finishes."""
-    from report import call_offset_ms, finish_tool_span, tool_span
+    from report import finish_tool_span, tool_span
     with tool_span(name, args, call_id=call_id) as span:
         try:
             result = await _execute_tool(name, args)
-            finish_tool_span(span, result, ok=True)
+            ok = bool(result.get("ok", result.get("success", True)))
+            finish_tool_span(span, result, ok=ok)
             return result
         except Exception as e:
             err = {"success": False, "error": f"{type(e).__name__}: {e}"}

--- a/voice-agent-harnesses/vapi/adapters/chirp.py
+++ b/voice-agent-harnesses/vapi/adapters/chirp.py
@@ -33,8 +33,10 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from harness import (  # noqa: E402
     ensure_squad,
     industry_path,
+    load_blueprint,
     run_tool,
     start_websocket_call,
+    webhook_tool_names,
 )
 from report import (  # noqa: E402
     end_speech_span,
@@ -238,7 +240,8 @@ def _trace_server_tools(body: dict, seen: set[str]) -> None:
             fn = call.get("function") or {}
             name = fn.get("name") or call.get("name")
             key = str(call.get("id") or name)
-            if not name or name in ("schedule_appointment",) or key in seen:
+            # webhook tools already have a live span from /tool/{name}
+            if not name or name in _cfg.get("webhook_tools", ()) or key in seen:
                 continue
             seen.add(key)
             args = fn.get("arguments") or {}
@@ -264,7 +267,12 @@ def main(model: str | None = None) -> None:
         raise SystemExit("need PUBLIC_URL (cloudflared https url) — Vapi tool webhooks point at it")
 
     ids = ensure_squad(a.industry, public_url)
-    _cfg.update(model=a.model, industry=a.industry, squad_id=ids["squad_id"])
+    _cfg.update(
+        model=a.model,
+        industry=a.industry,
+        squad_id=ids["squad_id"],
+        webhook_tools=webhook_tool_names(load_blueprint(a.industry)),
+    )
     print(
         f"ws↔Vapi {a.model} × {a.industry} :{a.port} auth={bool(_auth())} "
         f"squad={ids['squad_id']} tools→{public_url}/tool/",

--- a/voice-agent-harnesses/vapi/harness.py
+++ b/voice-agent-harnesses/vapi/harness.py
@@ -5,9 +5,10 @@ harness only (re)pushes blueprint config and then serves the webhook Vapi calls
 back on. Multi-agent is a **squad**: the receptionist member carries a `handoff`
 tool whose destination is the scheduler member, and the first member answers the
 call. `end_call` is Vapi's built-in `endCall` tool, so it never reaches the
-harness — `schedule_appointment` is the only tool we execute, and it arrives as
-an HTTPS POST from Vapi to `adapters/chirp.py`'s `/tool/{name}` route (which is
-also where its `execute_tool` span comes from).
+harness — every industry tool arrives as an HTTPS POST from Vapi to
+`adapters/chirp.py`'s `/tool/{name}` route (which is also where its
+`execute_tool` span comes from) and is forwarded verbatim to the industry tool
+server's POST /tools/{name} dispatch.
 
 Tool URLs point at the current cloudflared tunnel, which is ephemeral, so
 `ensure_squad` re-pushes the whole assistant config on every chirp boot; only the
@@ -281,18 +282,22 @@ def start_websocket_call(squad_id: str) -> tuple[str, str]:
     return resp["transport"]["websocketCallUrl"], resp["id"]
 
 
-async def _post_appointment(date: str) -> dict[str, Any]:
-    async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.post(f"{TOOL_SERVER_URL}/appointments", json={"date": date})
-        resp.raise_for_status()
-        body = resp.json()
-    return {"success": True, "date": body["date"]}
+def webhook_tool_names(bp: dict[str, Any]) -> set[str]:
+    """The tools that execute through our webhook: every non-handoff,
+    non-session blueprint tool (handoff/endCall run Vapi-side)."""
+    return {
+        t["name"]
+        for entry in bp["agents"].values()
+        for t in entry["tools"]
+        if not t.get("handoff") and not t.get("session") and t["name"] in bp["catalog"]
+    }
 
 
 async def _execute_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
-    if name == "schedule_appointment":
-        return await _post_appointment(args["date"])
-    return {"success": False, "error": f"unknown tool {name}"}
+    """Generic dispatch: POST /tools/{name}; the server's envelope is the result."""
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args})
+        return resp.json()
 
 
 async def run_tool(name: str, args: dict[str, Any], *, call_id: str | None = None) -> dict[str, Any]:
@@ -301,11 +306,12 @@ async def run_tool(name: str, args: dict[str, Any], *, call_id: str | None = Non
     Never raises — failures become `{success: false, error: ...}` so the call (and
     its OTel tree) still finishes cleanly.
     """
-    from report import call_offset_ms, finish_tool_span, tool_span
+    from report import finish_tool_span, tool_span
     with tool_span(name, args, call_id=call_id) as span:
         try:
             result = await _execute_tool(name, args)
-            finish_tool_span(span, result, ok=True)
+            ok = bool(result.get("ok", result.get("success", True)))
+            finish_tool_span(span, result, ok=ok)
             return result
         except Exception as e:
             err = {"success": False, "error": f"{type(e).__name__}: {e}"}


### PR DESCRIPTION
## The contract

Every industry tool server (`industries/{control-industry,healthcare,legal,travel}/tool_server.py`) now exposes one uniform dispatch route:

```
POST /tools/{tool_name}
{"arguments": { ...model-supplied args... }}
```

- Returns the envelope that industry's `tools.json` `outputSchema` already declares: `{"ok": bool, "data": ..., "error_code": str|null, "caller_safe_message"/"patient_safe_message": str|null}` (control-industry keeps its `{"success": ..., ...}` shape).
- Unknown tool name → 404 with a clear message.
- Session tools (`session: true`, e.g. `end_call`) and handoff tools (`handoff: true`) are NOT dispatchable → 404; they stay harness-native (end_call keeps the existing delayed-close/farewell behavior everywhere).
- All existing REST routes are untouched — `GET /health`, `GET /state`, and the domain routes remain for evals and debugging.
- Domain failures come back as HTTP 200 with `ok: false` + `error_code` + safe message, so harnesses stay dumb pipes; server-side guards (legal/travel hold→confirm token discipline, travel fare ladder, healthcare identity/fee/policy gates) are preserved through the envelope and asserted by tests.

Every harness that executes industry tools is now a dumb pipe: it reads `tools.json` + `agent_blueprint.json`, registers every non-handoff non-session tool generically, POSTs `{TOOL_SERVER_URL}/tools/{name}` with `{"arguments": args}`, and returns the JSON to the model verbatim. All per-tool handler dicts and special-cased result reshaping are deleted.

## Server-by-server

| Industry | Change |
|---|---|
| control-industry | `/tools/schedule_appointment` → existing appointment insert, `{"success", "date"}` envelope |
| legal | Dispatch wired onto the existing route handlers. tools.json tools carry no `caller_id`, so `lookup_caller` pins the caller module-side for the rest of the call (single concurrent call, matching benchmark `max_concurrent=1`). `--selfcheck` extended: known tool ok, unknown/session/handoff 404, cross-tool + single-use token guards preserved through dispatch |
| travel | Dispatch wired onto the quote/confirm write gate and read routes; `--selfcheck` extended the same way (SAVER_NOT_CHANGEABLE and token guards through the envelope) |
| healthcare | Only locations/providers/patients/appointments/waitlist had server logic; the other ~29 tools now have minimal deterministic implementations backed by the seeded SQLite fixtures: identity gate with 3-failure lock, deterministic slot generation, cancellation fee-disclosure two-step (24 h medical / 72 h cosmetic, $50/$125), cosmetic policy-acknowledgement gate + price ranges, rx-refill hard-stop routes (isotretinoin/controlled/biologic), eligibility keyed on seeded member ids, carrier acceptance table with `must_not_assert` fallback, static grounded KB, SMS template validation, callback SLAs. Writes with no dedicated table land in a new `tool_events` table so `GET /state` still shows them |

Invariant (enforced by `tests/test_tool_server.py`): every non-handoff, non-session tool in each industry's `tools.json` is dispatchable — 1 (control) + 34 (healthcare) + 19 (legal) + 23 (travel) tools.

## Harness-by-harness

| Harness | Change |
|---|---|
| openai | `INDUSTRY_TOOL_HANDLERS` (lone `schedule_appointment` entry) deleted; `_fn_tool` dispatches industry tools generically; session tools keep `SESSION_TOOL_HANDLERS` + delayed close; self-check now also builds healthcare/legal/travel |
| gemini | `_post_appointment` + hardcoded `_execute_tool` → generic dispatch keyed on blueprint handoff/session flags; soft-handoff "Multi-agent note" generated from the blueprint |
| assemblyai | Same as gemini |
| deepgram | Same as gemini |
| elevenlabs | Client tools forward to dispatch verbatim; `transfer_to_agent`/`end_call` system tools unchanged (`ensure_agents` still supports one handoff pair — provider-topology generalization is out of scope, noted below) |
| livekit | Hardcoded `Receptionist`/`Scheduler` classes replaced by generic `BlueprintAgent` building raw-schema function tools from the blueprint: handoff tools return the target agent instance, session tools set hangup, industry tools dispatch. Runtimes updated (`bp["start"]`); gemini runtime passes a per-agent `llm_factory` (fresh RealtimeModel per agent, preserving the non-mutable-session handoff trick). `test_harness.py` rewritten for the generic API + a new generic-industries test |
| pipecat | `_execute_tool` keyed on blueprint flags; handoff still returns `{"success", "role"}` for the Flows/LLMSwitcher switch in `bot.py` (unchanged) |
| vapi | Webhook forwards to `POST /tools/{name}`; `_trace_server_tools` skips webhook tools via a blueprint-derived set (`webhook_tool_names`) instead of the hardcoded `schedule_appointment` |
| retell | `/tool/{name}` webhook forwards to dispatch; platform-side backfill unchanged |
| bland | Webhook forwards to dispatch; handoff webhook nodes stay local acks via blueprint flags (loaded from `INDUSTRY` env) |
| cartesia | `/tool/{name}` webhook forwards to dispatch; `line_agent/main.py` already built `http_server_tool`s generically from the blueprint — unchanged |

`execute_tool` span success now reads the industry envelope: `result.get("ok", result.get("success", True))`.

Left alone deliberately (not tool coupling, noted for honesty): scripted greetings/openers (`GREETING`, `SCHEDULER_OPENER`, cartesia `HANDOFF_INTRO`) and control-industry-shaped provider *topology* builders (vapi 2-member squad, bland pathway graph, elevenlabs agent pair, `pipecat/check.py` + `bluejay_setup.py` control-industry fixtures). Those are provider/agent-graph concerns, not tool dispatch; multi-hub topologies (legal/travel/healthcare have 4–7 agents) need their own pass on those platforms.

## Audit of remaining harness dirs

README-only stubs, no code, left alone: `agentforce`, `dialogflow`, `telynx`, `twilio`, `qwen`, `grok`, `glm`, `moshi`, `inworld`, `nemotron`. There is no `nvidia/` directory on main (only the unmerged `origin/nvidia-harnesses` branch).

Docs: `voice-agent-harnesses/README.md` now documents the contract. `docs/PROVIDER_INTEGRATION_HANDOFF.md` is **gitignored** (docs/ is in .gitignore), so it could not ride in this PR; the local copy was updated in place with the same contract (Step A/Step B and the checklist).

## Validation

All local/static — no live provider API calls.

- `python industries/<name>/tool_server.py` booted for all four industries with `MIVAS_DB_PATH` pointed at temp files; `GET /health`, `GET /state`, and `POST /tools/<name>` exercised over real HTTP for **every** tools.json tool: `control-industry: 1 dispatchable, 2 native 404` / `healthcare: 34, 1` / `legal: 19, 5` / `travel: 23, 4`, unknown names 404 everywhere.
- `python industries/legal/tool_server.py --selfcheck` → `ok — 24 tools, 5 agents, gate/token/filter traps all hold, dispatch covers 19 tools`
- `python industries/travel/tool_server.py --selfcheck` → `ok — 27 tools, 4 agents, fare ladder / waiver / token traps all hold, dispatch covers 23 tools`
- `uv run python run.py --check --harness openai/realtime-2.1 --industry <X>` → `ok` for control-industry, healthcare, legal, travel (previously anything but control-industry raised `KeyError: no harness industry handler`).
- `python tests/test_tool_server.py` → ok (all five tests, incl. the every-tool-dispatchable invariant).
- `voice-agent-harnesses/openai/harness.py` self-check → ok; `openai/test_nudge_greeting.py` → ok.
- `livekit/test_harness.py` (harness venv) → ok (metadata parse, blueprint, real handoff via generic BlueprintAgent, generic industries, farewell wait).
- `pipecat/harness.py` demo → ok (per-agent tool split, handoff, soft-fail on dead tool server via the dispatch path).
- `retell/test_platform_tools.py` → ok; `bland/base/agent.py --check` → ok; `voice-agent-harnesses/test_await_terminal.py` → ok (all 11 harnesses); `voice-agent-harnesses/check_call_sites.py` → ok.
- `pyflakes` clean over every touched file (also removed two pre-existing unused imports in vapi/retell `run_tool`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a uniform, industry‑agnostic `POST /tools/{name}` dispatch and converts all harnesses into generic pipes, preserving server‑side guards and extending healthcare with deterministic tools. Tests assert every non‑handoff, non‑session tool is dispatchable; docs describe the contract.

- **New Features**
  - Added `POST /tools/{tool_name}` on all industry servers; body `{"arguments": {...}}`, returns each industry's `tools.json` envelope; unknown/session/handoff tools 404.
  - Healthcare: filled in missing tools with deterministic logic; writes without tables land in `tool_events` so `GET /state` shows them.
  - Harnesses: all platforms now read `tools.json`/`agent_blueprint.json` and forward tools generically; LiveKit uses a generic `BlueprintAgent`; Gemini/Deepgram/AssemblyAI add a blueprint‑derived multi‑agent note; Vapi tracer skips webhook tools via a blueprint‑derived set.
  - Tests: iterate every industry's `tools.json` and assert dispatchability and envelope shape; reverse parity (no dispatch without a `tools.json` tool); make healthcare’s verify‑then‑read ordering explicit.

- **Bug Fixes**
  - Healthcare: bind bookings to offered slots; gate cancel/reschedule/refill/clinical‑message to the verified patient; persist late‑cancel fees; validate plan/carrier; stop overwriting `plan_name`; validate transfer destinations; scrub exception text from `patient_safe_message`; cancelling an already‑cancelled appointment is now idempotent.
  - Control‑industry: `tools.json` declares the `schedule_appointment` failure envelope (`success`, optional `date`, `error`).
  - Travel: `confirm_*` enforces the hold’s expected kind via a private `_confirm` helper (body‑only public API); fixed `caller_safe_message` on malformed args; stop logging full tool arguments on failed dispatch.
  - Legal: `ToolCall.arguments` uses `Field(default_factory=dict)`; `_cid()` errors until `lookup_caller` pins a caller; missing required args flow through the invalid‑argument envelope.
  - Harnesses: Cartesia/ElevenLabs preserve failure from the dispatch envelope and default missing `ok`/`success` to `false`; Gemini scopes handoff/session tools to the active agent and blocks stale tools after a handoff; LiveKit treats missing `ok`/`success` as failure and derives each agent’s opener from its own prompt.

<sup>Written for commit 61b91fbe6e89ca4b7664af46f3e5b6e1cf98e1ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/7?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

