### PR TITLE
Add xAI Grok voice CHIRP harness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,15 @@ LIVEKIT_API_SECRET=
 # livekit-agents conflicts with the pinned livekit>=1.1.0 the retell harness needs, so the
 # livekit harness ships its own requirements.txt + .venv rather than joining the shared deps.
 
+# Grok / xAI Speech-to-Speech (family/runtime = grok/voice)
+# Docs: https://docs.x.ai/developers/model-capabilities/audio/voice-agent
+GROK_API_KEY=
+# XAI_API_KEY=            # alias for GROK_API_KEY
+# GROK_VOICE_MODEL=grok-voice-latest
+# GROK_VOICE=eve
+# GROK_WS_URL=wss://api.x.ai/v1/realtime
+# CHIRP_PORT=8768         # do not share ports with other local CHIRP harnesses
+
 # Pipecat (framework harness — the bot runs on Pipecat Cloud, so TOOL_SERVER_URL must be public)
 # Two DIFFERENT key types, not interchangeable:
 #   sk_ (private) — deploying the agent image, used by voice-agent-harnesses/pipecat/deploy.py
@@ -82,7 +91,7 @@ PIPECAT_PRIVATE_API_KEY=
 # CHIRP WebSocket adapter (Bluejay → harness)
 # CHIRP_USER=mivas
 # CHIRP_PASS=mivas
-# CHIRP_PORT=8765   # vapi 8770 / retell 8771 / bland 8772 / cartesia 8773 when running side by side
+# CHIRP_PORT=8765   # grok 8768 / vapi 8770 / retell 8771 / bland 8772 / cartesia 8773 when running side by side
 # INDUSTRY=control-industry
 
 # Bluejay OTLP + link trace to sim result (Chirp sends X-Simulation-Result-Id on upgrade)
@@ -90,7 +99,8 @@ PIPECAT_PRIVATE_API_KEY=
 # BLUEJAY_OTLP_ENDPOINT=https://otlp.getbluejay.ai/v1/traces
 # BLUEJAY_API_URL=https://api.getbluejay.ai/v1
 # BLUEJAY_SERVICE_NAME=mivas-openai   # or mivas-gemini / mivas-assemblyai / mivas-deepgram /
-#                                     # mivas-elevenlabs / mivas-vapi / mivas-retell / mivas-bland / mivas-cartesia
+#                                     # mivas-elevenlabs / mivas-vapi / mivas-retell / mivas-bland /
+#                                     # mivas-cartesia / mivas-grok
 
 # --- Kubernetes / CHIRP ---
 # MIVAS_MODE=chirp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,4 +32,4 @@ package = false
 venvPath = "."
 venv = ".venv"
 pythonVersion = "3.12"
-extraPaths = ["voice-agent-harnesses/openai", "voice-agent-harnesses/gemini", "voice-agent-harnesses/assemblyai", "voice-agent-harnesses/deepgram", "voice-agent-harnesses/elevenlabs", "voice-agent-harnesses/vapi", "voice-agent-harnesses/retell", "voice-agent-harnesses/bland", "voice-agent-harnesses/cartesia", "voice-agent-harnesses/livekit", "voice-agent-harnesses/pipecat"]
+extraPaths = ["voice-agent-harnesses/openai", "voice-agent-harnesses/gemini", "voice-agent-harnesses/assemblyai", "voice-agent-harnesses/deepgram", "voice-agent-harnesses/elevenlabs", "voice-agent-harnesses/vapi", "voice-agent-harnesses/retell", "voice-agent-harnesses/bland", "voice-agent-harnesses/cartesia", "voice-agent-harnesses/livekit", "voice-agent-harnesses/pipecat", "voice-agent-harnesses/grok"]

--- a/voice-agent-harnesses/grok/README.md
+++ b/voice-agent-harnesses/grok/README.md
@@ -1,3 +1,38 @@
 # grok
 
-Benchmarks and evaluation assets for grok voice agents.
+xAI Grok Speech-to-Speech harnesses. Each subfolder is one model runtime.
+
+| Folder | Model |
+|---|---|
+| `voice/` | [`grok-voice-latest`](https://docs.x.ai/developers/model-capabilities/audio/voice-agent) (alias for `grok-voice-think-fast-2.0`) |
+
+Shared builder: `harness.py`. Tracing/reporting: `report.py` (`BLUEJAY_SERVICE_NAME=mivas-grok`, provider `xai`).
+
+- Industry tools → industry state API (`TOOL_SERVER_URL`)
+- Session tools (`session: true`, e.g. `end_call`) → harness-local + close
+- Handoffs → hard dual-session switch (one Grok WS per blueprint agent; idle gets no audio)
+- Speak-first: bare `response.create` after `session.updated` (pack owns greeting text)
+- Audio: Grok PCM 24 kHz ↔ CHIRP 16 kHz `pcm_s16le` + `speech.started` / `speech.completed`
+- Tracing → Bluejay OTel `voice.call` (`agent.speech` / `customer.speech` / `execute_tool`); Chirp stamps `X-Simulation-Result-Id` and POSTs `{trace_ids}`
+
+```bash
+uv sync
+# GROK_API_KEY (or XAI_API_KEY) in root .env
+uv run python run.py --harness grok/voice --mode check
+uv run python industries/control-industry/tool_server.py
+CHIRP_PORT=8768 CHIRP_USER=mivas CHIRP_PASS=mivas \
+  uv run python run.py --harness grok/voice --mode chirp
+```
+
+## Env
+
+| var | use |
+|---|---|
+| `GROK_API_KEY` | xAI API key (`Authorization: Bearer …`) |
+| `XAI_API_KEY` | alias for `GROK_API_KEY` |
+| `GROK_VOICE_MODEL` | default `grok-voice-latest` |
+| `GROK_VOICE` | session voice (default `eve`) |
+| `GROK_WS_URL` | override WS base (default `wss://api.x.ai/v1/realtime`) |
+| `TOOL_SERVER_URL` | industry state API |
+| `BLUEJAY_API_KEY` | OTel + `update-simulation-result` |
+| `CHIRP_USER` / `CHIRP_PASS` / `CHIRP_PORT` | Bluejay websocket auth (default port `8768`) |

--- a/voice-agent-harnesses/grok/harness.py
+++ b/voice-agent-harnesses/grok/harness.py
@@ -1,0 +1,533 @@
+"""Blueprint → xAI Speech-to-Speech (Grok Voice) session helpers.
+
+Industry tools map onto the industry state API (`TOOL_SERVER_URL`).
+Handoff tools (`handoff: true`) switch the active blueprint agent.
+Session tools (`session: true`, e.g. end_call) hang up.
+
+Multi-agent is hard isolation: one Grok Realtime WebSocket per blueprint agent,
+each with that agent's pack instructions + tools only. The CHIRP bridge keeps
+all sockets open and rewires audio to the active agent on handoff.
+
+Industry-agnostic: pack owns prompts/tool policy. No harness greeting strings.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import re
+import uuid
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+# Verbal booking confirm without a function-call event (same failure mode as
+# hosted VoiceChat). Recover schedule_appointment for tool-server + OTel.
+_BOOKING_CONFIRM_RE = re.compile(
+    r"(?:booking\s+confirmed|appointment\s+(?:is\s+)?scheduled|"
+    r"you(?:'| a)re\s+(?:all\s+)?set(?:\s+for)?|confirmed\s+for|"
+    r"appointment\s+has\s+been\s+confirmed|"
+    r"(?:i(?:'|'?ll| will| have)\s+)?(?:get\s+that\s+)?booked\s+for|"
+    r"got\s+that\s+booked)",
+    re.IGNORECASE,
+)
+_MONTHS = (
+    "january",
+    "february",
+    "march",
+    "april",
+    "may",
+    "june",
+    "july",
+    "august",
+    "september",
+    "october",
+    "november",
+    "december",
+)
+_DATE_NUMERIC_RE = re.compile(r"\b(\d{1,2}/\d{1,2}/\d{4})\b")
+_DATE_MONTH_RE = re.compile(
+    r"\b(" + "|".join(_MONTHS) + r")\s+(\d{1,2})(?:st|nd|rd|th)?"
+    r"(?:[,\s]+(\d{4}))?\b",
+    re.IGNORECASE,
+)
+_WEEKDAYS = (
+    "monday",
+    "tuesday",
+    "wednesday",
+    "thursday",
+    "friday",
+    "saturday",
+    "sunday",
+)
+_NEXT_WEEKDAY_RE = re.compile(
+    r"\bnext\s+(" + "|".join(_WEEKDAYS) + r")\b", re.IGNORECASE
+)
+
+HARNESS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = HARNESS_DIR.parents[1] if len(HARNESS_DIR.parents) > 1 else HARNESS_DIR
+
+RUNTIME = "voice"
+MODEL = os.environ.get("GROK_VOICE_MODEL", "grok-voice-latest")
+DEFAULT_WS_URL = "wss://api.x.ai/v1/realtime"
+SAMPLE_RATE = 24_000
+VOICE = os.environ.get("GROK_VOICE", "eve")
+TOOL_SERVER_URL = os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
+END_CALL_CLOSE_DELAY_S = float(os.environ.get("MIVAS_END_CALL_CLOSE_DELAY_S", "2.5"))
+
+
+def industry_path(name: str | Path) -> Path:
+    path = Path(name)
+    if path.is_dir():
+        return path.resolve()
+    env_dir = os.environ.get("INDUSTRY_DIR", "").strip()
+    if env_dir and Path(env_dir).is_dir():
+        return Path(env_dir).resolve()
+    for base in (HARNESS_DIR / "industries", REPO_ROOT / "industries"):
+        if (base / name).is_dir():
+            return (base / name).resolve()
+    return (REPO_ROOT / "industries" / name).resolve()
+
+
+def load_blueprint(industry_dir: str | Path) -> dict[str, Any]:
+    industry_dir = industry_path(industry_dir)
+    blueprint = json.loads((industry_dir / "agent_blueprint.json").read_text())
+    catalog = {
+        t["name"]: t
+        for t in json.loads((industry_dir / "tools.json").read_text())["tools"]
+    }
+    agents = {
+        entry["name"]: {
+            "name": entry["name"],
+            "instructions": (industry_dir / entry["system_prompt"]).read_text(),
+            "tools": entry["tools"],
+        }
+        for entry in blueprint["agents"]
+    }
+    return {
+        "industry_dir": industry_dir,
+        "start": blueprint["agents"][0]["name"],
+        "agents": agents,
+        "catalog": catalog,
+    }
+
+
+def api_key() -> str:
+    key = (
+        os.environ.get("GROK_API_KEY", "").strip()
+        or os.environ.get("XAI_API_KEY", "").strip()
+    )
+    if not key:
+        raise SystemExit("need GROK_API_KEY or XAI_API_KEY")
+    return key
+
+
+def ws_url(model: str | None = None) -> str:
+    base = os.environ.get("GROK_WS_URL", DEFAULT_WS_URL).rstrip("/")
+    return f"{base}?model={model or MODEL}"
+
+
+def ws_headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {api_key()}"}
+
+
+def connect_grok(model: str | None = None):
+    """Return a websockets connect CM for the xAI Voice Realtime API."""
+    import websockets
+
+    return websockets.connect(ws_url(model), additional_headers=ws_headers())
+
+
+def tool_server_url() -> str:
+    return os.environ.get("TOOL_SERVER_URL", TOOL_SERVER_URL).rstrip("/")
+
+
+def tool_names(bp: dict[str, Any], agent: str) -> list[str]:
+    return [t["name"] for t in bp["agents"][agent]["tools"] if t["name"] in bp["catalog"]]
+
+
+def handoff_target(bp: dict[str, Any], agent: str, tool: str) -> str | None:
+    for t in bp["agents"][agent]["tools"]:
+        if t["name"] == tool and t.get("handoff"):
+            target = t.get("handoff_to")
+            return target if target in bp["agents"] else None
+    return None
+
+
+def is_session_tool(bp: dict[str, Any], agent: str, tool: str) -> bool:
+    for t in bp["agents"][agent]["tools"]:
+        if t["name"] == tool:
+            return bool(t.get("session"))
+    return False
+
+
+def handoff_role(result: dict[str, Any], bp: dict[str, Any]) -> str | None:
+    role = result.get("role")
+    return role if isinstance(role, str) and role in bp["agents"] else None
+
+
+def _event_id() -> str:
+    return str(uuid.uuid4())
+
+
+def _tool_decl(spec: dict) -> dict[str, Any]:
+    """xAI custom function tool from an industry catalog entry."""
+    raw = dict(spec.get("inputSchema") or {"type": "object"})
+    raw.pop("additionalProperties", None)
+    props = raw.get("properties")
+    properties: dict[str, Any] = dict(props) if isinstance(props, dict) else {}
+    params: dict[str, Any] = {"type": "object", "properties": properties}
+    if raw.get("required"):
+        params["required"] = list(raw["required"])
+    return {
+        "type": "function",
+        "name": spec["name"],
+        "description": spec.get("description", spec["name"]),
+        "parameters": params,
+    }
+
+
+def today_context_line(today: _dt.date | None = None) -> str:
+    """Clock fact for relative dates — Grok Voice has no built-in 'today'."""
+    d = today or _dt.date.today()
+    return f"Today is {d.strftime('%A')}, {d.strftime('%B')} {d.day}, {d.year}."
+
+
+def with_today_context(instructions: str, today: _dt.date | None = None) -> str:
+    line = today_context_line(today)
+    text = (instructions or "").rstrip()
+    if line in text:
+        return text
+    return f"{text}\n\n{line}"
+
+
+def extract_appointment_date(text: str, *, default_year: int | None = None) -> str | None:
+    """Best-effort MM/DD/YYYY from agent speech (last concrete / next-weekday)."""
+    if not text:
+        return None
+    year_default = int(default_year or _dt.date.today().year)
+    hits: list[tuple[int, int, str]] = []
+
+    for m in _DATE_NUMERIC_RE.finditer(text):
+        mm, dd, yyyy = m.group(1).split("/")
+        hits.append((50, m.end(), f"{int(mm):02d}/{int(dd):02d}/{int(yyyy)}"))
+    for m in _DATE_MONTH_RE.finditer(text):
+        month = _MONTHS.index(m.group(1).lower()) + 1
+        day = int(m.group(2))
+        year = int(m.group(3)) if m.group(3) else year_default
+        hits.append((50, m.end(), f"{month:02d}/{day:02d}/{year}"))
+    for m in _NEXT_WEEKDAY_RE.finditer(text):
+        target = _WEEKDAYS.index(m.group(1).lower())
+        today = _dt.date.today()
+        delta = (target - today.weekday()) % 7
+        if delta == 0:
+            delta = 7
+        day = today + _dt.timedelta(days=delta)
+        hits.append((45, m.end(), day.strftime("%m/%d/%Y")))
+
+    if not hits:
+        return None
+    best = max(h[0] for h in hits)
+    cands = [h for h in hits if h[0] == best]
+    cands.sort(key=lambda x: x[1])
+    return cands[-1][2]
+
+
+def infer_schedule_appointment(text: str) -> dict[str, Any] | None:
+    """If transcript confirms a booking, return schedule_appointment args."""
+    if not text or not _BOOKING_CONFIRM_RE.search(text):
+        return None
+    m = _BOOKING_CONFIRM_RE.search(text)
+    assert m is not None
+    window = text[max(0, m.start() - 40) : min(len(text), m.end() + 100)]
+    date = extract_appointment_date(window) or extract_appointment_date(text)
+    if not date:
+        return None
+    return {"date": date}
+
+
+def session_update_for_agent(bp: dict[str, Any], agent: str) -> dict[str, Any]:
+    """Pack instructions + that agent's tools only. No harness prompt stuffing."""
+    if agent not in bp["agents"]:
+        raise KeyError(f"unknown agent {agent!r}")
+    tools = [_tool_decl(bp["catalog"][name]) for name in tool_names(bp, agent)]
+    # Telephony-friendly VAD: more prefix padding so the first syllable isn't
+    # clipped, longer silence so mid-sentence pauses don't end the turn early.
+    silence_ms = int(os.environ.get("GROK_VAD_SILENCE_MS", "700"))
+    prefix_ms = int(os.environ.get("GROK_VAD_PREFIX_MS", "400"))
+    threshold = float(os.environ.get("GROK_VAD_THRESHOLD", "0.7"))
+    return {
+        "type": "session.update",
+        "event_id": _event_id(),
+        "session": {
+            "voice": VOICE,
+            "instructions": with_today_context(bp["agents"][agent]["instructions"]),
+            "turn_detection": {
+                "type": "server_vad",
+                "threshold": threshold,
+                "silence_duration_ms": silence_ms,
+                "prefix_padding_ms": prefix_ms,
+            },
+            "audio": {
+                "input": {
+                    "format": {"type": "audio/pcm", "rate": SAMPLE_RATE},
+                    # Emit conversation.item.input_audio_transcription.* so the
+                    # bridge can log what Grok actually heard from the DH.
+                    "transcription": {"model": "grok-transcribe", "language_hint": "en"},
+                },
+                "output": {"format": {"type": "audio/pcm", "rate": SAMPLE_RATE}},
+            },
+            "tools": tools,
+        },
+    }
+
+
+def advertised_tools(industry_dir: str | Path, agent: str | None = None) -> list[str]:
+    bp = load_blueprint(industry_dir)
+    name = agent or bp["start"]
+    return [t["name"] for t in session_update_for_agent(bp, name)["session"]["tools"]]
+
+
+def build_agents(industry_dir: str | Path) -> tuple[str, list[str]]:
+    bp = load_blueprint(industry_dir)
+    return bp["start"], list(bp["agents"])
+
+
+async def _execute_tool(
+    name: str, args: dict[str, Any], bp: dict[str, Any], state: dict[str, Any]
+) -> tuple[dict[str, Any], bool]:
+    """Run a blueprint tool. Returns (result, should_end_call)."""
+    target = handoff_target(bp, state["agent"], name)
+    if target:
+        state["agent"] = target
+        return {"success": True, "role": target}, False
+
+    if name == "schedule_appointment":
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.post(
+                f"{tool_server_url()}/appointments", json={"date": args["date"]}
+            )
+            resp.raise_for_status()
+            return {"success": True, "date": resp.json()["date"]}, False
+
+    if name == "end_call" or is_session_tool(bp, state["agent"], name):
+        return {"success": True}, True
+
+    return {"success": False, "error": f"unknown tool {name}"}, False
+
+
+async def run_tool(
+    name: str,
+    args: dict[str, Any],
+    bp: dict[str, Any],
+    state: dict[str, Any],
+    *,
+    call_id: str | None = None,
+) -> tuple[dict[str, Any], bool]:
+    from report import finish_tool_span, tool_span
+
+    parent = state.get("_otel_root")
+    with tool_span(name, args, call_id=call_id, parent=parent) as span:
+        try:
+            result, stop = await _execute_tool(name, args, bp, state)
+            ok = bool(result.get("success"))
+        except Exception as e:  # noqa: BLE001 — dead tool must not kill the call
+            result, stop, ok = (
+                {"success": False, "error": f"{type(e).__name__}: {e}"},
+                False,
+                False,
+            )
+        finish_tool_span(span, result, ok=ok)
+        return result, stop
+
+
+def function_call_output(call_id: str, result: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "conversation.item.create",
+        "event_id": _event_id(),
+        "item": {
+            "type": "function_call_output",
+            "call_id": call_id,
+            "output": json.dumps(result),
+        },
+    }
+
+
+def nudge_greeting() -> dict[str, Any]:
+    """Bare response.create — greeting text comes from pack instructions only."""
+    return {"type": "response.create", "event_id": _event_id()}
+
+
+def _text_item(role: str, text: str) -> dict[str, Any]:
+    """conversation.item.create for a text turn (OpenAI/xAI Realtime shape)."""
+    content_type = "input_text" if role == "user" else "text"
+    return {
+        "type": "conversation.item.create",
+        "event_id": _event_id(),
+        "item": {
+            "type": "message",
+            "role": role,
+            "content": [{"type": content_type, "text": text}],
+        },
+    }
+
+
+def handoff_seed_events(
+    *,
+    user_said: str = "",
+    prior_agent_said: str = "",
+) -> list[dict[str, Any]]:
+    """Seed a cold dual-session target with prior call context (then nudge).
+
+    OpenAI soft-handoff keeps one conversation; Grok hard-isolation opens a
+    blank WS. Replaying the last user/assistant turns into the target is the
+    closest equivalent — industry-agnostic (no pack strings).
+    """
+    user = " ".join((user_said or "").split()).strip()[:500]
+    prior = " ".join((prior_agent_said or "").split()).strip()[:280]
+    events: list[dict[str, Any]] = [
+        _text_item(
+            "user",
+            "SYSTEM: Mid-call handoff. You are taking over an active call. "
+            "Continue from the conversation below — do not greet, welcome, "
+            "or ask how you can help; pick up where it left off.",
+        )
+    ]
+    if prior:
+        events.append(_text_item("assistant", prior))
+    if user:
+        events.append(_text_item("user", user))
+    else:
+        events.append(
+            _text_item(
+                "user",
+                "Please continue helping me with what I just asked. Do not greet me.",
+            )
+        )
+    return events
+
+
+async def handle_function_call(
+    name: str,
+    arguments: str | dict,
+    call_id: str,
+    bp: dict[str, Any],
+    state: dict[str, Any],
+) -> tuple[dict[str, Any], bool, dict[str, Any]]:
+    """Run a tool and build the conversation.item.create reply."""
+    if isinstance(arguments, str):
+        try:
+            args = json.loads(arguments or "{}")
+        except json.JSONDecodeError:
+            args = {}
+    else:
+        args = dict(arguments or {})
+
+    result, stop = await run_tool(name, args, bp, state, call_id=call_id)
+    return result, stop, function_call_output(call_id, result)
+
+
+async def configure_session(ws, agent: str, bp: dict[str, Any], *, timeout: float = 60.0) -> dict:
+    """Send session.update and wait for session.updated. Returns the event."""
+    import asyncio
+
+    await ws.send(json.dumps(session_update_for_agent(bp, agent)))
+    while True:
+        raw = await asyncio.wait_for(ws.recv(), timeout=timeout)
+        if isinstance(raw, bytes):
+            continue
+        ev = json.loads(raw)
+        et = ev.get("type")
+        if et == "session.updated":
+            return ev
+        if et == "error":
+            raise RuntimeError(f"session.update failed for {agent}: {ev}")
+
+
+async def run_session(industry_dir: str | Path, *, model: str = MODEL) -> None:
+    """Smoke: open one session per agent, session.update each, then close."""
+    import asyncio
+    import contextlib
+
+    from report import traced_run
+
+    bp = load_blueprint(industry_dir)
+    name = Path(industry_path(industry_dir)).name
+
+    async with traced_run(f"mivas-{name}-{model}", model=model):
+        for agent in bp["agents"]:
+            async with connect_grok(model) as grok:
+                created = json.loads(await asyncio.wait_for(grok.recv(), timeout=30))
+                print(f"{agent} {created.get('type')}", flush=True)
+                updated = await configure_session(grok, agent, bp)
+                n = len((updated.get("session") or {}).get("tools") or [])
+                print(
+                    f"{agent} {updated.get('type')} tools={n} ok",
+                    flush=True,
+                )
+                with contextlib.suppress(Exception):
+                    await grok.close()
+
+
+def demo() -> None:
+    """Offline blueprint/tool-shape check (no network)."""
+    bp = load_blueprint("control-industry")
+    start = bp["start"]
+    start_tools = advertised_tools("control-industry", start)
+    assert tool_names(bp, start) == start_tools
+    all_names = {n for a in bp["agents"] for n in tool_names(bp, a)}
+    today_line = today_context_line()
+    for agent, names in ((a, tool_names(bp, a)) for a in bp["agents"]):
+        update = session_update_for_agent(bp, agent)
+        session = update["session"]
+        pack = bp["agents"][agent]["instructions"]
+        assert session["instructions"].startswith(pack.rstrip())
+        assert today_line in session["instructions"]
+        assert [t["name"] for t in session["tools"]] == names
+        assert all(t.get("type") == "function" for t in session["tools"])
+        assert session["turn_detection"]["type"] == "server_vad"
+        assert "# Multi-agent note" not in session["instructions"]
+        assert "you MUST call" not in session["instructions"].lower()
+        leaked = all_names - set(names)
+        for n in leaked:
+            # other agents' tools must not be advertised on this session
+            assert n not in [t["name"] for t in session["tools"]], f"{agent} leaked {n}"
+    # Relative-date recovery uses the real clock, not model priors (was Mar 2025).
+    nxt = extract_appointment_date("next Tuesday afternoon")
+    assert nxt and nxt.endswith(f"/{_dt.date.today().year}")
+    assert infer_schedule_appointment("Booking confirmed for March 18.") == {
+        "date": f"03/18/{_dt.date.today().year}"
+    }
+    seed = handoff_seed_events(
+        user_said="I'd like next Tuesday afternoon.",
+        prior_agent_said="One moment while I transfer you.",
+    )
+    assert [e["item"]["role"] for e in seed] == ["user", "assistant", "user"]
+    assert "next Tuesday" in seed[-1]["item"]["content"][0]["text"]
+    assert "Mid-call handoff" in seed[0]["item"]["content"][0]["text"]
+    if len(bp["agents"]) > 1 and all_names - set(start_tools):
+        assert set(start_tools) != all_names
+    state = {"agent": start}
+    target = None
+    handoff_name = None
+    for name in start_tools:
+        cand = handoff_target(bp, start, name)
+        if cand:
+            target, handoff_name = cand, name
+            break
+    if target and handoff_name:
+        import asyncio
+
+        res, stop = asyncio.run(run_tool(handoff_name, {}, bp, state))
+        assert res.get("success") and res.get("role") == target and not stop
+        assert state["agent"] == target
+    print(
+        f"grok self-check ok start={start} tools={start_tools} "
+        f"agents={list(bp['agents'])} model={MODEL} ws={ws_url()}"
+    )
+
+
+if __name__ == "__main__":
+    demo()

--- a/voice-agent-harnesses/grok/report.py
+++ b/voice-agent-harnesses/grok/report.py
@@ -1,0 +1,566 @@
+"""OpenTelemetry → Bluejay OTLP for Grok / xAI voice harnesses.
+
+The xAI Speech-to-Speech WebSocket has no Agents-SDK span tree, so we emit
+GenAI-native spans:
+
+  voice.call (root) — gen_ai.provider.name=xai
+    ├── agent.speech          (TTS / agent audio turns)
+    ├── customer.speech       (CHIRP speech.started / completed)
+    └── execute_tool <name>   (gen_ai.tool.*)
+
+After the call we POST to update-simulation-result with:
+  - trace_ids  → waterfall flamegraph
+  Conversation tool markers come from execute_tool OTel spans (not a tool_calls POST).
+
+Chirp supplies simulation_result_id via X-Simulation-Result-Id on upgrade.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import sys
+import time
+from contextlib import asynccontextmanager, contextmanager
+from contextvars import ContextVar
+from typing import Any, AsyncIterator, Iterator
+
+import httpx
+from opentelemetry import trace as otel_trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.trace import Span, SpanKind, Status, StatusCode
+
+logger = logging.getLogger("mivas.otel.grok")
+if not logger.handlers:
+    _h = logging.StreamHandler(sys.stdout)
+    _h.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s"))
+    logger.addHandler(_h)
+    logger.setLevel(logging.INFO)
+    logger.propagate = False
+
+DEFAULT_OTLP_ENDPOINT = "https://otlp.getbluejay.ai/v1/traces"
+DEFAULT_API_URL = "https://api.getbluejay.ai/v1"
+FINAL_STATUSES = {
+    "COMPLETED",
+    "FAILED",
+    "SYSTEM_ERROR",
+    "NO_ANSWER",
+    "CANCELLED",
+    "NO_CONNECTION",
+}
+EARLY_UPSERT_STATUSES = {"EVALUATING", "EVALUATED", "CONVERSATION_ENDED"}
+PROVIDER = "xai"
+TRACER_NAME = "mivas.grok"
+
+_provider: TracerProvider | None = None
+_root_span: ContextVar[Span | None] = ContextVar("mivas_grok_otel_root", default=None)
+_call_t0: ContextVar[float | None] = ContextVar("mivas_grok_otel_t0", default=None)
+_reported_tools: ContextVar[list[dict[str, Any]] | None] = ContextVar(
+    "mivas_grok_reported_tools", default=None
+)
+# module fallbacks when asyncio tasks don't inherit ContextVars
+_active_root: Span | None = None
+_active_t0: float | None = None
+_active_tools: list[dict[str, Any]] | None = None
+
+
+def _api_url() -> str:
+    return os.environ.get("BLUEJAY_API_URL", DEFAULT_API_URL).rstrip("/")
+
+
+def _otlp_endpoint() -> str:
+    return os.environ.get("BLUEJAY_OTLP_ENDPOINT", DEFAULT_OTLP_ENDPOINT)
+
+
+def _service_name() -> str:
+    return os.environ.get("BLUEJAY_SERVICE_NAME", "mivas-grok")
+
+
+def _api_key() -> str | None:
+    return os.environ.get("BLUEJAY_API_KEY") or None
+
+
+def _json_attr(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, default=str)
+    except Exception:
+        return str(value)
+
+
+def call_offset_ms() -> int:
+    t0 = _call_t0.get()
+    if t0 is None:
+        t0 = _active_t0
+    if t0 is None:
+        return 0
+    return max(0, int((time.monotonic() - t0) * 1000))
+
+
+def setup_otel() -> TracerProvider | None:
+    """Install global OTel exporter to Bluejay OTLP. No-op without BLUEJAY_API_KEY."""
+    global _provider
+
+    api_key = _api_key()
+    if not api_key:
+        return None
+
+    if _provider is not None:
+        return _provider
+
+    endpoint = _otlp_endpoint()
+    resource = Resource.create({SERVICE_NAME: _service_name()})
+    provider = TracerProvider(resource=resource)
+    provider.add_span_processor(
+        SimpleSpanProcessor(
+            OTLPSpanExporter(endpoint, headers={"X-API-KEY": api_key})
+        )
+    )
+    otel_trace.set_tracer_provider(provider)
+    _provider = provider
+    logger.info("otel → %s service=%s", endpoint, _service_name())
+    return provider
+
+
+def flush() -> None:
+    if _provider is not None:
+        try:
+            _provider.force_flush()
+        except Exception as e:
+            logger.error("otel flush failed: %s", e)
+
+
+def _parent_span() -> Span | None:
+    """Always the voice.call root — never the current speech/tool span.
+
+    Falling back to get_current_span() nests customer.speech under agent.speech
+    (and vice versa) in Bluejay's waterfall.
+    """
+    parent = _root_span.get()
+    if parent is not None and parent.get_span_context().is_valid:
+        return parent
+    if _active_root is not None and _active_root.get_span_context().is_valid:
+        return _active_root
+    return None
+
+
+def record_tool_call(
+    name: str,
+    parameters: Any,
+    output: Any,
+    *,
+    start_offset_ms: int | None = None,
+) -> None:
+    """Buffer a tool call for the end-of-call update-simulation-result POST."""
+    tools = _reported_tools.get()
+    if tools is None:
+        tools = _active_tools
+    if tools is None:
+        return
+    tools.append(
+        {
+            "name": str(name),
+            "parameters": parameters if isinstance(parameters, dict) else {"raw": parameters},
+            "output": output,
+            "start_offset_ms": int(
+                start_offset_ms if start_offset_ms is not None else call_offset_ms()
+            ),
+        }
+    )
+
+
+@contextmanager
+def tool_span(
+    name: str,
+    parameters: Any = None,
+    *,
+    call_id: str | None = None,
+    parent: Span | None = None,
+) -> Iterator[Span | None]:
+    """Sibling of speech spans under voice.call. No-op outside traced_run."""
+    root = parent if parent is not None and parent.get_span_context().is_valid else _parent_span()
+    if root is None:
+        yield None
+        return
+
+    tracer = otel_trace.get_tracer(TRACER_NAME)
+    parent_ctx = otel_trace.set_span_in_context(root)
+    attrs: dict[str, Any] = {
+        "gen_ai.operation.name": "execute_tool",
+        "gen_ai.provider.name": PROVIDER,
+        "gen_ai.tool.name": name,
+        "gen_ai.tool.call.arguments": _json_attr(parameters if parameters is not None else {}),
+        "bluejay.speech.start_offset_ms": call_offset_ms(),
+    }
+    if call_id:
+        attrs["gen_ai.tool.call.id"] = str(call_id)
+
+    # start_span (not start_as_current) so later speech stays a sibling of this tool.
+    span = tracer.start_span(
+        f"execute_tool {name}",
+        context=parent_ctx,
+        kind=SpanKind.CLIENT,
+        attributes=attrs,
+    )
+    try:
+        yield span
+    except Exception as e:
+        span.record_exception(e)
+        span.set_status(Status(StatusCode.ERROR, str(e)[:400]))
+        span.end()
+        raise
+    else:
+        if span.is_recording():
+            span.set_attribute("bluejay.speech.end_offset_ms", call_offset_ms())
+            span.end()
+
+
+def finish_tool_span(
+    span: Span | None,
+    output: Any,
+    *,
+    ok: bool = True,
+    name: str | None = None,
+    parameters: Any = None,
+    start_offset_ms: int | None = None,
+) -> None:
+    if span is None:
+        return
+    span.set_attribute("gen_ai.tool.call.result", _json_attr(output))
+    span.set_attribute("bluejay.speech.end_offset_ms", call_offset_ms())
+    if ok:
+        span.set_status(Status(StatusCode.OK))
+    else:
+        span.set_status(Status(StatusCode.ERROR, _json_attr(output)[:400]))
+    # tool_span ends the span on exit; this only fills attributes.
+
+
+def start_speech_span(
+    utterance_id: str, *, speaker: str = "agent", parent: Span | None = None
+) -> Span | None:
+    """Begin agent.speech or customer.speech as a direct child of voice.call."""
+    root = parent if parent is not None and parent.get_span_context().is_valid else _parent_span()
+    if root is None:
+        return None
+    tracer = otel_trace.get_tracer(TRACER_NAME)
+    parent_ctx = otel_trace.set_span_in_context(root)
+    is_customer = speaker in ("customer", "user", "digital_human")
+    span_name = "customer.speech" if is_customer else "agent.speech"
+    attrs: dict[str, Any] = {
+        "gen_ai.operation.name": (
+            "speech_to_text" if is_customer else "text_to_speech"
+        ),
+        "gen_ai.provider.name": PROVIDER,
+        "mivas.utterance_id": str(utterance_id),
+        "mivas.speech.speaker": "customer" if is_customer else "agent",
+        "bluejay.speech.start_offset_ms": call_offset_ms(),
+    }
+    span = tracer.start_span(
+        span_name,
+        context=parent_ctx,
+        kind=SpanKind.INTERNAL,
+        attributes=attrs,
+    )
+    return span
+
+
+def end_speech_span(span: Span | None) -> None:
+    if span is None:
+        return
+    span.set_attribute("bluejay.speech.end_offset_ms", call_offset_ms())
+    span.set_status(Status(StatusCode.OK))
+    span.end()
+
+
+async def _await_terminal_upsert(
+    client: httpx.AsyncClient, simulation_result_id: str, timeout: float = 300.0
+) -> str | None:
+    """Wait for a *final* status, then POST once.
+
+    Not TERMINAL_STATUSES (it counts EVALUATING) and not 18 s: posting mid-eval gets
+    trace_ids wiped, and the relink then re-extracts every execute_tool span on top of
+    the first POST's, so each tool lands twice. Eval needs ~175 s; CHIRP has no session
+    cap, so the wait is free.
+    """
+    deadline = time.monotonic() + timeout
+    key = _api_key()
+    if not key:
+        return None
+    while time.monotonic() < deadline:
+        try:
+            r = await client.get(
+                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                headers={"X-API-Key": key},
+            )
+            if r.status_code == 200:
+                st = str(
+                    ((r.json() or {}).get("simulation_result") or {}).get("status")
+                )
+                if st in FINAL_STATUSES:
+                    return st
+        except Exception:
+            pass
+        await asyncio.sleep(1.0)
+    return None
+
+
+async def post_simulation_enrichment(
+    simulation_result_id: str,
+    *,
+    trace_id: str | None,
+    tool_calls: list[dict[str, Any]] | None = None,
+) -> None:
+    """Link OTel trace_ids. tool_calls ignored — use execute_tool spans."""
+    del tool_calls
+    key = _api_key()
+    if not key or not simulation_result_id:
+        logger.warning(
+            "skip update-simulation-result — "
+            "simulation_result_id=%s key=%s",
+            simulation_result_id,
+            bool(key),
+        )
+        return
+    if not str(simulation_result_id).isdigit():
+        logger.warning(
+            "skip update-simulation-result — non-numeric sim id=%s",
+            simulation_result_id,
+        )
+        return
+
+    body: dict[str, Any] = {"simulation_result_id": str(simulation_result_id)}
+    if trace_id:
+        body["trace_ids"] = [trace_id]
+    if "trace_ids" not in body and "tool_calls" not in body:
+        logger.warning("skip update-simulation-result — nothing to post")
+        return
+
+    await asyncio.sleep(0.5)
+
+    last_err: str | None = None
+    for attempt in range(1, 4):
+        try:
+            async with httpx.AsyncClient(timeout=20) as client:
+                st = await _await_terminal_upsert(client, simulation_result_id)
+                if st is None:
+                    check = await client.get(
+                        f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                        headers={"X-API-Key": key},
+                    )
+                    if check.status_code == 404:
+                        logger.warning(
+                            "skip update-simulation-result — sim=%s not found",
+                            simulation_result_id,
+                        )
+                        return
+                r = await client.post(
+                    f"{_api_url()}/update-simulation-result",
+                    json=body,
+                    headers={"X-API-Key": key, "Content-Type": "application/json"},
+                )
+                if r.status_code >= 400:
+                    last_err = f"{r.status_code} {r.text[:300]} (status={st})"
+                    logger.error(
+                        "update-simulation-result FAILED attempt=%s %s",
+                        attempt,
+                        last_err,
+                    )
+                    if r.status_code == 404:
+                        return
+                else:
+                    logger.info(
+                        "update-simulation-result ok trace=%s sim=%s terminal=%s attempt=%s",
+                        trace_id,
+                        simulation_result_id,
+                        st,
+                        attempt,
+                    )
+                    if (st is None or st in EARLY_UPSERT_STATUSES) and trace_id:
+                        await _relink_after_final(
+                            client, simulation_result_id, body, key, trace_id, st
+                        )
+                    return
+        except Exception as e:
+            last_err = f"{type(e).__name__}: {e}"
+            logger.error(
+                "update-simulation-result error attempt=%s %s", attempt, last_err
+            )
+        await asyncio.sleep(1.0 * attempt)
+    logger.error("update-simulation-result gave up: %s", last_err)
+
+
+async def _relink_after_final(
+    client: httpx.AsyncClient,
+    simulation_result_id: str,
+    body: dict[str, Any],
+    key: str,
+    trace_id: str,
+    early_status: str | None,
+) -> None:
+    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link).
+
+    Only if it actually got wiped: each POST re-extracts the execute_tool spans and
+    appends them, so a redundant relink double-counts every tool on the timeline.
+    """
+    final: str | None = None
+    linked = False
+    deadline = time.monotonic() + 120.0
+    while time.monotonic() < deadline:
+        try:
+            r = await client.get(
+                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                headers={"X-API-Key": key},
+            )
+            if r.status_code == 200:
+                result = (r.json() or {}).get("simulation_result") or {}
+                st = str(result.get("status"))
+                if st in FINAL_STATUSES:
+                    final = st
+                    linked = trace_id in (result.get("trace_ids") or [])
+                    break
+        except Exception:
+            pass
+        await asyncio.sleep(2.0)
+    if final is not None and linked:
+        logger.info(
+            "relink not needed after %s — trace=%s still linked sim=%s final=%s",
+            early_status,
+            trace_id,
+            simulation_result_id,
+            final,
+        )
+        return
+    if final is None:
+        logger.warning(
+            "relink skipped — still not final after early upsert terminal=%s sim=%s",
+            early_status,
+            simulation_result_id,
+        )
+        return
+    r = await client.post(
+        f"{_api_url()}/update-simulation-result",
+        json=body,
+        headers={"X-API-Key": key, "Content-Type": "application/json"},
+    )
+    if r.status_code >= 400:
+        logger.error(
+            "relink after %s FAILED sim=%s %s %s",
+            early_status,
+            simulation_result_id,
+            r.status_code,
+            r.text[:300],
+        )
+    else:
+        logger.info(
+            "relink after %s ok trace=%s sim=%s final=%s",
+            early_status,
+            trace_id,
+            simulation_result_id,
+            final,
+        )
+
+
+# back-compat alias used by older call sites
+async def post_trace_ids(simulation_result_id: str, trace_id: str) -> None:
+    await post_simulation_enrichment(
+        simulation_result_id, trace_id=trace_id, tool_calls=_reported_tools.get()
+    )
+
+
+@asynccontextmanager
+async def traced_run(
+    workflow_name: str,
+    *,
+    simulation_result_id: str | None = None,
+    model: str | None = None,
+) -> AsyncIterator[Span | None]:
+    """OTel voice.call root; flush + link trace_ids/tool_calls on exit."""
+    global _active_root, _active_t0, _active_tools
+
+    provider = setup_otel()
+    if provider is None:
+        yield None
+        return
+
+    tracer = otel_trace.get_tracer(TRACER_NAME)
+    attrs: dict[str, Any] = {
+        "gen_ai.system": PROVIDER,
+        "gen_ai.provider.name": PROVIDER,
+        "gen_ai.operation.name": "invoke_agent",
+        "mivas.workflow.name": workflow_name,
+    }
+    if model:
+        attrs["gen_ai.request.model"] = model
+    if simulation_result_id:
+        attrs["bluejay.simulation_result_id"] = str(simulation_result_id)
+
+    otel_tid: str | None = None
+    root_token = None
+    tools_token = None
+    t0 = time.monotonic()
+    t0_token = _call_t0.set(t0)
+    tool_buf: list[dict[str, Any]] = []
+    prev_active = _active_root
+    prev_t0 = _active_t0
+    prev_tools = _active_tools
+    try:
+        with tracer.start_as_current_span(
+            "voice.call",
+            kind=SpanKind.SERVER,
+            attributes=attrs,
+        ) as root:
+            root_token = _root_span.set(root)
+            tools_token = _reported_tools.set(tool_buf)
+            _active_root = root
+            _active_t0 = t0
+            _active_tools = tool_buf
+            ctx = root.get_span_context()
+            if ctx.is_valid:
+                otel_tid = format(ctx.trace_id, "032x")
+                logger.info(
+                    "otel trace_id=%s sim=%s workflow=%s model=%s",
+                    otel_tid,
+                    simulation_result_id,
+                    workflow_name,
+                    model,
+                )
+            try:
+                yield root
+            except Exception as e:
+                if type(e).__name__.startswith("ConnectionClosed"):
+                    root.set_status(Status(StatusCode.OK))
+                else:
+                    raise
+    finally:
+        _active_root = prev_active
+        _active_t0 = prev_t0
+        _active_tools = prev_tools
+        if root_token is not None:
+            _root_span.reset(root_token)
+        if tools_token is not None:
+            _reported_tools.reset(tools_token)
+        _call_t0.reset(t0_token)
+        flush()
+        if simulation_result_id and (otel_tid or tool_buf):
+            try:
+                await post_simulation_enrichment(
+                    simulation_result_id,
+                    trace_id=otel_tid,
+                )
+            except Exception as e:
+                logger.error(
+                    "post_simulation_enrichment crashed: %s: %s",
+                    type(e).__name__,
+                    e,
+                )
+        elif simulation_result_id and not otel_tid:
+            logger.error(
+                "have simulation_result_id=%s but no otel trace id to post",
+                simulation_result_id,
+            )

--- a/voice-agent-harnesses/grok/voice/adapters/chirp.py
+++ b/voice-agent-harnesses/grok/voice/adapters/chirp.py
@@ -1,0 +1,837 @@
+"""CHIRP (16 kHz pcm_s16le) ↔ xAI Grok Voice (24 kHz PCM).
+
+Hard multi-agent: one Grok Realtime WS per blueprint agent; only the active
+agent receives input audio and has its output forwarded. Handoff rewires
+CHIRP audio to the target session and nudges it with bare `response.create`.
+
+Speak-first: after session.updated, send `{"type":"response.create"}`.
+
+Audio barge-in (critical):
+  Bluejay CHIRP `speech.started` often fires on *agent echo* in the mixed
+  recording path. Muting/cancelling on that signal hard-chops agent PCM
+  ("Hey," then silence) and starves Grok of the DH's full utterance.
+  Correct policy (matches OpenAI chirp + xAI docs):
+    - Always forward inbound DH PCM to Grok.
+    - Always forward agent PCM to Bluejay unless Grok itself reports
+      `input_audio_buffer.speech_started` (real user barge-in), or CHIRP
+      VAD fires *and* recent inbound RMS is loud *and* we are outside the
+      post-TTS echo-suppress window.
+    - Let Grok `server_vad` own turn-taking; do not fight it with CHIRP VAD.
+
+Observability: GROK_CHIRP_LOG=full|audio|off (default full). Periodic
+byte/RMS summaries + every mute/chop/speech event with reason.
+"""
+
+from __future__ import annotations
+
+import argparse
+import audioop
+import asyncio
+import base64
+import contextlib
+import json
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+from websockets.asyncio.server import serve
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from harness import (  # noqa: E402
+    END_CALL_CLOSE_DELAY_S,
+    MODEL,
+    SAMPLE_RATE,
+    configure_session,
+    connect_grok,
+    handle_function_call,
+    handoff_role,
+    handoff_seed_events,
+    industry_path,
+    infer_schedule_appointment,
+    load_blueprint,
+    nudge_greeting,
+    run_tool,
+    tool_names,
+    ws_url,
+)
+from report import end_speech_span, start_speech_span, traced_run  # noqa: E402
+
+W, R_GROK, R_CHIRP = 2, SAMPLE_RATE, 16_000
+
+# Ignore CHIRP speech.started while agent TTS was just loud (speaker echo → fake DH VAD).
+ECHO_SUPPRESS_S = float(os.environ.get("GROK_ECHO_SUPPRESS_S", "0.85"))
+# Inbound PCM must clear this RMS to count as a real barge-in (with CHIRP VAD).
+USER_RMS_ON = int(os.environ.get("GROK_USER_RMS_ON", "350"))
+USER_LIVE_S = float(os.environ.get("GROK_USER_LIVE_S", "0.35"))
+# Agent utterance ended under this duration after a mute → logged as CHOP.
+CHOP_WARN_MS = int(os.environ.get("GROK_CHOP_WARN_MS", "400"))
+
+_LOG_LEVEL = (os.environ.get("GROK_CHIRP_LOG") or "full").strip().lower()
+_LOG_ON = _LOG_LEVEL not in {"0", "off", "false", "no"}
+_LOG_AUDIO = _LOG_LEVEL in {"audio", "pcm", "all"}
+
+_call_t0: float | None = None
+
+
+def _ms() -> int:
+    if _call_t0 is None:
+        return 0
+    return int((time.monotonic() - _call_t0) * 1000)
+
+
+def _log(msg: str) -> None:
+    if _LOG_ON:
+        print(f"t+{_ms()}ms {msg}", flush=True)
+
+
+def _auth() -> str | None:
+    u, p = os.environ.get("CHIRP_USER", "").strip(), os.environ.get("CHIRP_PASS", "").strip()
+    return f"Basic {base64.b64encode(f'{u}:{p}'.encode()).decode()}" if u and p else None
+
+
+def _event(t: str, data: dict) -> str:
+    return json.dumps(
+        {"type": t, "id": str(uuid.uuid4()), "ts_ms": int(time.time() * 1000), "data": data},
+        separators=(",", ":"),
+    )
+
+
+def _eid() -> str:
+    return str(uuid.uuid4())
+
+
+def _simulation_result_id(ws) -> str | None:
+    headers = getattr(getattr(ws, "request", None), "headers", None)
+    if headers is None:
+        return None
+    val = headers.get("X-Simulation-Result-Id") or headers.get("x-simulation-result-id")
+    return str(val).strip() if val else None
+
+
+class _AudioStats:
+    """Per-call counters — printed on a timer and at call end."""
+
+    def __init__(self) -> None:
+        self.in_bytes = 0
+        self.in_frames = 0
+        self.in_peak_rms = 0
+        self.out_bytes = 0
+        self.out_frames = 0
+        self.out_peak_rms = 0
+        self.out_muted_bytes = 0
+        self.out_muted_frames = 0
+        self.chops = 0
+        self.echo_ignores = 0
+        self.barge_ins = 0
+        self.chirp_speech_starts = 0
+        self.grok_speech_starts = 0
+        self._last_summary = 0.0
+
+    def note_in(self, n: int, rms: int) -> None:
+        self.in_bytes += n
+        self.in_frames += 1
+        if rms > self.in_peak_rms:
+            self.in_peak_rms = rms
+
+    def note_out(self, n: int, rms: int, *, muted: bool) -> None:
+        if muted:
+            self.out_muted_bytes += n
+            self.out_muted_frames += 1
+        else:
+            self.out_bytes += n
+            self.out_frames += 1
+            if rms > self.out_peak_rms:
+                self.out_peak_rms = rms
+
+    def maybe_summary(self, *, force: bool = False) -> None:
+        now = time.monotonic()
+        if not force and now - self._last_summary < 2.0:
+            return
+        self._last_summary = now
+        _log(
+            "AUDIO "
+            f"in={self.in_bytes}B/{self.in_frames}f peak_rms={self.in_peak_rms} | "
+            f"out={self.out_bytes}B/{self.out_frames}f peak_rms={self.out_peak_rms} "
+            f"muted={self.out_muted_bytes}B/{self.out_muted_frames}f | "
+            f"chops={self.chops} barge={self.barge_ins} echo_ign={self.echo_ignores} "
+            f"chirp_vad={self.chirp_speech_starts} grok_vad={self.grok_speech_starts}"
+        )
+
+
+class _Turns:
+    """At most one open agent.speech and one customer.speech, both under voice.call."""
+
+    def __init__(self, ws, root, stats: _AudioStats) -> None:
+        self.ws = ws
+        self.root = root
+        self.stats = stats
+        self.agent_utt: str | None = None
+        self.agent_span = None
+        self.agent_text: list[str] = []
+        self.agent_started_mono: float | None = None
+        self.agent_out_bytes = 0
+        self.customer_utt: str | None = None
+        self.customer_span = None
+
+    async def start_agent(self) -> None:
+        if self.agent_utt is not None:
+            return
+        await self.end_customer()
+        self.agent_utt = f"u_{uuid.uuid4().hex[:12]}"
+        self.agent_text = []
+        self.agent_started_mono = time.monotonic()
+        self.agent_out_bytes = 0
+        self.agent_span = start_speech_span(
+            self.agent_utt, speaker="agent", parent=self.root
+        )
+        await self.ws.send(_event("speech.started", {"utterance_id": self.agent_utt}))
+        _log(f"agent.speech START uid={self.agent_utt}")
+
+    async def end_agent(self, *, why: str = "") -> None:
+        if self.agent_utt is None:
+            return
+        dur_ms = 0
+        if self.agent_started_mono is not None:
+            dur_ms = int((time.monotonic() - self.agent_started_mono) * 1000)
+        text = "".join(self.agent_text).strip()
+        if text and self.agent_span is not None:
+            with contextlib.suppress(Exception):
+                self.agent_span.set_attribute("mivas.transcript", text[:500])
+        chop = dur_ms < CHOP_WARN_MS and why.startswith("barge")
+        if chop:
+            self.stats.chops += 1
+        _log(
+            f"agent.speech END uid={self.agent_utt} why={why} "
+            f"dur_ms={dur_ms} out_bytes={self.agent_out_bytes} "
+            f"text={text[:80]!r}{' CHOP' if chop else ''}"
+        )
+        with contextlib.suppress(Exception):
+            await self.ws.send(
+                _event("speech.completed", {"utterance_id": self.agent_utt})
+            )
+        end_speech_span(self.agent_span)
+        self.agent_utt = None
+        self.agent_span = None
+        self.agent_text = []
+        self.agent_started_mono = None
+        self.agent_out_bytes = 0
+
+    def note_agent_text(self, delta: str) -> None:
+        if delta and self.agent_utt is not None:
+            self.agent_text.append(delta)
+
+    def note_agent_bytes(self, n: int) -> None:
+        self.agent_out_bytes += n
+
+    async def start_customer(self, uid: str, *, why: str = "") -> None:
+        # Tracing only — do NOT end agent audio here. Ending agent.speech for
+        # OTel must not imply we drop PCM (that was the hard-chop bug).
+        if self.customer_utt is not None:
+            end_speech_span(self.customer_span)
+        self.customer_utt = uid
+        self.customer_span = start_speech_span(
+            uid, speaker="customer", parent=self.root
+        )
+        _log(f"customer.speech START uid={uid} why={why}")
+
+    async def end_customer(self, *, why: str = "") -> None:
+        if self.customer_utt is None:
+            return
+        _log(f"customer.speech END uid={self.customer_utt} why={why}")
+        end_speech_span(self.customer_span)
+        self.customer_utt = None
+        self.customer_span = None
+
+    async def close(self) -> None:
+        await self.end_agent(why="close")
+        await self.end_customer(why="close")
+
+
+async def _open_sessions(bp: dict[str, Any], model: str) -> tuple[dict[str, Any], list[Any]]:
+    async def one(agent: str) -> tuple[str, Any, Any]:
+        cm = connect_grok(model)
+        grok = await cm.__aenter__()
+        try:
+            raw = await asyncio.wait_for(grok.recv(), timeout=60)
+            first = json.loads(raw) if isinstance(raw, str) else {}
+            _log(f"grok[{agent}] {first.get('type')}")
+            updated = await configure_session(grok, agent, bp)
+            n = len((updated.get("session") or {}).get("tools") or [])
+            _log(f"grok[{agent}] session.updated tools_registered={n}")
+        except Exception:
+            with contextlib.suppress(Exception):
+                await cm.__aexit__(None, None, None)
+            raise
+        return agent, grok, cm
+
+    results = await asyncio.gather(*(one(a) for a in bp["agents"]))
+    sessions = {name: grok for name, grok, _ in results}
+    cms = [cm for _, _, cm in results]
+    return sessions, cms
+
+
+async def _close_all(sessions: dict[str, Any], chirp_ws, end: asyncio.Event) -> None:
+    await asyncio.sleep(END_CALL_CLOSE_DELAY_S)
+    end.set()
+    for _name, grok in list(sessions.items()):
+        with contextlib.suppress(Exception):
+            await grok.close()
+    with contextlib.suppress(Exception):
+        await chirp_ws.close(1000)
+
+
+async def _bridge(ws, industry: str, model: str) -> None:
+    global _call_t0
+    _call_t0 = time.monotonic()
+    stats = _AudioStats()
+
+    bp = load_blueprint(industry)
+    state = {"agent": bp["start"]}
+    end = asyncio.Event()
+    industry_dir = industry_path(industry)
+    workflow = f"mivas-{Path(industry_dir).name}-{model}"
+    sim_id = _simulation_result_id(ws)
+    if sim_id:
+        _log(f"chirp sim_result_id={sim_id}")
+
+    _log(
+        f"grok ws={ws_url(model)} agents={list(bp['agents'])} start={bp['start']} "
+        f"echo_suppress={ECHO_SUPPRESS_S}s user_rms_on={USER_RMS_ON}"
+    )
+
+    sessions: dict[str, Any] = {}
+    session_cms: list[Any] = []
+    try:
+        async with traced_run(
+            workflow, simulation_result_id=sim_id, model=model
+        ) as otel_root:
+            state["_otel_root"] = otel_root
+            sessions, session_cms = await _open_sessions(bp, model)
+            turns = _Turns(ws, otel_root, stats)
+            ctl = {
+                "customer_speaking": False,  # CHIRP VAD (may be echo)
+                "grok_user_speaking": False,  # Grok server_vad — ground truth
+                "forward_agent": True,
+                "pending_fn": 0,
+                "need_continue": False,
+                "audio_done": True,
+                "response_active": False,
+                "last_agent_loud": 0.0,
+                "last_user_loud": 0.0,
+                "mute_why": "",
+                # Handoff context — last USER_ASR + agent transcript before switch.
+                "last_user_asr": "",
+                "last_spoken": "",
+            }
+            spoken: dict[str, list[str]] = {a: [] for a in sessions}
+
+            def active_ws():
+                return sessions[state["agent"]]
+
+            def _agent_echo_risk(now: float | None = None) -> bool:
+                now = now if now is not None else time.monotonic()
+                return bool(ctl["last_agent_loud"]) and (
+                    now - float(ctl["last_agent_loud"]) < ECHO_SUPPRESS_S
+                )
+
+            def _user_loud_recent(now: float | None = None) -> bool:
+                now = now if now is not None else time.monotonic()
+                return bool(ctl["last_user_loud"]) and (
+                    now - float(ctl["last_user_loud"]) < USER_LIVE_S
+                )
+
+            def _ctl_snap() -> str:
+                return (
+                    f"active={state['agent']} chirp_vad={ctl['customer_speaking']} "
+                    f"grok_vad={ctl['grok_user_speaking']} fwd={ctl['forward_agent']} "
+                    f"resp={ctl['response_active']} echo={_agent_echo_risk()} "
+                    f"user_loud={_user_loud_recent()} mute_why={ctl['mute_why']!r} "
+                    f"agent_utt={turns.agent_utt}"
+                )
+
+            async def _send_pcm24_to_active(pcm24: bytes) -> None:
+                if not pcm24 or end.is_set():
+                    return
+                await active_ws().send(
+                    json.dumps(
+                        {
+                            "type": "input_audio_buffer.append",
+                            "event_id": _eid(),
+                            "audio": base64.b64encode(pcm24).decode("ascii"),
+                        }
+                    )
+                )
+
+            async def _set_forward(forward: bool, *, why: str) -> None:
+                if ctl["forward_agent"] == forward and ctl["mute_why"] == (
+                    "" if forward else why
+                ):
+                    return
+                prev = ctl["forward_agent"]
+                ctl["forward_agent"] = forward
+                ctl["mute_why"] = "" if forward else why
+                _log(
+                    f"FORWARD {'ON' if forward else 'MUTE'} "
+                    f"prev={prev} why={why} {_ctl_snap()}"
+                )
+
+            async def _cancel_active(*, why: str) -> None:
+                if not ctl["response_active"]:
+                    _log(f"cancel SKIP (no active response) why={why}")
+                    return
+                ctl["response_active"] = False
+                _log(f"cancel SEND why={why} {_ctl_snap()}")
+                with contextlib.suppress(Exception):
+                    await active_ws().send(
+                        json.dumps({"type": "response.cancel", "event_id": _eid()})
+                    )
+
+            async def _on_real_barge_in(*, why: str) -> None:
+                """Confirmed user speech overlapping agent — mute + cancel."""
+                stats.barge_ins += 1
+                await _set_forward(False, why=why)
+                if turns.agent_utt is not None or ctl["response_active"]:
+                    await turns.end_agent(why=f"barge:{why}")
+                    await _cancel_active(why=why)
+
+            async def inbound() -> None:
+                up = None
+                try:
+                    async for msg in ws:
+                        if end.is_set():
+                            break
+                        if isinstance(msg, bytes) and msg:
+                            # ALWAYS forward DH PCM — never gate on agent speaking.
+                            # Grok server_vad decides turn boundaries from this stream.
+                            rms = audioop.rms(msg, W) if len(msg) >= W else 0
+                            stats.note_in(len(msg), rms)
+                            if rms >= USER_RMS_ON:
+                                ctl["last_user_loud"] = time.monotonic()
+                            pcm, up = audioop.ratecv(msg, W, 1, R_CHIRP, R_GROK, up)
+                            if pcm:
+                                await _send_pcm24_to_active(pcm)
+                                if _LOG_AUDIO:
+                                    _log(
+                                        f"user→grok bytes={len(pcm)} rms={rms} "
+                                        f"active={state['agent']}",
+                                    )
+                            stats.maybe_summary()
+                            continue
+                        if not isinstance(msg, str):
+                            continue
+                        try:
+                            event = json.loads(msg)
+                        except json.JSONDecodeError:
+                            continue
+                        etype = event.get("type")
+                        data = event.get("data") or {}
+                        if etype == "speech.started":
+                            stats.chirp_speech_starts += 1
+                            uid = data.get("utterance_id") or f"c_{uuid.uuid4().hex[:12]}"
+                            # Echo of our own TTS → Bluejay VAD. Trace only.
+                            if _agent_echo_risk() and not _user_loud_recent():
+                                stats.echo_ignores += 1
+                                _log(
+                                    f"CHIRP speech.started IGNORED echo uid={uid} "
+                                    f"{_ctl_snap()}"
+                                )
+                                await turns.start_customer(uid, why="chirp_echo_ignored")
+                                continue
+                            ctl["customer_speaking"] = True
+                            await turns.start_customer(uid, why="chirp_speech.started")
+                            # Only barge if inbound audio is actually loud — not echo.
+                            if _user_loud_recent() and (
+                                turns.agent_utt is not None or ctl["response_active"]
+                            ):
+                                await _on_real_barge_in(why="chirp_vad+user_rms")
+                            else:
+                                _log(
+                                    f"CHIRP speech.started trace-only uid={uid} "
+                                    f"{_ctl_snap()}"
+                                )
+                        elif etype == "speech.completed":
+                            ctl["customer_speaking"] = False
+                            _log(
+                                f"CHIRP speech.completed uid={data.get('utterance_id')} "
+                                f"{_ctl_snap()}"
+                            )
+                            await turns.end_customer(why="chirp_speech.completed")
+                            # If we muted on CHIRP VAD and Grok never confirmed user
+                            # speech, resume forwarding so we don't stick muted.
+                            if (
+                                not ctl["grok_user_speaking"]
+                                and not ctl["forward_agent"]
+                                and ctl["mute_why"].startswith("chirp_")
+                            ):
+                                await _set_forward(True, why="chirp_speech.completed")
+                finally:
+                    ctl["customer_speaking"] = False
+                    await turns.end_customer(why="inbound_exit")
+                    end.set()
+
+            handled_tools: set[str] = set()
+
+            async def _dispatch_tool(
+                *,
+                name: str,
+                arguments: str | dict,
+                call_id: str,
+                outgoing: str,
+                outgoing_ws,
+                notify_model: bool = True,
+                source: str = "fc",
+            ) -> None:
+                if not name:
+                    return
+                args_key = (
+                    json.dumps(arguments, sort_keys=True, separators=(",", ":"))
+                    if isinstance(arguments, dict)
+                    else str(arguments)
+                )
+                key = (
+                    f"{outgoing}:{name}:{args_key}"
+                    if name == "schedule_appointment"
+                    else f"{outgoing}:{name}:{args_key}:{call_id}"
+                )
+                if key in handled_tools:
+                    return
+                if name == "schedule_appointment" and any(
+                    k.startswith(f"{outgoing}:schedule_appointment:")
+                    for k in handled_tools
+                ):
+                    return
+                handled_tools.add(key)
+                if state["agent"] != outgoing:
+                    _log(f"grok[{outgoing}] ignore tool on inactive {name}")
+                    return
+                # Do not end_agent here in a way that implies audio chop — tool
+                # spans are siblings; close the speech span cleanly first.
+                if turns.agent_utt is not None:
+                    await turns.end_agent(why=f"tool:{name}")
+                ctl["pending_fn"] += 1
+                if notify_model:
+                    result, stop, reply = await handle_function_call(
+                        name, arguments, call_id, bp, state
+                    )
+                    with contextlib.suppress(Exception):
+                        await outgoing_ws.send(json.dumps(reply))
+                else:
+                    if isinstance(arguments, str):
+                        try:
+                            args = json.loads(arguments or "{}")
+                        except json.JSONDecodeError:
+                            args = {}
+                    else:
+                        args = dict(arguments or {})
+                    result, stop = await run_tool(
+                        name, args, bp, state, call_id=call_id
+                    )
+                ctl["pending_fn"] -= 1
+                _log(
+                    f"grok[{outgoing}] tool {name} -> {result.get('success')} "
+                    f"source={source}"
+                )
+                role = handoff_role(result, bp)
+                if role and role != outgoing:
+                    user_ctx = str(ctl.get("last_user_asr") or "")
+                    prior = str(ctl.get("last_spoken") or "")
+                    _log(
+                        f"grok handoff → {role} "
+                        f"user={user_ctx[:80]!r} prior={prior[:80]!r}"
+                    )
+                    ctl["need_continue"] = False
+                    await _set_forward(True, why="handoff")
+                    # Seed cold dual-session target with prior turns (OpenAI soft
+                    # handoff equivalent), then nudge — not a blank greeting.
+                    target = sessions[role]
+                    for ev in handoff_seed_events(
+                        user_said=user_ctx, prior_agent_said=prior
+                    ):
+                        with contextlib.suppress(Exception):
+                            await target.send(json.dumps(ev))
+                            _log(f"handoff seed → {role} role={ev['item']['role']}")
+                    with contextlib.suppress(Exception):
+                        await target.send(json.dumps(nudge_greeting()))
+                        _log(f"handoff nudge → {role}")
+                elif stop:
+                    asyncio.create_task(_close_all(sessions, ws, end))
+                else:
+                    ctl["need_continue"] = True
+                    if ctl["pending_fn"] == 0 and ctl["audio_done"]:
+                        ctl["need_continue"] = False
+                        with contextlib.suppress(Exception):
+                            await outgoing_ws.send(json.dumps(nudge_greeting()))
+
+            async def _maybe_infer_schedule(agent: str, transcript: str) -> None:
+                if agent != state["agent"]:
+                    return
+                if "schedule_appointment" not in tool_names(bp, agent):
+                    return
+                if any(
+                    k.startswith(f"{agent}:schedule_appointment:") for k in handled_tools
+                ):
+                    return
+                blob = " ".join(spoken.get(agent, [])[-6:] + [transcript]).strip()
+                args = infer_schedule_appointment(blob)
+                if not args:
+                    return
+                _log(
+                    f"grok[{agent}] infer schedule_appointment {args} "
+                    f"from={transcript[:80]!r}"
+                )
+                await _dispatch_tool(
+                    name="schedule_appointment",
+                    arguments=args,
+                    call_id=f"infer_{agent}_{_eid()[:8]}",
+                    outgoing=agent,
+                    outgoing_ws=sessions[agent],
+                    notify_model=False,
+                    source="infer",
+                )
+
+            async def _forward_agent_pcm(agent: str, pcm24: bytes, down_state):
+                """Resample 24k→16k and send to CHIRP unless muted."""
+                pcm16, down_state = audioop.ratecv(
+                    pcm24, W, 1, R_GROK, R_CHIRP, down_state
+                )
+                if not pcm16:
+                    return down_state
+                rms = audioop.rms(pcm16, W) if len(pcm16) >= W else 0
+                muted = not ctl["forward_agent"]
+                stats.note_out(len(pcm16), rms, muted=muted)
+                if muted:
+                    if _LOG_AUDIO:
+                        _log(
+                            f"agent→chirp DROP bytes={len(pcm16)} rms={rms} "
+                            f"why={ctl['mute_why']}"
+                        )
+                    return down_state
+                if rms >= 200:
+                    ctl["last_agent_loud"] = time.monotonic()
+                ctl["response_active"] = True
+                ctl["audio_done"] = False
+                if turns.agent_utt is None:
+                    await turns.start_agent()
+                turns.note_agent_bytes(len(pcm16))
+                await ws.send(pcm16)
+                if _LOG_AUDIO:
+                    _log(f"agent→chirp bytes={len(pcm16)} rms={rms}")
+                stats.maybe_summary()
+                return down_state
+
+            async def outbound_agent(agent: str) -> None:
+                grok = sessions[agent]
+                down = None
+                try:
+                    async for raw in grok:
+                        if end.is_set():
+                            break
+                        if isinstance(raw, bytes):
+                            if state["agent"] != agent:
+                                continue
+                            down = await _forward_agent_pcm(agent, raw, down)
+                            continue
+                        try:
+                            event = json.loads(raw)
+                        except json.JSONDecodeError:
+                            continue
+                        etype = event.get("type")
+                        is_active = state["agent"] == agent
+
+                        # Grok server_vad — authoritative barge-in signal (xAI docs).
+                        if etype == "input_audio_buffer.speech_started":
+                            if is_active:
+                                stats.grok_speech_starts += 1
+                                ctl["grok_user_speaking"] = True
+                                _log(f"grok VAD speech_started {_ctl_snap()}")
+                                await _on_real_barge_in(why="grok_vad")
+                            continue
+                        if etype == "input_audio_buffer.speech_stopped":
+                            if is_active:
+                                ctl["grok_user_speaking"] = False
+                                _log(f"grok VAD speech_stopped {_ctl_snap()}")
+                                await _set_forward(True, why="grok_vad_stopped")
+                            continue
+
+                        if etype in {
+                            "response.output_audio.delta",
+                            "response.audio.delta",
+                        }:
+                            if not is_active:
+                                continue
+                            # New agent audio after barge-in → resume unless Grok
+                            # still hears the user.
+                            if not ctl["forward_agent"] and not ctl["grok_user_speaking"]:
+                                await _set_forward(True, why="agent_audio_resume")
+                            b64 = event.get("delta") or event.get("audio") or ""
+                            if not b64:
+                                continue
+                            pcm24 = base64.b64decode(b64)
+                            down = await _forward_agent_pcm(agent, pcm24, down)
+
+                        elif etype in {
+                            "response.output_audio.done",
+                            "response.audio.done",
+                            "response.done",
+                        }:
+                            if is_active:
+                                await turns.end_agent(why=etype)
+                                ctl["audio_done"] = True
+                                ctl["response_active"] = False
+                                if (
+                                    ctl["need_continue"]
+                                    and ctl["pending_fn"] == 0
+                                    and not end.is_set()
+                                ):
+                                    ctl["need_continue"] = False
+                                    with contextlib.suppress(Exception):
+                                        await grok.send(json.dumps(nudge_greeting()))
+
+                        elif etype in {
+                            "response.output_audio_transcript.delta",
+                            "response.output_text.delta",
+                        }:
+                            if is_active:
+                                turns.note_agent_text(event.get("delta") or "")
+
+                        elif etype == "response.output_audio_transcript.done":
+                            if is_active:
+                                tr = (event.get("transcript") or "").strip()
+                                if tr:
+                                    _log(f"grok[{agent}] transcript={tr[:160]}")
+                                    spoken.setdefault(agent, []).append(tr)
+                                    ctl["last_spoken"] = tr
+                                    if tr not in "".join(turns.agent_text):
+                                        turns.note_agent_text(tr)
+                                    await _maybe_infer_schedule(agent, tr)
+
+                        elif etype in {
+                            "conversation.item.input_audio_transcription.completed",
+                            "conversation.item.input_audio_transcription.updated",
+                        }:
+                            # What Grok actually heard from the DH — gold signal for
+                            # "DH audio cut off before the model".
+                            if is_active:
+                                tr = (event.get("transcript") or "").strip()
+                                if tr and etype.endswith("completed"):
+                                    ctl["last_user_asr"] = tr
+                                tag = (
+                                    "USER_ASR"
+                                    if etype.endswith("completed")
+                                    else "USER_ASR_partial"
+                                )
+                                _log(
+                                    f"grok[{agent}] {tag}={tr[:200]!r} {_ctl_snap()}"
+                                )
+
+                        elif etype == "response.function_call_arguments.done":
+                            await _dispatch_tool(
+                                name=event.get("name", ""),
+                                arguments=event.get("arguments") or "{}",
+                                call_id=event.get("call_id") or _eid(),
+                                outgoing=agent,
+                                outgoing_ws=grok,
+                                source="fc",
+                            )
+
+                        elif etype == "error":
+                            err = (event.get("error") or {}).get("message") or event
+                            _log(f"grok[{agent}] error: {err}")
+                        elif etype == "session.end":
+                            _log(f"grok[{agent}] session.end")
+                            if is_active:
+                                end.set()
+                                break
+                        elif etype in {
+                            "response.created",
+                            "response.cancelled",
+                            "rate_limits.updated",
+                            "session.updated",
+                        }:
+                            if etype == "response.cancelled" and is_active:
+                                ctl["response_active"] = False
+                                _log(f"grok[{agent}] response.cancelled {_ctl_snap()}")
+                            elif etype == "response.created" and is_active:
+                                _log(f"grok[{agent}] response.created")
+                finally:
+                    if state["agent"] == agent:
+                        await turns.end_agent(why="outbound_exit")
+                        end.set()
+
+            await sessions[bp["start"]].send(json.dumps(nudge_greeting()))
+            _log(f"grok nudge_greeting → {bp['start']}")
+
+            tasks = [asyncio.create_task(inbound())] + [
+                asyncio.create_task(outbound_agent(a)) for a in sessions
+            ]
+            done, pending = await asyncio.wait(
+                tasks, return_when=asyncio.FIRST_COMPLETED
+            )
+            end.set()
+            await turns.close()
+            stats.maybe_summary(force=True)
+            _log(
+                f"CALL END chops={stats.chops} barge={stats.barge_ins} "
+                f"echo_ign={stats.echo_ignores} "
+                f"in={stats.in_bytes}B out={stats.out_bytes}B "
+                f"muted={stats.out_muted_bytes}B"
+            )
+            for t in pending:
+                t.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+            for t in done:
+                if t.cancelled():
+                    continue
+                exc = t.exception()
+                if isinstance(exc, BaseException) and not type(exc).__name__.startswith(
+                    "ConnectionClosed"
+                ):
+                    raise exc
+    finally:
+        for cm in reversed(session_cms):
+            with contextlib.suppress(Exception):
+                await cm.__aexit__(None, None, None)
+
+
+async def _handler(ws, industry: str, model: str) -> None:
+    expected = _auth()
+    if expected and ws.request.headers.get("Authorization") != expected:
+        await ws.close(1008, "unauthorized")
+        return
+    try:
+        await _bridge(ws, industry, model)
+    except Exception as e:
+        if type(e).__name__.startswith("ConnectionClosed"):
+            return
+        _log(f"chirp bridge error: {type(e).__name__}: {e}")
+        with contextlib.suppress(Exception):
+            await ws.close(1011, "bridge error")
+
+
+def main(model: str | None = None) -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--industry", default=os.environ.get("INDUSTRY", "control-industry"))
+    p.add_argument("--host", default=os.environ.get("CHIRP_HOST", "0.0.0.0"))
+    p.add_argument("--port", type=int, default=int(os.environ.get("CHIRP_PORT", "8768")))
+    p.add_argument("--model", default=model or os.environ.get("GROK_VOICE_MODEL", MODEL))
+    a = p.parse_args()
+    industry_path(a.industry)
+    print(
+        f"ws↔Grok {a.model} × {a.industry} chirp=:{a.port} "
+        f"upstream={ws_url(a.model)} auth={bool(_auth())} "
+        f"log={_LOG_LEVEL} echo_suppress={ECHO_SUPPRESS_S}s",
+        flush=True,
+    )
+
+    async def run() -> None:
+        async with serve(lambda ws: _handler(ws, a.industry, a.model), a.host, a.port):
+            await asyncio.Future()
+
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/voice-agent-harnesses/grok/voice/agent.py
+++ b/voice-agent-harnesses/grok/voice/agent.py
@@ -1,0 +1,49 @@
+"""Grok Voice harness — xAI Speech-to-Speech × industry agent_blueprint.json.
+
+family/runtime = grok/voice
+Docs: https://docs.x.ai/developers/model-capabilities/audio/voice-agent
+
+Multi-agent: one Grok Realtime session per blueprint agent (dual-session switch).
+Speak-first: bare `response.create` after session.updated (no greeting strings).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from harness import (  # noqa: E402
+    MODEL,
+    RUNTIME,
+    TOOL_SERVER_URL,
+    advertised_tools,
+    build_agents,
+    demo,
+    industry_path,
+    load_blueprint,
+    run_session,
+    tool_names,
+    tool_server_url,
+    ws_url,
+)
+
+
+if __name__ == "__main__":
+    industry = next((a for a in sys.argv[1:] if not a.startswith("-")), "control-industry")
+    industry_dir = Path(os.environ.get("INDUSTRY_DIR", str(industry_path(industry))))
+    if "--check" in sys.argv:
+        demo()
+        start, agents = build_agents(industry_dir)
+        bp = load_blueprint(industry_dir)
+        tools = advertised_tools(industry_dir)
+        per = {a: tool_names(bp, a) for a in bp["agents"]}
+        print(
+            f"ok {industry_dir.name} × {RUNTIME} model={MODEL} start={start} "
+            f"agents={agents} start_tools={tools} per_agent={per} "
+            f"ws={ws_url()} tool_server={tool_server_url() or TOOL_SERVER_URL}"
+        )
+    else:
+        asyncio.run(run_session(industry_dir))


### PR DESCRIPTION
## Summary
- Add `grok/voice` CHIRP harness (`harness.py`, `report.py`, 16 kHz↔24 kHz adapter) for xAI Grok Speech-to-Speech.
- Dual-session multi-agent with echo-safe barge-in, today-clock injection, booking-tool inference, and handoff context seeding so specialists don't cold-reask after transfer.
- Wire `GROK_API_KEY` / port `8768` into `.env.example` and pyright `extraPaths`.

## Test plan
- [ ] `uv run python run.py --harness grok/voice --mode check`
- [ ] Tool server + CHIRP on `8768` + cloudflared; update Bluejay agent websocket URL/creds
- [ ] Queue ≥3 control-industry booker runs; verify full greetings, post-handoff continuity, plausible appointment dates, and real `handoff_to_scheduler` + `schedule_appointment` tool actuals in transcripts


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `grok/voice` CHIRP harness to run xAI Grok Speech‑to‑Speech with Bluejay, including dual‑session multi‑agent handoffs and echo‑safe barge‑in. Also wires OpenTelemetry traces to Bluejay and exposes new env vars and a default `CHIRP_PORT=8768`.

- **New Features**
  - CHIRP bridge with 16 kHz↔24 kHz PCM adapter and speak‑first greeting (`response.create`).
  - Echo‑safe barge‑in: always forward DH audio; mute/cancel only on Grok VAD or confirmed user VAD.
  - Multi‑agent via one Grok WS per agent; handoff seeds context (last user/agent turns) and nudges target.
  - Tools: industry tools call `TOOL_SERVER_URL`; session tools end call; infers `schedule_appointment` from verbal confirmations when tool events are missing.
  - Tracing: emits `voice.call` root with `agent.speech`, `customer.speech`, and `execute_tool` spans; posts `trace_ids` to Bluejay with relink after final status.

- **Migration**
  - Set `GROK_API_KEY` (or `XAI_API_KEY`) and optional `GROK_VOICE_MODEL`, `GROK_VOICE`, `GROK_WS_URL`; set `CHIRP_USER`/`CHIRP_PASS` and `CHIRP_PORT=8768`.
  - Ensure `TOOL_SERVER_URL` is reachable; start the tool server for your industry.
  - For traces, set `BLUEJAY_API_KEY`, `BLUEJAY_OTLP_ENDPOINT`, and `BLUEJAY_SERVICE_NAME=mivas-grok`.
  - Quick check: `uv run python run.py --harness grok/voice --mode check`; run CHIRP mode and point Bluejay to `ws://<host>:8768`.

<sup>Written for commit 02370317eda52aa9dbb849a1764a78be4aa4c14e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/10?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

