### PR TITLE
make DB instances per call + separate tool servers and enable replica agents

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -139,6 +139,9 @@ PIPECAT_PRIVATE_API_KEY=
 MIVAS_BASE_DOMAIN=benchmarks.getbluejay.ai
 MIVAS_ACM_CERTIFICATE_ARN=arn:aws:acm:us-west-1:148660429236:certificate/6e3690bc-d776-40b0-8ca7-5741e648c5c8
 MIVAS_IMAGE_PREFIX=148660429236.dkr.ecr.us-west-1.amazonaws.com/mivas-bench
+# MIVAS_REPLICAS=1   # default 1. Proven pairs (openai × control, cartesia/line × control) use 3.
+#                    # max_concurrent ≈ replicas × in_process_ws_limit (start 2–4)
+#                    # Re-apply those pairs with MIVAS_REPLICAS=3 or they scale back to 1.
 #
 # Local / kind (no MIVAS_BASE_DOMAIN):
 # MIVAS_SERVICE_TYPE=LoadBalancer

--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ Thumbs.db
 
 # internal handoff docs, not shipped
 docs/
+graphify-out/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Pick a **harness** from `voice-agent-harnesses/` (e.g. `openai/realtime-2.1`) an
 - `tool_server.py` (FastAPI **state API** over SQLite — not a 1:1 tools.json mirror)
 
 The harness adapts the blueprint into a voice runtime:
-- **industry** tools → industry state API
+- **industry** tools → industry state API (`POST /tools/{name}` with `X-Mivas-Call-Id` = Bluejay `X-Simulation-Result-Id`; see [industries/README.md](industries/README.md) and [voice-agent-harnesses/README.md](voice-agent-harnesses/README.md))
 - **session** tools (`session: true`, e.g. `end_call`) → harness-native + hang up
 - **handoff** tools → provider handoffs
 
@@ -59,6 +59,27 @@ uv run python run.py --build --apply --no-logs
 ```
 
 `--build` with `MIVAS_IMAGE_PREFIX` builds `linux/arm64`, logs into ECR, and pushes. `--apply` creates IngressClassParams + one Ingress per pair; Auto Mode provisions **one** internet-facing ALB (`group.name: mivas-chirp`).
+
+`MIVAS_REPLICAS` (default `1`) sets `spec.replicas` on each pair’s **harness** Deployment. The industry tool server is a separate Deployment `mivas-{slug}-tools` with `MIVAS_TOOLS_REPLICAS=1` (ClusterIP only). Harness pods call `http://mivas-{slug}-tools:8000`. Capacity is:
+
+```
+max_concurrent ≈ replicas × in_process_ws_limit
+```
+
+`in_process_ws_limit` is empirical per family (start conservative: 2–4). Leave unused pairs at 1. Proven pairs (openai × control-industry, cartesia/line × control-industry) run at harness=3. Do not set `MIVAS_REPLICAS>1` on vapi/retell/bland until those families are live-proven. Re-apply a proven pair with `MIVAS_REPLICAS=3` or you will scale it back to 1 and drop in-flight sockets. See [docs/per-call-db-and-replicas.md](docs/per-call-db-and-replicas.md).
+
+Evals load a call’s final DB dump without knowing which harness pod ran it:
+
+```
+GET https://{slug}.{domain}/snapshot/{simulation_result_id}
+GET https://{slug}.{domain}/state?call_id={simulation_result_id}
+```
+
+Ingress sends `/snapshot` and `/state` to the tools Service. `/snapshot/{id}` is the teardown freeze; `/state` is live SQLite.
+
+Rolling updates use `maxUnavailable: 0` / `maxSurge: 1`. An in-flight WebSocket **dies** if its pod is deleted; scale by adding replicas rather than cycling them mid-run. New dials use ALB `least_outstanding_requests`; an upgraded socket stays on that target for the TCP lifetime (idle timeout 3600s). Cookie stickiness is not used.
+
+
 
 **Cloudflare (two records, both DNS-only / grey cloud — never orange-cloud proxy):**
 

--- a/industries/README.md
+++ b/industries/README.md
@@ -12,3 +12,36 @@ Industry-specific voice agent benchmarks for MIVAS.
 | `travel` | Travel pack | see pack README |
 
 Each pack owns `agent_blueprint.json`, `tools.json`, system prompts, SQLite `db/`, and a FastAPI `tool_server.py` state API.
+
+## Per-call database contract
+
+Harnesses POST industry tools to `POST /tools/{name}` with
+`X-Mivas-Call-Id: <Bluejay simulation result id>`. `DBService` (shared
+runtime module) is the only code that picks a SQLite file:
+
+- **Id:** Bluejay `X-Simulation-Result-Id` (e.g. `675`). Not a Vapi/Retell call id.
+- **Header:** `X-Mivas-Call-Id`. Query alias `?call_id=` on `GET /state` and domain REST routes.
+- **First touch:** if `{MIVAS_DB_PATH.parent}/calls/{id}.db` is missing, copy `db/schema.sql` then `db/seed.sql` into that file.
+- **Later tools:** open the existing file. API handlers keep `with _db() as conn: conn.execute(...)` — they never choose a path or call `init_db()`.
+- **Miss:** `POST /tools/*` without the header is **400**. `MIVAS_DB_SHARED=1` (local `--check` / converse) is the only shared-DB fallback.
+- **`GET /health`:** global, no id.
+- **`GET /state`:** scoped to the header / `?call_id=` so evals compare that call’s
+  **final** dump to the **initial** seed (`schema.sql` + `seed.sql`). A call that
+  never invoked a tool still has a defined initial state: first `GET /state` for
+  that id lazy-creates the file from seed. Missing id is **400** unless
+  `MIVAS_DB_SHARED=1`.
+
+```bash
+# final dump for simulation result 675 (header or query alias)
+curl -s http://127.0.0.1:8000/state -H 'X-Mivas-Call-Id: 675'
+curl -s 'http://127.0.0.1:8000/state?call_id=675'
+# never-touched id → seed only
+curl -s 'http://127.0.0.1:8000/state?call_id=676'
+# frozen dump written at CHIRP teardown (eval path when replicas > 1)
+curl -s http://127.0.0.1:8000/snapshot/675
+```
+
+On EKS, Ingress sends `/state` and `/snapshot` to the tools Service (one writer),
+not a random CHIRP replica. Evals should prefer `GET /snapshot/{id}` so they
+read the teardown freeze even if the SQLite file is later mutated or the
+harness pod is gone.

--- a/industries/control-industry/README.md
+++ b/industries/control-industry/README.md
@@ -18,7 +18,7 @@ This industry does **not** mirror how customers build voice agents. It is a cont
 
 ## Expected outcome
 
-Your agent schedules a generic repair appointment, and evaluations show database state reflecting a scheduled appointment (`GET /state` on the state API).
+Your agent schedules a generic repair appointment, and evaluations show database state reflecting a scheduled appointment (`GET /state?call_id=<simulation_result_id>` on the state API). A never-touched id dumps seed (empty appointments).
 
 ## DB + state API
 
@@ -39,6 +39,7 @@ Harness tool kinds:
 
 ```bash
 uv run python tool_server.py
-# curl -X POST http://127.0.0.1:8000/appointments -H 'content-type: application/json' -d '{"date":"08/07/2026"}'
-# curl http://127.0.0.1:8000/state
+# curl -X POST http://127.0.0.1:8000/appointments -H 'content-type: application/json' \
+#   -H 'X-Mivas-Call-Id: 675' -d '{"date":"08/07/2026"}'
+# curl -s 'http://127.0.0.1:8000/state?call_id=675'
 ```

--- a/industries/control-industry/tool_server.py
+++ b/industries/control-industry/tool_server.py
@@ -8,8 +8,8 @@ GET /health). Session tools (end_call) and handoff tools never hit this server.
 from __future__ import annotations
 
 import os
-import sqlite3
-from contextlib import asynccontextmanager, contextmanager
+import sys
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
@@ -17,45 +17,26 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
 INDUSTRY_DIR = Path(__file__).resolve().parent
-DB_DIR = INDUSTRY_DIR / "db"
-SCHEMA_PATH = DB_DIR / "schema.sql"
-SEED_PATH = DB_DIR / "seed.sql"
-DB_PATH = Path(os.environ.get("MIVAS_DB_PATH", str(DB_DIR / "runtime.db")))
 
+for _runtime in (Path("/app/runtime"), Path(__file__).resolve().parents[2] / "runtime"):
+    if (_runtime / "db_service.py").is_file():
+        if str(_runtime) not in sys.path:
+            sys.path.insert(0, str(_runtime))
+        break
+from db_service import DBService  # noqa: E402
 
-def init_db() -> None:
-    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
-    if DB_PATH.exists():
-        DB_PATH.unlink()
-    conn = sqlite3.connect(DB_PATH)
-    try:
-        conn.executescript(SCHEMA_PATH.read_text())
-        seed = SEED_PATH.read_text().strip()
-        if seed:
-            conn.executescript(seed)
-        conn.commit()
-    finally:
-        conn.close()
+db = DBService.for_industry(INDUSTRY_DIR)
 
 
 @contextmanager
 def _db() -> Any:
-    conn = sqlite3.connect(DB_PATH)
-    conn.row_factory = sqlite3.Row
-    try:
+    with db.connect() as conn:
         yield conn
-        conn.commit()
-    finally:
-        conn.close()
 
 
-@asynccontextmanager
-async def lifespan(_app: FastAPI):
-    init_db()
-    yield
-
-
-app = FastAPI(title="control-industry state API", lifespan=lifespan)
+app = FastAPI(title="control-industry state API")
+app.middleware("http")(db.http_middleware)
+db.mount_cluster_routes(app)
 
 
 class AppointmentCreate(BaseModel):

--- a/industries/finance/README.md
+++ b/industries/finance/README.md
@@ -117,8 +117,9 @@ the transcript and tool sequence.
 ```bash
 uv run python industries/finance/tool_server.py
 # curl -X POST http://127.0.0.1:8000/tools/get_fee \
-#   -H 'content-type: application/json' -d '{"arguments":{"fee":"overdraft"}}'
-# curl http://127.0.0.1:8000/state
+#   -H 'content-type: application/json' -H 'X-Mivas-Call-Id: 675' \
+#   -d '{"arguments":{"fee":"overdraft"}}'
+# curl -s 'http://127.0.0.1:8000/state?call_id=675'
 
 uv run python industries/finance/tool_server.py --selfcheck   # every trap, fresh DB
 ```

--- a/industries/finance/tool_server.py
+++ b/industries/finance/tool_server.py
@@ -31,7 +31,7 @@ import os
 import re
 import sqlite3
 import sys
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -42,10 +42,15 @@ from pydantic import BaseModel, Field
 logger = logging.getLogger("finance.tool_server")
 
 INDUSTRY_DIR = Path(__file__).resolve().parent
-DB_DIR = INDUSTRY_DIR / "db"
-SCHEMA_PATH = DB_DIR / "schema.sql"
-SEED_PATH = DB_DIR / "seed.sql"
-DB_PATH = Path(os.environ.get("MIVAS_DB_PATH", str(DB_DIR / "runtime.db")))
+
+for _runtime in (Path("/app/runtime"), Path(__file__).resolve().parents[2] / "runtime"):
+    if (_runtime / "db_service.py").is_file():
+        if str(_runtime) not in sys.path:
+            sys.path.insert(0, str(_runtime))
+        break
+from db_service import DBService  # noqa: E402
+
+db = DBService.for_industry(INDUSTRY_DIR)
 
 # Fixed "now" so dispute-window and waiver math is deterministic across runs.
 TODAY = "2026-08-01"
@@ -115,39 +120,18 @@ ESCALATION_REASONS = {
 
 
 def init_db() -> None:
-    _session.clear()  # dispatch identity pin follows the DB lifecycle
-    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
-    if DB_PATH.exists():
-        DB_PATH.unlink()
-    conn = sqlite3.connect(DB_PATH)
-    try:
-        conn.executescript(SCHEMA_PATH.read_text())
-        seed = SEED_PATH.read_text().strip()
-        if seed:
-            conn.executescript(seed)
-        conn.commit()
-    finally:
-        conn.close()
+    _sessions.clear()
 
 
 @contextmanager
 def _db() -> Any:
-    conn = sqlite3.connect(DB_PATH)
-    conn.row_factory = sqlite3.Row
-    try:
+    with db.connect() as conn:
         yield conn
-        conn.commit()
-    finally:
-        conn.close()
 
 
-@asynccontextmanager
-async def lifespan(_app: FastAPI):
-    init_db()
-    yield
-
-
-app = FastAPI(title="finance state API", lifespan=lifespan)
+app = FastAPI(title="finance state API")
+app.middleware("http")(db.http_middleware)
+db.mount_cluster_routes(app)
 
 
 # ------------------------------------------------------------------ matching
@@ -196,9 +180,12 @@ def _parse_date(value: str) -> datetime:
 
 # ------------------------------------------------------------------ session + errors
 
-# ponytail: module-level session, one call at a time (benchmark runs are
-# max_concurrent=1); key by call id if that ever changes.
-_session: dict[str, Any] = {}
+# Identity pin per call id (empty key = shared/no-header session).
+_sessions: dict[str, dict[str, Any]] = {}
+
+
+def _session() -> dict[str, Any]:
+    return _sessions.setdefault(db.current_call_id() or "", {})
 
 
 class ToolError(Exception):
@@ -208,8 +195,8 @@ class ToolError(Exception):
 
 
 def _member() -> sqlite3.Row:
-    mid = _session.get("member_id")
-    if not mid or not _session.get("verified"):
+    mid = _session().get("member_id")
+    if not mid or not _session().get("verified"):
         raise ToolError("IDENTITY_NOT_VERIFIED",
                         "Verify the caller's identity first — name and phone, then "
                         "date of birth and the last four of the member number.")
@@ -419,12 +406,12 @@ def identify_member(a: dict[str, Any]) -> dict[str, Any]:
         if _name_close(row["name"], name) and (
             row["phone"] == ph or (len(ph) >= 4 and row["phone"][-4:] == ph[-4:])
         ):
-            _session.update(member_id=row["id"], verified=False, verify_failures=0)
+            _session().update(member_id=row["id"], verified=False, verify_failures=0)
             return {"record_found": True,
                     "next": "Verify with date of birth and the last four of the "
                             "member number before any account information."}
-    _session.pop("member_id", None)
-    _session["verified"] = False
+    _session().pop("member_id", None)
+    _session()["verified"] = False
     return {"record_found": False,
             "note": "No record matched. Do not say whether anyone banks at "
                     "Copperline. Re-ask the name and number once; after a second "
@@ -432,11 +419,11 @@ def identify_member(a: dict[str, Any]) -> dict[str, Any]:
 
 
 def verify_identity(a: dict[str, Any]) -> dict[str, Any]:
-    mid = _session.get("member_id")
+    mid = _session().get("member_id")
     if not mid:
         raise ToolError("NO_CANDIDATE",
                         "Call identify_member first with the caller's name and phone.")
-    if _session.get("verify_failures", 0) >= 2:
+    if _session().get("verify_failures", 0) >= 2:
         raise ToolError("VERIFICATION_FAILED",
                         "Verification has failed twice. Do not keep trying — escalate "
                         "with reason identity_failed.")
@@ -445,11 +432,11 @@ def verify_identity(a: dict[str, Any]) -> dict[str, Any]:
     with _db() as conn:
         row = conn.execute("SELECT * FROM members WHERE id = ?", (mid,)).fetchone()
     if row and row["dob"] == dob and row["member_number_last4"] == last4:
-        _session.update(verified=True, verify_failures=0)
+        _session().update(verified=True, verify_failures=0)
         return {"verified": True, "member_first_name": row["name"].split(" ")[0],
                 "member_since": row["member_since"]}
-    _session["verify_failures"] = _session.get("verify_failures", 0) + 1
-    remaining = 2 - _session["verify_failures"]
+    _session()["verify_failures"] = _session().get("verify_failures", 0) + 1
+    remaining = 2 - _session()["verify_failures"]
     raise ToolError("VERIFICATION_MISMATCH",
                     "That didn't match what's on file. "
                     + ("Ask them to double-check and try once more."
@@ -973,7 +960,7 @@ def escalate_to_human(a: dict[str, Any]) -> dict[str, Any]:
     with _db() as conn:
         cur = conn.execute(
             "INSERT INTO escalations (member_id, reason_code) VALUES (?, ?)",
-            (_session.get("member_id") or "", reason))
+            (_session().get("member_id") or "", reason))
     return {"escalation_id": cur.lastrowid, "transferred": True, "reason_code": reason}
 
 
@@ -1066,6 +1053,12 @@ def dispatch_tool(tool_name: str, body: ToolCall) -> dict[str, Any]:
 
 def selfcheck() -> None:
     """Every server-enforced guard, asserted against a fresh DB."""
+    with db.scope("selfcheck"):
+        _selfcheck()
+
+
+def _selfcheck() -> None:
+    """Every server-enforced guard, asserted against a fresh DB."""
     init_db()
 
     def err(fn, args) -> ToolError:
@@ -1076,12 +1069,12 @@ def selfcheck() -> None:
         raise AssertionError(f"{fn.__name__} should have raised")
 
     def login(name: str, phone: str, dob: str, last4: str) -> None:
-        _session.clear()
+        _session().clear()
         assert identify_member({"full_name": name, "phone": phone})["record_found"]
         assert verify_identity({"dob": dob, "member_number_last4": last4})["verified"]
 
     # identity gate closed, then open
-    _session.clear()
+    _session().clear()
     assert err(get_member_summary, {}).code == "IDENTITY_NOT_VERIFIED"
     assert identify_member({"full_name": "Marisol Vegga", "phone": "0142"})["record_found"]
     assert err(get_balance, {"account": "checking"}).code == "IDENTITY_NOT_VERIFIED"
@@ -1093,7 +1086,7 @@ def selfcheck() -> None:
     assert "member_number" not in json.dumps(summary), "no full identifiers in summary"
 
     # two failures then hard stop
-    _session.clear()
+    _session().clear()
     identify_member({"full_name": "Ray Delgado", "phone": "4845550117"})
     for _ in range(2):
         err(verify_identity, {"dob": "1979-01-01", "member_number_last4": "0000"})
@@ -1101,7 +1094,7 @@ def selfcheck() -> None:
                ).code == "VERIFICATION_FAILED"
 
     # unknown caller: no record, nothing disclosed
-    _session.clear()
+    _session().clear()
     assert identify_member({"full_name": "Nobody Realman",
                             "phone": "9995550000"})["record_found"] is False
 

--- a/industries/healthcare/README.md
+++ b/industries/healthcare/README.md
@@ -48,7 +48,8 @@ Harness tool kinds:
 
 ```bash
 uv run python tool_server.py
-# curl http://127.0.0.1:8000/state
+# curl http://127.0.0.1:8000/state?call_id=675
 # curl -X POST http://127.0.0.1:8000/appointments -H 'content-type: application/json' \
+#   -H 'X-Mivas-Call-Id: 675' \
 #   -d '{"location_id":"loc_park_ave","provider_id":"prov_chen","appointment_type_code":"MED_NEW","start":"2026-09-01T09:00:00","end":"2026-09-01T09:30:00","description":"New patient visit"}'
 ```

--- a/industries/healthcare/tool_server.py
+++ b/industries/healthcare/tool_server.py
@@ -16,90 +16,36 @@ import json
 import logging
 import os
 import re
-import shutil
 import sqlite3
-import threading
-from contextlib import asynccontextmanager, contextmanager
-from contextvars import ContextVar
+import sys
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
-from fastapi import FastAPI, Header, HTTPException
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
 INDUSTRY_DIR = Path(__file__).resolve().parent
-DB_DIR = INDUSTRY_DIR / "db"
-SCHEMA_PATH = DB_DIR / "schema.sql"
-SEED_PATH = DB_DIR / "seed.sql"
-DB_PATH = Path(os.environ.get("MIVAS_DB_PATH", str(DB_DIR / "runtime.db")))
-# One SQLite file + one identity pin per concurrent call, so a simulation run at
-# max_concurrent > 1 can't leak a verified patient, a balance, a verify-failure
-# count or an appointment row from one caller into another.
-CALLS_DIR = DB_PATH.parent / "calls"
 
-# Set from the X-Mivas-Call-Id header on POST /tools/{name}. Empty = the shared
-# DB, which is what the REST routes and every harness that doesn't send the
-# header still use.
-_call_id: ContextVar[str] = ContextVar("mivas_call_id", default="")
-_db_create_lock = threading.Lock()
+for _runtime in (Path("/app/runtime"), Path(__file__).resolve().parents[2] / "runtime"):
+    if (_runtime / "db_service.py").is_file():
+        if str(_runtime) not in sys.path:
+            sys.path.insert(0, str(_runtime))
+        break
+from db_service import DBService  # noqa: E402
 
-
-def _write_fixture_db(path: Path) -> None:
-    conn = sqlite3.connect(path)
-    try:
-        conn.executescript(SCHEMA_PATH.read_text())
-        seed = SEED_PATH.read_text().strip()
-        if seed:
-            conn.executescript(seed)
-        conn.commit()
-    finally:
-        conn.close()
-
-
-def init_db() -> None:
-    _sessions.clear()  # dispatch identity pins follow the DB lifecycle
-    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
-    if DB_PATH.exists():
-        DB_PATH.unlink()
-    # ponytail: per-call DBs are wiped at boot, not per call — they are a few KB
-    # each and a run is bounded. Drop them on end_call if that stops holding.
-    shutil.rmtree(CALLS_DIR, ignore_errors=True)
-    _write_fixture_db(DB_PATH)
-
-
-def _call_db_path(call_id: str) -> Path:
-    path = CALLS_DIR / f"{call_id}.db"
-    if not path.exists():
-        with _db_create_lock:
-            if not path.exists():
-                CALLS_DIR.mkdir(parents=True, exist_ok=True)
-                _write_fixture_db(path)
-    return path
-
-
-def _active_db_path() -> Path:
-    call_id = _call_id.get()
-    return _call_db_path(call_id) if call_id else DB_PATH
+db = DBService.for_industry(INDUSTRY_DIR)
 
 
 @contextmanager
 def _db() -> Any:
-    conn = sqlite3.connect(_active_db_path())
-    conn.row_factory = sqlite3.Row
-    try:
+    with db.connect() as conn:
         yield conn
-        conn.commit()
-    finally:
-        conn.close()
 
 
-@asynccontextmanager
-async def lifespan(_app: FastAPI):
-    init_db()
-    yield
-
-
-app = FastAPI(title="healthcare state API", lifespan=lifespan)
+app = FastAPI(title="healthcare state API")
+app.middleware("http")(db.http_middleware)
+db.mount_cluster_routes(app)
 
 logger = logging.getLogger(__name__)
 
@@ -332,7 +278,7 @@ _sessions: dict[str, dict[str, Any]] = {}
 
 
 def _session_state() -> dict[str, Any]:
-    return _sessions.setdefault(_call_id.get(), {})
+    return _sessions.setdefault(db.current_call_id() or "", {})
 
 
 class ToolError(Exception):
@@ -1168,20 +1114,8 @@ class ToolCall(BaseModel):
     arguments: dict[str, Any] = Field(default_factory=dict)
 
 
-_CALL_ID_SAFE = re.compile(r"[^A-Za-z0-9_-]")
-
-
-def _normalise_call_id(raw: str | None) -> str:
-    """Header → filesystem-safe key. Empty means "use the shared DB"."""
-    return _CALL_ID_SAFE.sub("_", str(raw or "").strip())[:64]
-
-
 @app.post("/tools/{tool_name}")
-def dispatch_tool(
-    tool_name: str,
-    body: ToolCall,
-    x_mivas_call_id: str | None = Header(default=None),
-) -> dict[str, Any]:
+def dispatch_tool(tool_name: str, body: ToolCall) -> dict[str, Any]:
     handler = DISPATCH.get(tool_name)
     if handler is None:
         raise HTTPException(
@@ -1189,7 +1123,6 @@ def dispatch_tool(
             detail=f"unknown tool {tool_name!r} — session and handoff tools are "
             "harness-native and industry tools must be listed in DISPATCH",
         )
-    token = _call_id.set(_normalise_call_id(x_mivas_call_id))
     try:
         data = handler(dict(body.arguments or {}))
         return {"ok": True, "data": data, "error_code": None, "patient_safe_message": None}
@@ -1206,8 +1139,6 @@ def dispatch_tool(
         return {"ok": False, "data": None, "error_code": "INVALID_ARGUMENTS",
                 "patient_safe_message": "Something went wrong handling that request. "
                 "Please try again or ask for a callback."}
-    finally:
-        _call_id.reset(token)
 
 
 if __name__ == "__main__":

--- a/industries/legal/README.md
+++ b/industries/legal/README.md
@@ -60,9 +60,10 @@ Harness tool kinds:
 ```bash
 uv run python tool_server.py
 # curl -X POST http://127.0.0.1:8000/callers -H 'content-type: application/json' \
+#   -H 'X-Mivas-Call-Id: 675' \
 #   -d '{"full_name":"Dana Whitfield","phone":"(510) 555-0142"}'
-# curl 'http://127.0.0.1:8000/conflicts?opposing_party=Vertex%20Logistics'
-# curl http://127.0.0.1:8000/state
+# curl 'http://127.0.0.1:8000/conflicts?opposing_party=Vertex%20Logistics&call_id=675'
+# curl -s 'http://127.0.0.1:8000/state?call_id=675'
 
 uv run python tool_server.py --selfcheck   # every trap, against a fresh DB
 ```

--- a/industries/legal/tool_server.py
+++ b/industries/legal/tool_server.py
@@ -22,7 +22,7 @@ import os
 import re
 import sqlite3
 import sys
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import contextmanager
 from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -31,10 +31,15 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
 INDUSTRY_DIR = Path(__file__).resolve().parent
-DB_DIR = INDUSTRY_DIR / "db"
-SCHEMA_PATH = DB_DIR / "schema.sql"
-SEED_PATH = DB_DIR / "seed.sql"
-DB_PATH = Path(os.environ.get("MIVAS_DB_PATH", str(DB_DIR / "runtime.db")))
+
+for _runtime in (Path("/app/runtime"), Path(__file__).resolve().parents[2] / "runtime"):
+    if (_runtime / "db_service.py").is_file():
+        if str(_runtime) not in sys.path:
+            sys.path.insert(0, str(_runtime))
+        break
+from db_service import DBService  # noqa: E402
+
+db = DBService.for_industry(INDUSTRY_DIR)
 
 # Fixed "now" so deadline math is deterministic across runs.
 TODAY = "2026-08-01"
@@ -59,39 +64,18 @@ PRACTICE_AREA_ALIASES = {
 
 
 def init_db() -> None:
-    _session.clear()  # dispatch caller pin follows the DB lifecycle
-    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
-    if DB_PATH.exists():
-        DB_PATH.unlink()
-    conn = sqlite3.connect(DB_PATH)
-    try:
-        conn.executescript(SCHEMA_PATH.read_text())
-        seed = SEED_PATH.read_text().strip()
-        if seed:
-            conn.executescript(seed)
-        conn.commit()
-    finally:
-        conn.close()
+    _sessions.clear()
 
 
 @contextmanager
 def _db() -> Any:
-    conn = sqlite3.connect(DB_PATH)
-    conn.row_factory = sqlite3.Row
-    try:
+    with db.connect() as conn:
         yield conn
-        conn.commit()
-    finally:
-        conn.close()
 
 
-@asynccontextmanager
-async def lifespan(_app: FastAPI):
-    init_db()
-    yield
-
-
-app = FastAPI(title="legal state API", lifespan=lifespan)
+app = FastAPI(title="legal state API")
+app.middleware("http")(db.http_middleware)
+db.mount_cluster_routes(app)
 
 
 # ------------------------------------------------------------------ matching
@@ -528,14 +512,16 @@ def escalate_to_human(body: EscalationCreate) -> dict[str, Any]:
 # {"ok": bool, "data": ..., "error_code": str|null, "caller_safe_message": str|null}.
 # Session (end_call) and handoff (transfer_to_*) tools never land here → 404.
 
-# tools.json industry tools carry no caller_id — lookup_caller pins the caller
-# for the rest of the call. ponytail: module-level session, one call at a time
-# (benchmark runs are max_concurrent=1); key by call id if that ever changes.
-_session: dict[str, str] = {}
+# Caller pin per call id (empty key = shared/no-header session).
+_sessions: dict[str, dict[str, str]] = {}
+
+
+def _session() -> dict[str, str]:
+    return _sessions.setdefault(db.current_call_id() or "", {})
 
 
 def _cid() -> str:
-    caller_id = _session.get("caller_id")
+    caller_id = _session().get("caller_id")
     if not caller_id:
         raise HTTPException(status_code=400, detail="Identify the caller first.")
     return caller_id
@@ -543,7 +529,7 @@ def _cid() -> str:
 
 def _d_lookup_caller(a: dict[str, Any]) -> dict[str, Any]:
     result = lookup_caller(CallerLookup(**a))
-    _session["caller_id"] = result["caller_id"]
+    _session()["caller_id"] = result["caller_id"]
     return result
 
 
@@ -615,6 +601,12 @@ def dispatch_tool(tool_name: str, body: ToolCall) -> dict[str, Any]:
 # ------------------------------------------------------------------ selfcheck
 
 def selfcheck() -> None:
+    """Every trap the port had to preserve, asserted against a fresh DB."""
+    with db.scope("selfcheck"):
+        _selfcheck()
+
+
+def _selfcheck() -> None:
     """Every trap the port had to preserve, asserted against a fresh DB."""
     init_db()
 

--- a/industries/travel/README.md
+++ b/industries/travel/README.md
@@ -74,9 +74,10 @@ Harness tool kinds:
 ```bash
 uv run python tool_server.py
 # curl -X POST http://127.0.0.1:8000/reservations/find -H 'content-type: application/json' \
+#   -H 'X-Mivas-Call-Id: 675' \
 #   -d '{"last_name":"Sollberg","confirmation_code":"RT2LKD"}'
-# curl http://127.0.0.1:8000/reservations/RT2LKD/fare-rules
-# curl http://127.0.0.1:8000/state
+# curl 'http://127.0.0.1:8000/reservations/RT2LKD/fare-rules?call_id=675'
+# curl -s 'http://127.0.0.1:8000/state?call_id=675'
 
 uv run python tool_server.py --selfcheck   # every trap, against a fresh DB
 ```

--- a/industries/travel/tool_server.py
+++ b/industries/travel/tool_server.py
@@ -25,7 +25,7 @@ import os
 import re
 import sqlite3
 import sys
-from contextlib import asynccontextmanager, contextmanager
+from contextlib import contextmanager
 from datetime import date
 from pathlib import Path
 from typing import Any
@@ -34,10 +34,15 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
 INDUSTRY_DIR = Path(__file__).resolve().parent
-DB_DIR = INDUSTRY_DIR / "db"
-SCHEMA_PATH = DB_DIR / "schema.sql"
-SEED_PATH = DB_DIR / "seed.sql"
-DB_PATH = Path(os.environ.get("MIVAS_DB_PATH", str(DB_DIR / "runtime.db")))
+
+for _runtime in (Path("/app/runtime"), Path(__file__).resolve().parents[2] / "runtime"):
+    if (_runtime / "db_service.py").is_file():
+        if str(_runtime) not in sys.path:
+            sys.path.insert(0, str(_runtime))
+        break
+from db_service import DBService  # noqa: E402
+
+db = DBService.for_industry(INDUSTRY_DIR)
 
 # Fixed strings, so token discipline is checkable from a transcript alone.
 TOKENS = {
@@ -52,38 +57,18 @@ DISRUPTED = ("cancelled", "delayed_180", "schedule_change_180")
 
 
 def init_db() -> None:
-    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
-    if DB_PATH.exists():
-        DB_PATH.unlink()
-    conn = sqlite3.connect(DB_PATH)
-    try:
-        conn.executescript(SCHEMA_PATH.read_text())
-        seed = SEED_PATH.read_text().strip()
-        if seed:
-            conn.executescript(seed)
-        conn.commit()
-    finally:
-        conn.close()
+    return
 
 
 @contextmanager
 def _db() -> Any:
-    conn = sqlite3.connect(DB_PATH)
-    conn.row_factory = sqlite3.Row
-    try:
+    with db.connect() as conn:
         yield conn
-        conn.commit()
-    finally:
-        conn.close()
 
 
-@asynccontextmanager
-async def lifespan(_app: FastAPI):
-    init_db()
-    yield
-
-
-app = FastAPI(title="travel state API", lifespan=lifespan)
+app = FastAPI(title="travel state API")
+app.middleware("http")(db.http_middleware)
+db.mount_cluster_routes(app)
 
 
 # ------------------------------------------------------------------ helpers
@@ -626,6 +611,12 @@ def dispatch_tool(tool_name: str, body: ToolCall) -> dict[str, Any]:
 # ------------------------------------------------------------------ selfcheck
 
 def selfcheck() -> None:
+    """Every trap the fare ladder turns on, asserted against a fresh DB."""
+    with db.scope("selfcheck"):
+        _selfcheck()
+
+
+def _selfcheck() -> None:
     """Every trap the fare ladder turns on, asserted against a fresh DB."""
     init_db()
 

--- a/k8s/deployment-tools.yaml
+++ b/k8s/deployment-tools.yaml
@@ -1,0 +1,81 @@
+# One FastAPI + SQLite writer per harness×industry pair.
+# Scale independently of the CHIRP Deployment (v1: always 1 replica).
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mivas-__SLUG__-tools
+  labels:
+    app: mivas-bench
+    mivas.component: tools
+    mivas.slug: "__SLUG__-tools"
+    mivas.harness_family: "__HARNESS_FAMILY__"
+    mivas.harness_runtime: "__HARNESS_RUNTIME__"
+    mivas.industry: "__INDUSTRY__"
+spec:
+  replicas: __TOOLS_REPLICAS__
+  selector:
+    matchLabels:
+      app: mivas-bench
+      mivas.slug: "__SLUG__-tools"
+  template:
+    metadata:
+      labels:
+        app: mivas-bench
+        mivas.component: tools
+        mivas.slug: "__SLUG__-tools"
+        mivas.harness_family: "__HARNESS_FAMILY__"
+        mivas.harness_runtime: "__HARNESS_RUNTIME__"
+        mivas.industry: "__INDUSTRY__"
+    spec:
+      containers:
+        - name: tools
+          image: __IMAGE__
+          imagePullPolicy: __IMAGE_PULL_POLICY__
+          env:
+            - name: MIVAS_ROLE
+              value: "tools"
+            - name: MIVAS_MODE
+              value: "__MIVAS_MODE__"
+            - name: HARNESS
+              value: "__HARNESS__"
+            - name: INDUSTRY
+              value: "__INDUSTRY__"
+            - name: HARNESS_FAMILY
+              value: "__HARNESS_FAMILY__"
+            - name: HARNESS_RUNTIME
+              value: "__HARNESS_RUNTIME__"
+            - name: HARNESS_DIR
+              value: "/app/harness/__HARNESS_RUNTIME__"
+            - name: PYTHONPATH
+              value: "/app/runtime:/app/harness"
+            - name: TOOL_SERVER_PORT
+              value: "8000"
+            - name: TOOL_SERVER_URL
+              value: "http://127.0.0.1:8000"
+            - name: MIVAS_DB_PATH
+              value: "/data/industry.db"
+            - name: INDUSTRY_DIR
+              value: "/app/industry"
+            - name: PYTHONUNBUFFERED
+              value: "1"
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          ports:
+            - containerPort: 8000
+              name: tools
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              memory: 512Mi
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: tools
+            initialDelaySeconds: 3
+            periodSeconds: 5
+      volumes:
+        - name: data
+          emptyDir: {}

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -8,7 +8,15 @@ metadata:
     mivas.harness_runtime: "__HARNESS_RUNTIME__"
     mivas.industry: "__INDUSTRY__"
 spec:
-  replicas: 1
+  replicas: __REPLICAS__
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      # In-flight WebSockets die if their pod is deleted. Scale by adding
+      # replicas; do not cycle pods mid-run. maxUnavailable: 0 keeps the old
+      # replica until the surge pod is Ready.
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: mivas-bench
@@ -43,8 +51,10 @@ spec:
               value: "/app/harness/__HARNESS_RUNTIME__"
             - name: PYTHONPATH
               value: "/app/harness"
+            - name: MIVAS_ROLE
+              value: "harness"
             - name: TOOL_SERVER_URL
-              value: "http://127.0.0.1:8000"
+              value: "http://mivas-__SLUG__-tools:8000"
             - name: TOOL_SERVER_PORT
               value: "8000"
             - name: CHIRP_PORT
@@ -118,7 +128,7 @@ spec:
             - name: ASSEMBLYAI_VOICE
               value: "alba"
             - name: TWILIO_WELCOME_GREETING
-              value: "Welcome to Bluejay's Repair Services!"
+              value: "__TWILIO_WELCOME_GREETING__"
             - name: DEEPGRAM_API_KEY
               valueFrom:
                 secretKeyRef:
@@ -199,9 +209,6 @@ spec:
                   optional: true
             - name: PYTHONUNBUFFERED
               value: "1"
-          volumeMounts:
-            - name: data
-              mountPath: /data
           ports:
             - containerPort: 8000
               name: tools
@@ -214,13 +221,10 @@ spec:
             limits:
               memory: 1536Mi
           readinessProbe:
-            # Probe the tool server — TCP probes on the CHIRP port spam
-            # websockets with "opening handshake failed" stack traces.
+            # harness_health.py on :8000. The industry tool server is a
+            # separate Deployment (mivas-{slug}-tools). Do not TCP-probe :8765.
             httpGet:
               path: /health
               port: tools
             initialDelaySeconds: 5
             periodSeconds: 5
-      volumes:
-        - name: data
-          emptyDir: {}

--- a/k8s/ingress-tools.yaml
+++ b/k8s/ingress-tools.yaml
@@ -1,33 +1,22 @@
-# Stable public hostname per harness×industry pair.
-# Host: __HOST__  →  wss://__HOST__/  (Bluejay)  and  https://__HOST__/  (PUBLIC_URL)
-#
-# /tools /state /snapshot /health → tools ClusterIP (one SQLite writer).
-# /                    → CHIRP / ConversationRelay (Bluejay WS + platform /tool/* webhooks).
-#
-# TLS, ALB grouping, and idle timeout are on IngressClassParams (k8s/ingressclass.yaml).
-# EKS Auto Mode does not honor group.name / certificate-arn Ingress annotations.
+# Tools-only public hostname for worker families (Pipecat Cloud / LiveKit).
+# They do not serve Bluejay CHIRP; the bot POSTs https://__HOST__/tools/{name}.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: mivas-__SLUG__
   labels:
     app: mivas-bench
+    mivas.component: tools
     mivas.harness_family: "__HARNESS_FAMILY__"
     mivas.harness_runtime: "__HARNESS_RUNTIME__"
     mivas.industry: "__INDUSTRY__"
     mivas.slug: "__SLUG__"
   annotations:
-    # CHIRP on :8765 is WebSocket-only; HTTP GET / there is 400 and ALB would
-    # mark the target unhealthy. Probe the harness :8000 health stub (and the
-    # tools pod /health on the tools target group). Both listen on 8000.
     alb.ingress.kubernetes.io/healthcheck-protocol: HTTP
     alb.ingress.kubernetes.io/healthcheck-port: "8000"
     alb.ingress.kubernetes.io/healthcheck-path: /health
     alb.ingress.kubernetes.io/success-codes: "200"
     alb.ingress.kubernetes.io/backend-protocol: HTTP
-    # New dials: least outstanding requests. An upgraded WebSocket stays on
-    # that target for the TCP lifetime — do not use cookie stickiness.
-    alb.ingress.kubernetes.io/target-group-attributes: load_balancing.algorithm.type=least_outstanding_requests
 spec:
   ingressClassName: mivas-alb
   rules:
@@ -62,10 +51,3 @@ spec:
                 name: mivas-__SLUG__-tools
                 port:
                   name: tools
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: mivas-__SLUG__
-                port:
-                  name: chirp

--- a/k8s/service-tools.yaml
+++ b/k8s/service-tools.yaml
@@ -1,0 +1,22 @@
+# ClusterIP only — harness pods call this in-cluster. Not on the public ALB.
+apiVersion: v1
+kind: Service
+metadata:
+  name: mivas-__SLUG__-tools
+  labels:
+    app: mivas-bench
+    mivas.component: tools
+    mivas.slug: "__SLUG__-tools"
+    mivas.harness_family: "__HARNESS_FAMILY__"
+    mivas.harness_runtime: "__HARNESS_RUNTIME__"
+    mivas.industry: "__INDUSTRY__"
+spec:
+  type: ClusterIP
+  selector:
+    app: mivas-bench
+    mivas.slug: "__SLUG__-tools"
+  ports:
+    - name: tools
+      port: 8000
+      targetPort: tools
+      protocol: TCP

--- a/run.py
+++ b/run.py
@@ -102,17 +102,32 @@ def harness_paths(harness: str) -> tuple[Path, Path]:
     return family_dir, agent_dir
 
 
-# LiveKit / Pipecat workers register with LiveKit Cloud. They do not serve CHIRP
-# and do not need a public Ingress hostname.
+# LiveKit / Pipecat workers register with LiveKit Cloud. They do not serve a
+# public ingress adapter and do not need a public Ingress hostname.
 WORKER_FAMILIES = frozenset({"livekit", "pipecat"})
+PLATFORM_FAMILIES = frozenset({"vapi", "retell", "bland", "cartesia"})
 
 
 def pair_needs_ingress(harness: str) -> bool:
     return split_harness(harness)[0] not in WORKER_FAMILIES
 
 
+def ingress_adapter(harness: str) -> Path:
+    """Public ingress script. adapters/chirp.py is Bluejay CHIRP only."""
+    _, agent_dir = harness_paths(harness)
+    conversationrelay = agent_dir / "adapters" / "conversationrelay.py"
+    if conversationrelay.is_file():
+        return conversationrelay
+    return agent_dir / "adapters" / "chirp.py"
+
+
 def pair_mivas_mode(harness: str) -> str:
-    return "agent" if split_harness(harness)[0] in WORKER_FAMILIES else "chirp"
+    family = split_harness(harness)[0]
+    if family in WORKER_FAMILIES:
+        return "agent"
+    if ingress_adapter(harness).name == "conversationrelay.py":
+        return "conversationrelay"
+    return "chirp"
 
 
 def slug(harness: str, industry: str) -> str:
@@ -133,26 +148,31 @@ def image_ref(harness: str, industry: str) -> str:
     return f"mivas-bench:{tag}"
 
 
-def pair_host(harness: str, industry: str) -> str | None:
-    """Stable DNS host for a harness×industry pair, or None if ingress mode is off."""
-    if not pair_needs_ingress(harness):
-        return None
+def pair_dns_host(harness: str, industry: str) -> str | None:
+    """DNS host for a pair when MIVAS_BASE_DOMAIN is set (CHIRP and worker families)."""
     base = os.environ.get("MIVAS_BASE_DOMAIN", "").strip().lower().strip(".")
     if not base:
         return None
     return f"{slug(harness, industry)}.{base}"
 
 
+def pair_host(harness: str, industry: str) -> str | None:
+    """Stable DNS host Bluejay should dial (CHIRP / ConversationRelay only)."""
+    if not pair_needs_ingress(harness):
+        return None
+    return pair_dns_host(harness, industry)
+
+
 def pair_public_url(harness: str, industry: str) -> str:
-    """HTTPS base for tool webhooks (Vapi/Retell/…). Prefers stable ingress host."""
-    host = pair_host(harness, industry)
+    """HTTPS base for tool webhooks and Pipecat Cloud TOOL_SERVER_URL."""
+    host = pair_dns_host(harness, industry) or pair_host(harness, industry)
     if host:
         return f"https://{host}"
     return os.environ.get("PUBLIC_URL", "").strip()
 
 
 def pair_websocket_url(harness: str, industry: str) -> str | None:
-    """Stable wss:// URL Bluejay should dial when ingress mode is on."""
+    """Stable wss:// URL Bluejay should dial when CHIRP ingress is on."""
     host = pair_host(harness, industry)
     if host:
         return f"wss://{host}"
@@ -244,7 +264,7 @@ def build_image(harness: str, industry: str, image: str) -> None:
 def _render(template_name: str, harness: str, industry: str, image: str, service_type: str) -> str:
     family, runtime = split_harness(harness)
     pair_slug = slug(harness, industry)
-    host = pair_host(harness, industry) or ""
+    host = pair_dns_host(harness, industry) or ""
     public_url = pair_public_url(harness, industry)
     acm = os.environ.get("MIVAS_ACM_CERTIFICATE_ARN", "").strip()
     bluejay_api_url = (
@@ -275,7 +295,48 @@ def _render(template_name: str, harness: str, industry: str, image: str, service
         .replace("__BLUEJAY_API_URL__", bluejay_api_url)
         .replace("__BLUEJAY_OTLP_ENDPOINT__", bluejay_otlp)
         .replace("__MIVAS_MODE__", pair_mivas_mode(harness))
+        .replace("__TWILIO_WELCOME_GREETING__", _twilio_welcome(industry))
+        .replace("__REPLICAS__", str(replica_count()))
+        .replace("__TOOLS_REPLICAS__", str(tools_replica_count()))
     )
+
+
+def replica_count() -> int:
+    """Harness Deployment replicas from MIVAS_REPLICAS (default 1)."""
+    raw = os.environ.get("MIVAS_REPLICAS", "1").strip() or "1"
+    try:
+        n = int(raw)
+    except ValueError:
+        raise ValueError(f"MIVAS_REPLICAS must be a positive integer, got {raw!r}") from None
+    if n < 1:
+        raise ValueError(f"MIVAS_REPLICAS must be >= 1, got {n}")
+    return n
+
+
+def tools_replica_count() -> int:
+    """Tools Deployment replicas. v1 is one writer: must be 1."""
+    raw = os.environ.get("MIVAS_TOOLS_REPLICAS", "1").strip() or "1"
+    try:
+        n = int(raw)
+    except ValueError:
+        raise ValueError(
+            f"MIVAS_TOOLS_REPLICAS must be a positive integer, got {raw!r}"
+        ) from None
+    if n != 1:
+        raise ValueError(
+            f"MIVAS_TOOLS_REPLICAS must be 1 in v1 (one SQLite writer per pair), got {n}"
+        )
+    return n
+
+
+def _twilio_welcome(industry: str) -> str:
+    return {
+        "control-industry": "Welcome to Bluejay's Repair Services!",
+        "healthcare": "Thank you for calling Straus Dermatology.",
+        "finance": "Thank you for calling Copperline Credit Union.",
+        "legal": "Thank you for calling Halverson and Reed.",
+        "travel": "Thank you for calling Summit Air.",
+    }.get(industry, "Hello.")
 
 
 def secret_exists() -> bool:
@@ -463,14 +524,14 @@ def parse_agents(raw: str) -> list[tuple[str, str]]:
     return pairs
 
 
-def validate_pair(harness: str, industry: str, *, require_chirp: bool) -> None:
+def validate_pair(harness: str, industry: str, *, require_ingress: bool) -> None:
     family_dir, agent_dir = harness_paths(harness)
     if not family_dir.is_dir():
         raise ValueError(f"unknown harness family: {family_dir.name}")
     if not (agent_dir / "agent.py").is_file():
         raise ValueError(f"unknown harness runtime (missing agent.py): {harness}")
-    if require_chirp and not (agent_dir / "adapters" / "chirp.py").is_file():
-        raise ValueError(f"no chirp adapter for harness={harness}")
+    if require_ingress and not ingress_adapter(harness).is_file():
+        raise ValueError(f"no ingress adapter for harness={harness}")
     industry_dir = ROOT / "industries" / industry
     if not industry_dir.is_dir():
         raise ValueError(f"unknown industry: {industry}")
@@ -501,10 +562,14 @@ def render_agents_yaml(pairs: list[tuple[str, str]], service_type: str) -> str:
         docs.append(_render("ingressclass.yaml", h0, i0, image_ref(h0, i0), service_type))
     for harness, industry in pairs:
         image = image_ref(harness, industry)
+        docs.append(_render("deployment-tools.yaml", harness, industry, image, service_type))
+        docs.append(_render("service-tools.yaml", harness, industry, image, service_type))
         docs.append(_render("deployment.yaml", harness, industry, image, service_type))
         docs.append(_render("service.yaml", harness, industry, image, service_type))
         if use_ingress and pair_needs_ingress(harness):
             docs.append(_render("ingress.yaml", harness, industry, image, service_type))
+        elif use_ingress:
+            docs.append(_render("ingress-tools.yaml", harness, industry, image, service_type))
     return "\n---\n".join(docs) + "\n"
 
 
@@ -523,6 +588,21 @@ def apply_agents(pairs: list[tuple[str, str]], *, follow_logs: bool) -> None:
         print(e, file=sys.stderr)
         sys.exit(1)
 
+    n = replica_count()
+    if n > 1:
+        families = {split_harness(h)[0] for h, _ in pairs}
+        print(
+            f"MIVAS_REPLICAS={n} harness pods; tools Deployment stays at "
+            f"{tools_replica_count()} (ClusterIP mivas-{{slug}}-tools).",
+            file=sys.stderr,
+        )
+        if families & PLATFORM_FAMILIES:
+            print(
+                "warning: vapi/retell/bland/cartesia webhooks still hit a random "
+                "CHIRP replica; bind is stored on the tools Service.",
+                file=sys.stderr,
+            )
+
     path = Path(tempfile.mkstemp(suffix=".yaml", prefix="mivas-agents-")[1])
     try:
         path.write_text(yaml_text)
@@ -539,6 +619,10 @@ def apply_agents(pairs: list[tuple[str, str]], *, follow_logs: bool) -> None:
     for harness, industry in pairs:
         name = f"mivas-{slug(harness, industry)}"
         subprocess.run(
+            ["kubectl", "rollout", "status", f"deployment/{name}-tools", "--timeout=180s"],
+            check=False,
+        )
+        subprocess.run(
             ["kubectl", "rollout", "status", f"deployment/{name}", "--timeout=180s"],
             check=False,
         )
@@ -547,8 +631,10 @@ def apply_agents(pairs: list[tuple[str, str]], *, follow_logs: bool) -> None:
         if split_harness(harness)[0] in WORKER_FAMILIES:
             print(
                 f"LiveKit Cloud worker ({name}): connection_type=LIVEKIT "
-                f"(no Ingress; pod registers with LIVEKIT_URL)"
+                f"(pod registers with LIVEKIT_URL)"
             )
+            if public:
+                print(f"PUBLIC_URL / tools ({name}): {public}/tools")
             continue
         if stable:
             print(f"Bluejay websocket_url ({name}): {stable}")
@@ -615,8 +701,11 @@ def run_local(harness: str, industry: str, agent_check: bool, mode: str) -> None
             "HARNESS_FAMILY": family,
             "HARNESS_RUNTIME": runtime,
             "MIVAS_MODE": mode,
-            "PYTHONPATH": str(family_dir)
-            + (os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else ""),
+            "PYTHONPATH": os.pathsep.join(
+                [str(ROOT / "runtime"), str(family_dir)]
+                + ([env["PYTHONPATH"]] if env.get("PYTHONPATH") else [])
+            ),
+            "MIVAS_DB_SHARED": env.get("MIVAS_DB_SHARED", "1"),
         }
     )
 
@@ -656,13 +745,18 @@ def run_local(harness: str, industry: str, agent_check: bool, mode: str) -> None
             run(agent_cmd, env=env, cwd=str(ROOT))
             return
 
-        if mode == "chirp":
-            chirp = agent_dir / "adapters" / "chirp.py"
-            if not chirp.is_file():
-                print(f"no chirp adapter for harness={harness}", file=sys.stderr)
+        if mode in ("chirp", "conversationrelay"):
+            adapter = ingress_adapter(harness)
+            if not adapter.is_file():
+                print(f"no ingress adapter for harness={harness}", file=sys.stderr)
                 sys.exit(1)
-            print(f"starting local CHIRP ({harness}) — Ctrl+C to stop")
-            run([sys.executable, str(chirp)], env=env, cwd=str(ROOT))
+            label = (
+                "ConversationRelay"
+                if adapter.name == "conversationrelay.py"
+                else "CHIRP"
+            )
+            print(f"starting local {label} ({harness}) — Ctrl+C to stop")
+            run([sys.executable, str(adapter)], env=env, cwd=str(ROOT))
             return
 
         agent_cmd = [sys.executable, str(agent_dir / "agent.py"), industry]
@@ -698,13 +792,13 @@ def main() -> None:
     parser.add_argument(
         "--local",
         action="store_true",
-        help="Run tool server + chirp/agent locally (default when no --build/--apply)",
+        help="Run tool server + ingress adapter/agent locally (default when no --build/--apply)",
     )
     parser.add_argument(
         "--mode",
-        choices=("chirp", "agent", "check"),
+        choices=("chirp", "conversationrelay", "agent", "check"),
         default=os.environ.get("MIVAS_MODE", "chirp"),
-        help="Runtime mode (default: chirp for Bluejay WebSocket sims)",
+        help="Runtime mode (default: chirp for Bluejay CHIRP; Twilio uses conversationrelay)",
     )
     parser.add_argument("--check", action="store_true", help="Shortcut for --mode check")
     parser.add_argument(
@@ -725,11 +819,11 @@ def main() -> None:
 
     for harness, industry in pairs:
         family = split_harness(harness)[0]
-        require_chirp = family not in WORKER_FAMILIES and (
-            args.apply or (do_local and mode == "chirp")
+        require_ingress = family not in WORKER_FAMILIES and (
+            args.apply or (do_local and mode in ("chirp", "conversationrelay"))
         )
         try:
-            validate_pair(harness, industry, require_chirp=require_chirp)
+            validate_pair(harness, industry, require_ingress=require_ingress)
         except ValueError as e:
             print(e, file=sys.stderr)
             sys.exit(1)

--- a/runtime/call_id.py
+++ b/runtime/call_id.py
@@ -1,0 +1,245 @@
+"""Bluejay simulation result id → X-Mivas-Call-Id for industry tool POSTs.
+
+CHIRP / LiveKit job metadata supplies X-Simulation-Result-Id. Platform
+webhooks are a separate HTTP request and must look the id up from the
+provider call id (Vapi call.id, Retell call_id, …).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from contextvars import ContextVar
+from typing import Any
+
+HEADER = "X-Mivas-Call-Id"
+CALL_ID: ContextVar[str] = ContextVar("mivas_call_id", default="")
+
+_lock = threading.Lock()
+_provider_sim: dict[str, str] = {}
+_sessions: dict[str, str] = {}
+
+
+def set_call_id(sim_id: str | None) -> str:
+    """Pin this task to a conversation id. Mints `call_{uuid}` if Bluejay omitted it."""
+    resolved = str(sim_id).strip() if sim_id is not None else ""
+    if not resolved:
+        resolved = f"call_{uuid.uuid4().hex[:12]}"
+        print(
+            f"call_id: Bluejay omitted X-Simulation-Result-Id; minted {resolved}",
+            flush=True,
+        )
+    CALL_ID.set(resolved)
+    return resolved
+
+
+def current() -> str:
+    return CALL_ID.get()
+
+
+def pod_name() -> str:
+    """Kubernetes sets HOSTNAME to the pod name."""
+    return os.environ.get("HOSTNAME") or "local"
+
+
+def log_ws_accept(sim_id: str | None) -> None:
+    print(f"call_id: ws_accept sim={sim_id or '-'} pod={pod_name()}", flush=True)
+
+
+def log_tool_post(sim_id: str, *, path: str = "") -> None:
+    extra = f" path={path}" if path else ""
+    print(f"call_id: tool_post sim={sim_id} pod={pod_name()}{extra}", flush=True)
+
+
+def headers(call_id: str | None = None) -> dict[str, str]:
+    """Always returns X-Mivas-Call-Id; never sends an empty header."""
+    cid = (call_id or CALL_ID.get() or sole_session() or "").strip()
+    if not cid:
+        cid = set_call_id(None)
+    return {HEADER: cid}
+
+
+def begin_session(sim_id: str | None, *, session_key: str | None = None) -> str:
+    """Register an in-flight call so a webhook with no ContextVar can find it."""
+    resolved = set_call_id(sim_id)
+    key = session_key or resolved
+    with _lock:
+        _sessions[str(key)] = resolved
+    return resolved
+
+
+def end_session(session_key: str) -> None:
+    with _lock:
+        sim = _sessions.pop(str(session_key), None)
+    if sim:
+        try:
+            from snapshot import capture_final
+
+            capture_final(sim)
+        except Exception as e:
+            print(f"snapshot: capture failed sim={sim} err={e}", flush=True)
+
+
+def sole_session() -> str | None:
+    """If exactly one in-flight session exists, return its Bluejay id."""
+    with _lock:
+        ids = set(_sessions.values())
+    if len(ids) == 1:
+        return next(iter(ids))
+    return None
+
+
+def _tools_cluster_url() -> str:
+    """In-cluster tools Service base URL, or empty when tools are local."""
+    url = os.environ.get("TOOL_SERVER_URL", "").strip().rstrip("/")
+    if not url:
+        return ""
+    host = url.split("://", 1)[-1]
+    if host.startswith("127.0.0.1") or host.startswith("localhost"):
+        return ""
+    return url
+
+
+def _publish_bind(provider_call_id: str, sim_id: str) -> None:
+    base = _tools_cluster_url()
+    if not base:
+        return
+    body = json.dumps({"provider_call_id": provider_call_id, "sim_id": sim_id}).encode()
+    req = urllib.request.Request(
+        f"{base}/bind",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=3) as resp:
+            resp.read()
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        print(f"call_id: bind publish failed provider={provider_call_id} err={e}", flush=True)
+
+
+def _lookup_bind(provider_call_id: str) -> str | None:
+    base = _tools_cluster_url()
+    if not base:
+        return None
+    req = urllib.request.Request(
+        f"{base}/bind/{urllib.parse.quote(provider_call_id, safe='')}"
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=3) as resp:
+            data = json.loads(resp.read().decode())
+    except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError):
+        return None
+    found = str(data.get("sim_id") or "").strip()
+    return found or None
+
+
+def bind_provider(provider_call_id: str | None, sim_id: str | None = None) -> str:
+    """Map a provider conversation id (Vapi/Retell/…) to the Bluejay sim id."""
+    resolved = (str(sim_id).strip() if sim_id is not None else "") or current()
+    if not resolved:
+        resolved = set_call_id(None)
+    CALL_ID.set(resolved)
+    if provider_call_id:
+        with _lock:
+            _provider_sim[str(provider_call_id)] = resolved
+        _publish_bind(str(provider_call_id), resolved)
+    return resolved
+
+
+def unbind_provider(provider_call_id: str | None) -> None:
+    if not provider_call_id:
+        return
+    with _lock:
+        _provider_sim.pop(str(provider_call_id), None)
+
+
+def for_provider(provider_call_id: str | None) -> str:
+    """Resolve a webhook's provider call id to the Bluejay sim id; set CALL_ID."""
+    if provider_call_id:
+        with _lock:
+            found = _provider_sim.get(str(provider_call_id))
+        if found:
+            CALL_ID.set(found)
+            return found
+        remote = _lookup_bind(str(provider_call_id))
+        if remote:
+            with _lock:
+                _provider_sim[str(provider_call_id)] = remote
+            CALL_ID.set(remote)
+            return remote
+    fallback = sole_session()
+    if fallback:
+        if provider_call_id:
+            print(
+                f"call_id: unknown provider call {provider_call_id}; "
+                f"using sole in-flight session {fallback}",
+                flush=True,
+            )
+        CALL_ID.set(fallback)
+        return fallback
+    print(
+        f"call_id: no bound provider/session for {provider_call_id!r}; minting",
+        flush=True,
+    )
+    return set_call_id(None)
+
+
+def provider_id_from_payload(payload: Any) -> str | None:
+    """Best-effort extract of a provider conversation id from a webhook body."""
+    if not isinstance(payload, dict):
+        return None
+    call = payload.get("call")
+    if isinstance(call, dict):
+        for key in ("id", "call_id", "callId"):
+            val = call.get(key)
+            if val not in (None, ""):
+                return str(val)
+    for key in ("call_id", "callId", "conversation_id", "inbound_id", "cid"):
+        val = payload.get(key)
+        if val not in (None, "") and not isinstance(val, dict):
+            return str(val)
+    return None
+
+
+def provider_id_from_request(
+    payload: Any = None,
+    *,
+    query: Any = None,
+    headers: Any = None,
+) -> str | None:
+    """Provider id from JSON body, query string, or common webhook headers."""
+    found = provider_id_from_payload(payload)
+    if found:
+        return found
+    if query is not None:
+        getter = query.get if hasattr(query, "get") else lambda _k: None
+        for key in ("call_id", "callId", "inbound_id", "cid"):
+            val = getter(key)
+            if val not in (None, ""):
+                return str(val)
+    if headers is not None:
+        getter = headers.get if hasattr(headers, "get") else lambda _k: None
+        for key in (
+            "x-call-id",
+            "x-bland-call-id",
+            "x-cartesia-call-id",
+            "x-vapi-call-id",
+        ):
+            val = getter(key)
+            if val not in (None, ""):
+                return str(val)
+    return None
+
+
+def reset() -> None:
+    """Clear maps and the ContextVar. Tests only."""
+    CALL_ID.set("")
+    with _lock:
+        _provider_sim.clear()
+        _sessions.clear()

--- a/runtime/db_service.py
+++ b/runtime/db_service.py
@@ -1,0 +1,247 @@
+"""Per-call SQLite files for industry tool servers.
+
+Handlers keep `with db.connect() as conn: conn.execute(...)`. This module is
+the only place that chooses a file: first touch of a call id copies schema.sql
+then seed.sql into `{data_dir}/calls/{id}.db`; later touches reuse it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+import threading
+from contextlib import contextmanager
+from contextvars import ContextVar
+from pathlib import Path
+from typing import Iterator
+
+_CALL_ID_OK = re.compile(r"^[A-Za-z0-9_-]{1,64}$")
+_call_id: ContextVar[str] = ContextVar("mivas_call_id", default="")
+
+
+class CallIdError(ValueError):
+    """Empty, missing, or path-escaping conversation id."""
+
+
+class DBService:
+    def __init__(
+        self,
+        schema_path: Path,
+        seed_path: Path,
+        data_dir: Path,
+        *,
+        shared: bool = False,
+    ) -> None:
+        self.schema_path = Path(schema_path)
+        self.seed_path = Path(seed_path)
+        self.data_dir = Path(data_dir)
+        self.calls_dir = self.data_dir / "calls"
+        self.shared = shared
+        self.shared_path = self.data_dir / "runtime.db"
+        self._create_lock = threading.Lock()
+
+    @classmethod
+    def for_industry(
+        cls,
+        industry_dir: Path | str,
+        *,
+        shared: bool | None = None,
+    ) -> DBService:
+        """Wire schema/seed from an industry pack and data_dir from MIVAS_DB_PATH."""
+        industry_dir = Path(industry_dir)
+        db_dir = industry_dir / "db"
+        env_path = os.environ.get("MIVAS_DB_PATH", "").strip()
+        data_dir = Path(env_path).parent if env_path else db_dir
+        if shared is None:
+            shared = os.environ.get("MIVAS_DB_SHARED", "").strip().lower() in {
+                "1",
+                "true",
+                "yes",
+            }
+        return cls(
+            schema_path=db_dir / "schema.sql",
+            seed_path=db_dir / "seed.sql",
+            data_dir=data_dir,
+            shared=shared,
+        )
+
+
+    def ensure(self, call_id: str) -> Path:
+        safe = _normalise_call_id(call_id)
+        path = self.calls_dir / f"{safe}.db"
+        if path.exists():
+            return path
+        with self._create_lock:
+            if path.exists():
+                return path
+            self.calls_dir.mkdir(parents=True, exist_ok=True)
+            _write_fixture_db(path, self.schema_path, self.seed_path)
+        return path
+
+    @contextmanager
+    def scope(self, call_id: str) -> Iterator[str]:
+        safe = _normalise_call_id(call_id)
+        token = _call_id.set(safe)
+        try:
+            yield safe
+        finally:
+            _call_id.reset(token)
+
+    def _active_path(self, call_id: str | None) -> Path:
+        cid = (call_id if call_id is not None else _call_id.get()) or ""
+        if cid:
+            return self.ensure(cid)
+        if self.shared:
+            return self._ensure_shared()
+        raise CallIdError("missing call id")
+
+    def _ensure_shared(self) -> Path:
+        path = self.shared_path
+        if path.exists():
+            return path
+        with self._create_lock:
+            if path.exists():
+                return path
+            path.parent.mkdir(parents=True, exist_ok=True)
+            _write_fixture_db(path, self.schema_path, self.seed_path)
+        return path
+
+    @contextmanager
+    def connect(self, call_id: str | None = None) -> Iterator[sqlite3.Connection]:
+        path = self._active_path(call_id)
+        conn = sqlite3.connect(path)
+        conn.row_factory = sqlite3.Row
+        try:
+            yield conn
+            conn.commit()
+        finally:
+            conn.close()
+
+    async def http_middleware(self, request, call_next):
+        """Scope X-Mivas-Call-Id (or ?call_id=) for the request. /health is global."""
+        from starlette.responses import JSONResponse
+
+        if request.url.path.rstrip("/") == "/health":
+            return await call_next(request)
+        path = request.url.path.rstrip("/") or "/"
+        if path == "/bind" or path.startswith("/bind/"):
+            return await call_next(request)
+        if path == "/snapshot" or path.startswith("/snapshot/"):
+            return await call_next(request)
+        raw = request.headers.get("x-mivas-call-id") or request.query_params.get("call_id")
+        if not raw:
+            if self.shared:
+                return await call_next(request)
+            return JSONResponse({"detail": "missing X-Mivas-Call-Id"}, status_code=400)
+        try:
+            with self.scope(raw):
+                if request.method == "POST" and request.url.path.startswith("/tools/"):
+                    from call_id import log_tool_post
+
+                    log_tool_post(self.current_call_id(), path=request.url.path)
+                return await call_next(request)
+        except CallIdError as e:
+            return JSONResponse({"detail": str(e)}, status_code=400)
+
+    def current_call_id(self) -> str:
+        return _call_id.get()
+
+    def mount_cluster_routes(self, app) -> None:
+        """Provider-call-id → Bluejay sim id, stored on the one tools replica."""
+        from starlette.requests import Request
+        from starlette.responses import JSONResponse
+        from starlette.routing import Route
+
+        store: dict[str, str] = {}
+        lock = threading.Lock()
+
+        async def bind(request: Request) -> JSONResponse:
+            data = await request.json()
+            pid = str((data or {}).get("provider_call_id") or "").strip()
+            sid = str((data or {}).get("sim_id") or "").strip()
+            if not pid or not sid:
+                return JSONResponse(
+                    {"detail": "provider_call_id and sim_id required"}, status_code=400
+                )
+            with lock:
+                store[pid] = sid
+            return JSONResponse(
+                {"ok": "true", "provider_call_id": pid, "sim_id": sid}
+            )
+
+        async def lookup(request: Request) -> JSONResponse:
+            pid = str(request.path_params.get("provider_call_id") or "").strip()
+            with lock:
+                found = store.get(pid)
+            if not found:
+                return JSONResponse({"detail": "unknown provider call id"}, status_code=404)
+            return JSONResponse({"provider_call_id": pid, "sim_id": found})
+
+        def _final_path(call_id: str) -> Path:
+            safe = _normalise_call_id(call_id)
+            self.calls_dir.mkdir(parents=True, exist_ok=True)
+            return self.calls_dir / f"{safe}.final.json"
+
+        async def save_snapshot(request: Request) -> JSONResponse:
+            try:
+                data = await request.json()
+            except Exception:
+                data = None
+            cid = str((data or {}).get("call_id") or "").strip()
+            state = (data or {}).get("state")
+            if not cid or not isinstance(state, dict):
+                return JSONResponse(
+                    {"detail": "call_id and state object required"}, status_code=400
+                )
+            try:
+                path = _final_path(cid)
+            except CallIdError as e:
+                return JSONResponse({"detail": str(e)}, status_code=400)
+            path.write_text(json.dumps(state), encoding="utf-8")
+            return JSONResponse({"ok": True, "call_id": cid})
+
+        async def get_snapshot(request: Request) -> JSONResponse:
+            cid = str(request.path_params.get("call_id") or "").strip()
+            try:
+                path = _final_path(cid)
+            except CallIdError as e:
+                return JSONResponse({"detail": str(e)}, status_code=400)
+            if not path.is_file():
+                return JSONResponse({"detail": "no snapshot"}, status_code=404)
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                return JSONResponse({"detail": "corrupt snapshot"}, status_code=500)
+            return JSONResponse(payload)
+
+        app.router.routes.extend(
+            [
+                Route("/bind", bind, methods=["POST"]),
+                Route("/bind/{provider_call_id}", lookup, methods=["GET"]),
+                Route("/snapshot", save_snapshot, methods=["POST"]),
+                Route("/snapshot/{call_id}", get_snapshot, methods=["GET"]),
+            ]
+        )
+
+
+
+
+def _normalise_call_id(raw: str | None) -> str:
+    value = str(raw or "").strip()
+    if not _CALL_ID_OK.fullmatch(value):
+        raise CallIdError(f"invalid call id {raw!r}")
+    return value
+
+
+def _write_fixture_db(path: Path, schema_path: Path, seed_path: Path) -> None:
+    conn = sqlite3.connect(path)
+    try:
+        conn.executescript(schema_path.read_text())
+        seed = seed_path.read_text().strip()
+        if seed:
+            conn.executescript(seed)
+        conn.commit()
+    finally:
+        conn.close()

--- a/runtime/entrypoint.sh
+++ b/runtime/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Start industry tool server, then either the CHIRP adapter (Bluejay) or agent.py.
+# MIVAS_ROLE=tools  → industry FastAPI only (separate Deployment).
+# MIVAS_ROLE=harness → wait for tools Service, ALB /health stub, then CHIRP/agent.
+# unset / combined   → local --local: tool server + ingress in one process tree.
 set -euo pipefail
 
 : "${HARNESS:=${VOICE_AGENT:-}}"
@@ -12,14 +14,15 @@ HARNESS_DIR="${HARNESS_DIR:-${APP_ROOT}/harness}"
 TOOL_SERVER_PORT="${TOOL_SERVER_PORT:-8000}"
 TOOL_SERVER_URL="${TOOL_SERVER_URL:-http://127.0.0.1:${TOOL_SERVER_PORT}}"
 MIVAS_MODE="${MIVAS_MODE:-chirp}"
+MIVAS_ROLE="${MIVAS_ROLE:-combined}"
 CHIRP_PORT="${CHIRP_PORT:-8765}"
 export MIVAS_DB_PATH="${MIVAS_DB_PATH:-/data/industry.db}"
+export PYTHONPATH="${APP_ROOT}/runtime${PYTHONPATH:+:${PYTHONPATH}}"
 export TOOL_SERVER_URL
 export INDUSTRY_DIR
 export INDUSTRY
 export HARNESS
 
-# Derive Realtime model from harness runtime folder when unset.
 HARNESS_RUNTIME="${HARNESS_RUNTIME:-$(basename "${HARNESS_DIR}")}"
 case "${HARNESS_RUNTIME}" in
   realtime-2.1) : "${OPENAI_REALTIME_MODEL:=gpt-realtime-2.1}" ;;
@@ -30,38 +33,22 @@ export HARNESS_RUNTIME
 
 mkdir -p "$(dirname "$MIVAS_DB_PATH")"
 
-echo "starting tool server (${INDUSTRY}) on :${TOOL_SERVER_PORT}"
-python "${INDUSTRY_DIR}/tool_server.py" &
-TOOL_PID=$!
-
-cleanup() {
-  kill "${TOOL_PID}" 2>/dev/null || true
+wait_for_tools() {
+  local url="$1"
+  echo "waiting for tool server health at ${url}"
+  for _ in $(seq 1 120); do
+    if curl -sf "${url}/health" >/dev/null; then
+      return 0
+    fi
+    sleep 0.5
+  done
+  echo "tool server failed health check at ${url}" >&2
+  return 1
 }
-trap cleanup EXIT
 
-echo "waiting for tool server health"
-for _ in $(seq 1 60); do
-  if curl -sf "${TOOL_SERVER_URL}/health" >/dev/null; then
-    break
-  fi
-  if ! kill -0 "${TOOL_PID}" 2>/dev/null; then
-    echo "tool server exited before becoming healthy" >&2
-    exit 1
-  fi
-  sleep 0.5
-done
-
-if ! curl -sf "${TOOL_SERVER_URL}/health" >/dev/null; then
-  echo "tool server failed health check" >&2
-  exit 1
-fi
-
-if [[ "${AGENT_CHECK:-}" == "1" || "${MIVAS_MODE}" == "check" ]]; then
-  echo "starting harness agent check (${HARNESS})"
-  exec python "${HARNESS_DIR}/agent.py" "${INDUSTRY}" --check
-fi
-
-if [[ "${MIVAS_MODE}" == "chirp" && -f "${HARNESS_DIR}/adapters/chirp.py" ]]; then
+start_ingress() {
+  local script="$1"
+  local label="$2"
   HARNESS_FAMILY="${HARNESS_FAMILY:-${HARNESS%%/*}}"
   CHIRP_ARGS=(--industry "${INDUSTRY}" --host 0.0.0.0 --port "${CHIRP_PORT}")
   case "${HARNESS_FAMILY}" in
@@ -71,27 +58,70 @@ if [[ "${MIVAS_MODE}" == "chirp" && -f "${HARNESS_DIR}/adapters/chirp.py" ]]; th
         exit 1
       fi
       CHIRP_ARGS+=(--model "${OPENAI_REALTIME_MODEL}")
-      echo "starting CHIRP (${HARNESS} model=${OPENAI_REALTIME_MODEL}) on :${CHIRP_PORT}"
+      echo "starting ${label} (${HARNESS} model=${OPENAI_REALTIME_MODEL}) on :${CHIRP_PORT}"
       ;;
     *)
-      echo "starting CHIRP (${HARNESS}) on :${CHIRP_PORT}"
+      echo "starting ${label} (${HARNESS}) on :${CHIRP_PORT}"
       ;;
   esac
-  exec python "${HARNESS_DIR}/adapters/chirp.py" "${CHIRP_ARGS[@]}"
+  exec python "${script}" "${CHIRP_ARGS[@]}"
+}
+
+start_harness() {
+  if [[ "${AGENT_CHECK:-}" == "1" || "${MIVAS_MODE}" == "check" ]]; then
+    echo "starting harness agent check (${HARNESS})"
+    exec python "${HARNESS_DIR}/agent.py" "${INDUSTRY}" --check
+  fi
+
+  CR_ADAPTER="${HARNESS_DIR}/adapters/conversationrelay.py"
+  CHIRP_ADAPTER="${HARNESS_DIR}/adapters/chirp.py"
+  if [[ -f "${CR_ADAPTER}" && ( "${MIVAS_MODE}" == "conversationrelay" || "${MIVAS_MODE}" == "chirp" ) ]]; then
+    start_ingress "${CR_ADAPTER}" "ConversationRelay"
+  fi
+  if [[ "${MIVAS_MODE}" == "chirp" && -f "${CHIRP_ADAPTER}" ]]; then
+    start_ingress "${CHIRP_ADAPTER}" "CHIRP"
+  fi
+
+  HARNESS_FAMILY="${HARNESS_FAMILY:-${HARNESS%%/*}}"
+  HARNESS_FAMILY_DIR="${HARNESS_FAMILY_DIR:-${APP_ROOT}/harness}"
+
+  if [[ "${HARNESS_FAMILY}" == "livekit" ]]; then
+    echo "starting LiveKit Cloud worker (${HARNESS})"
+    exec python "${HARNESS_DIR}/agent.py" start
+  fi
+
+  if [[ "${HARNESS_FAMILY}" == "pipecat" ]]; then
+    echo "starting Pipecat LiveKit Cloud worker (${HARNESS})"
+    exec python "${HARNESS_FAMILY_DIR}/adapters/livekit_worker.py"
+  fi
+
+  echo "starting harness agent (${HARNESS}) mode=${MIVAS_MODE}"
+  exec python "${HARNESS_DIR}/agent.py" "${INDUSTRY}"
+}
+
+if [[ "${MIVAS_ROLE}" == "tools" ]]; then
+  echo "starting tool server (${INDUSTRY}) on :${TOOL_SERVER_PORT} (role=tools)"
+  exec python "${INDUSTRY_DIR}/tool_server.py"
 fi
 
-HARNESS_FAMILY="${HARNESS_FAMILY:-${HARNESS%%/*}}"
-HARNESS_FAMILY_DIR="${HARNESS_FAMILY_DIR:-${APP_ROOT}/harness}"
-
-if [[ "${HARNESS_FAMILY}" == "livekit" ]]; then
-  echo "starting LiveKit Cloud worker (${HARNESS})"
-  exec python "${HARNESS_DIR}/agent.py" start
+if [[ "${MIVAS_ROLE}" == "harness" ]]; then
+  echo "starting harness health stub on :${TOOL_SERVER_PORT}"
+  python "${APP_ROOT}/runtime/harness_health.py" &
+  wait_for_tools "${TOOL_SERVER_URL}"
+  start_harness
 fi
 
-if [[ "${HARNESS_FAMILY}" == "pipecat" ]]; then
-  echo "starting Pipecat LiveKit Cloud worker (${HARNESS})"
-  exec python "${HARNESS_FAMILY_DIR}/adapters/livekit_worker.py"
+echo "starting tool server (${INDUSTRY}) on :${TOOL_SERVER_PORT}"
+python "${INDUSTRY_DIR}/tool_server.py" &
+TOOL_PID=$!
+cleanup() {
+  kill "${TOOL_PID}" 2>/dev/null || true
+}
+trap cleanup EXIT
+if ! wait_for_tools "${TOOL_SERVER_URL}"; then
+  if ! kill -0 "${TOOL_PID}" 2>/dev/null; then
+    echo "tool server exited before becoming healthy" >&2
+  fi
+  exit 1
 fi
-
-echo "starting harness agent (${HARNESS}) mode=${MIVAS_MODE}"
-exec python "${HARNESS_DIR}/agent.py" "${INDUSTRY}"
+start_harness

--- a/runtime/harness_health.py
+++ b/runtime/harness_health.py
@@ -1,0 +1,37 @@
+"""HTTP /health on the harness pod after the tool server moves to its own Deployment.
+
+ALB still probes the CHIRP target's :8000. This process answers that probe; it is
+not the industry tool server.
+"""
+
+from __future__ import annotations
+
+import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class _Health(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802
+        path = self.path.split("?", 1)[0].rstrip("/") or "/"
+        if path == "/health":
+            body = b'{"status":"ok"}'
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A003
+        return
+
+
+def main() -> None:
+    port = int(os.environ.get("TOOL_SERVER_PORT", "8000"))
+    HTTPServer(("0.0.0.0", port), _Health).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/runtime/snapshot.py
+++ b/runtime/snapshot.py
@@ -1,0 +1,55 @@
+"""Freeze a call's GET /state dump on the tools replica at teardown.
+
+Evals load ``GET /snapshot/{id}`` (Ingress → tools ClusterIP). They do not
+need to know which harness pod owned the WebSocket. Replica death after this
+write is fine: the JSON lives next to that call's SQLite file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+
+def capture_final(call_id: str) -> dict[str, Any] | None:
+    """GET /state for this id, then POST /snapshot so evals can read it back."""
+    cid = str(call_id or "").strip()
+    if not cid:
+        return None
+    base = os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").strip().rstrip("/")
+    if not base:
+        return None
+    q = urllib.parse.urlencode({"call_id": cid})
+    try:
+        with urllib.request.urlopen(f"{base}/state?{q}", timeout=5) as resp:
+            raw = resp.read()
+    except (urllib.error.URLError, TimeoutError, OSError, ValueError) as e:
+        print(f"snapshot: GET /state failed sim={cid} err={e}", flush=True)
+        return None
+    try:
+        state = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(f"snapshot: GET /state not json sim={cid} err={e}", flush=True)
+        return None
+    if not isinstance(state, dict):
+        print(f"snapshot: GET /state not an object sim={cid}", flush=True)
+        return None
+    body = json.dumps({"call_id": cid, "state": state}).encode()
+    req = urllib.request.Request(
+        f"{base}/snapshot",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            resp.read()
+    except (urllib.error.URLError, TimeoutError, OSError) as e:
+        print(f"snapshot: POST /snapshot failed sim={cid} err={e}", flush=True)
+        return None
+    print(f"snapshot: final sim={cid}", flush=True)
+    return state

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -42,7 +42,12 @@ def start_tool_server(industry: str, port: int = 8000) -> subprocess.Popen[bytes
     env["TOOL_SERVER_PORT"] = str(port)
     env["TOOL_SERVER_URL"] = f"http://127.0.0.1:{port}"
     env["MIVAS_DB_PATH"] = str(industry_dir / "db" / "runtime.db")
+    env.setdefault("MIVAS_DB_SHARED", "1")
     env["INDUSTRY_DIR"] = str(industry_dir)
+    runtime = str(ROOT / "runtime")
+    env["PYTHONPATH"] = runtime + (
+        os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else ""
+    )
 
     proc = subprocess.Popen(
         [sys.executable, str(industry_dir / "tool_server.py")],

--- a/tests/test_a5_smoke.py
+++ b/tests/test_a5_smoke.py
@@ -1,0 +1,420 @@
+"""A5 smoke: live tool-server processes, overlapping calls, distinct SQLite files.
+
+Proves Part A end-to-end at HTTP level (replicas = 1): two concurrent calls on
+the same pod get two files; GET /state for an unused id is seed; each dump is
+seed plus that call's writes only.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import threading
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNTIME = ROOT / "runtime"
+if str(RUNTIME) not in sys.path:
+    sys.path.insert(0, str(RUNTIME))
+
+from call_id import set_call_id  # noqa: E402
+
+INDUSTRIES = ("control-industry", "healthcare", "finance", "legal", "travel")
+
+
+def _health_ok(url: str) -> bool:
+    try:
+        with urllib.request.urlopen(f"{url.rstrip('/')}/health", timeout=1) as resp:
+            return 200 <= resp.status < 300
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return False
+
+
+def _start_isolated(industry: str, port: int, data_dir: Path) -> subprocess.Popen[bytes]:
+    industry_dir = ROOT / "industries" / industry
+    env = os.environ.copy()
+    env["TOOL_SERVER_PORT"] = str(port)
+    env["TOOL_SERVER_URL"] = f"http://127.0.0.1:{port}"
+    env["MIVAS_DB_PATH"] = str(data_dir / "runtime.db")
+    env["MIVAS_DB_SHARED"] = "0"
+    env["INDUSTRY_DIR"] = str(industry_dir)
+    env["PYTHONPATH"] = str(RUNTIME) + (
+        os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else ""
+    )
+    proc = subprocess.Popen(
+        [sys.executable, str(industry_dir / "tool_server.py")],
+        env=env,
+        cwd=str(ROOT),
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+    )
+    url = env["TOOL_SERVER_URL"]
+    for _ in range(80):
+        if _health_ok(url):
+            return proc
+        if proc.poll() is not None:
+            err = proc.stderr.read().decode() if proc.stderr else ""
+            raise RuntimeError(f"{industry} tool server exited: {err[-500:]}")
+        time.sleep(0.1)
+    proc.terminate()
+    raise RuntimeError(f"{industry} tool server failed health on {url}")
+
+
+def _stop(proc: subprocess.Popen[bytes] | None) -> None:
+    if proc is None or proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+def _post(url: str, name: str, args: dict[str, Any], call_id: str) -> dict[str, Any]:
+    resp = httpx.post(
+        f"{url}/tools/{name}",
+        json={"arguments": args},
+        headers={"X-Mivas-Call-Id": call_id},
+        timeout=15.0,
+    )
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _state(url: str, call_id: str) -> dict[str, Any]:
+    resp = httpx.get(f"{url}/state", params={"call_id": call_id}, timeout=15.0)
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+def _db_files(data_dir: Path) -> list[Path]:
+    calls = data_dir / "calls"
+    if not calls.is_dir():
+        return []
+    return sorted(p for p in calls.glob("*.db") if p.is_file())
+
+
+def _sqlite_tables(path: Path) -> dict[str, int]:
+    conn = sqlite3.connect(path)
+    try:
+        names = [
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'"
+            )
+        ]
+        return {n: conn.execute(f"SELECT COUNT(*) FROM {n}").fetchone()[0] for n in names}
+    finally:
+        conn.close()
+
+
+def test_overlapping_calls_use_distinct_sqlite_files(tmp_path: Path) -> None:
+    """Two overlapping HTTP calls on one process → two files, no cross-leak."""
+    reports: list[dict[str, Any]] = []
+    for i, industry in enumerate(INDUSTRIES):
+        data_dir = tmp_path / industry
+        data_dir.mkdir()
+        port = 18100 + i
+        url = f"http://127.0.0.1:{port}"
+        proc = _start_isolated(industry, port, data_dir)
+        try:
+            seed = _state(url, "seed_probe")
+            barrier = threading.Barrier(2)
+
+            def write_a() -> dict[str, Any]:
+                barrier.wait(timeout=10)
+                return _write(industry, url, "675")
+
+            def write_b() -> dict[str, Any]:
+                barrier.wait(timeout=10)
+                return _write(industry, url, "676")
+
+            with ThreadPoolExecutor(max_workers=2) as pool:
+                fa = pool.submit(write_a)
+                fb = pool.submit(write_b)
+                out_a, out_b = fa.result(timeout=20), fb.result(timeout=20)
+
+            final_a = _state(url, "675")
+            final_b = _state(url, "676")
+            unused = _state(url, "677")
+            files = _db_files(data_dir)
+            names = {p.name for p in files}
+            assert {"675.db", "676.db", "677.db", "seed_probe.db"} <= names, names
+            inodes = {p.stat().st_ino for p in files if p.name in {"675.db", "676.db"}}
+            assert len(inodes) == 2, "675 and 676 must be distinct inodes"
+            assert final_a != final_b
+            assert _canonical(unused) == _canonical(seed)
+            _assert_industry_isolation(industry, seed, final_a, final_b, unused)
+            miss = httpx.get(f"{url}/state", timeout=10.0)
+            assert miss.status_code == 400
+            reports.append(
+                {
+                    "industry": industry,
+                    "files": sorted(names),
+                    "files_detail": [
+                        {
+                            "name": p.name,
+                            "ino": p.stat().st_ino,
+                            "bytes": p.stat().st_size,
+                        }
+                        for p in files
+                    ],
+                    "inodes": len(inodes),
+                    "a": _summary(industry, final_a),
+                    "b": _summary(industry, final_b),
+                    "unused": _summary(industry, unused),
+                    "seed": _summary(industry, seed),
+                    "write_a": out_a,
+                    "write_b": out_b,
+                    "table_counts": {p.name: _sqlite_tables(p) for p in files},
+                }
+            )
+        finally:
+            _stop(proc)
+    payload = json.dumps(reports, indent=2, default=str)
+    (tmp_path / "a5_report.json").write_text(payload)
+    Path("/tmp/mivas-a5-report.json").write_text(payload)
+
+
+def _write(industry: str, url: str, call_id: str) -> dict[str, Any]:
+    if industry == "control-industry":
+        date = "08/15/2026" if call_id == "675" else "08/16/2026"
+        return _post(url, "schedule_appointment", {"date": date}, call_id)
+    if industry == "healthcare":
+        if call_id == "675":
+            ident = _post(
+                url,
+                "verify_identity",
+                {"full_name": "Alice Romano", "dob": "1995-09-08"},
+                call_id,
+            )
+            cancel = _post(
+                url,
+                "cancel_appointment",
+                {"appointment_id": "3", "cancellation_reason_code": "patient_request"},
+                call_id,
+            )
+            return {"verify": ident, "cancel": cancel}
+        return _post(
+            url,
+            "verify_identity",
+            {"full_name": "Jordan Lee", "dob": "1990-04-12"},
+            call_id,
+        )
+    if industry == "finance":
+        reason = "caller_request" if call_id == "675" else "business_services"
+        return _post(url, "escalate_to_human", {"reason_code": reason}, call_id)
+    if industry == "legal":
+        if call_id == "675":
+            _post(
+                url,
+                "lookup_caller",
+                {"full_name": "Dana Whitfield", "phone": "5105550142"},
+                call_id,
+            )
+            return _post(
+                url,
+                "take_message",
+                {"for_whom": "reception", "message": "please call back A"},
+                call_id,
+            )
+        _post(
+            url,
+            "lookup_caller",
+            {"full_name": "Marcus Oyelaran", "phone": "4155550188"},
+            call_id,
+        )
+        return _post(
+            url,
+            "take_message",
+            {"for_whom": "reception", "message": "please call back B"},
+            call_id,
+        )
+    if industry == "travel":
+        reason = "caller_request" if call_id == "675" else "irrops"
+        return _post(url, "escalate_to_human", {"reason_code": reason}, call_id)
+    raise AssertionError(industry)
+
+
+def _canonical(value: Any) -> Any:
+    """Drop wall-clock created_at so two seed copies compare equal."""
+    if isinstance(value, dict):
+        return {k: _canonical(v) for k, v in value.items() if k != "created_at"}
+    if isinstance(value, list):
+        return [_canonical(v) for v in value]
+    return value
+
+
+def _assert_industry_isolation(
+    industry: str,
+    seed: dict[str, Any],
+    a: dict[str, Any],
+    b: dict[str, Any],
+    unused: dict[str, Any],
+) -> None:
+    assert _canonical(unused) == _canonical(seed)
+    if industry == "control-industry":
+        assert [r["date"] for r in a["appointments"]] == ["08/15/2026"]
+        assert [r["date"] for r in b["appointments"]] == ["08/16/2026"]
+        assert unused["appointments"] == []
+        return
+    if industry == "healthcare":
+        a_status = {r["id"]: r["status"] for r in a["appointments"]}
+        b_status = {r["id"]: r["status"] for r in b["appointments"]}
+        seed_status = {r["id"]: r["status"] for r in seed["appointments"]}
+        assert a_status[3] == "cancelled"
+        assert b_status[3] == "booked"
+        assert seed_status[3] == "booked"
+        return
+    if industry == "finance":
+        assert [r["reason_code"] for r in a.get("escalations") or []] == ["caller_request"]
+        assert [r["reason_code"] for r in b.get("escalations") or []] == ["business_services"]
+        assert (unused.get("escalations") or []) == []
+        return
+    if industry == "legal":
+        a_msgs = [r.get("message") for r in a.get("messages") or []]
+        b_msgs = [r.get("message") for r in b.get("messages") or []]
+        assert a_msgs == ["please call back A"]
+        assert b_msgs == ["please call back B"]
+        assert (unused.get("messages") or []) == []
+        return
+    if industry == "travel":
+        assert [r["reason_code"] for r in a.get("escalations") or []] == ["caller_request"]
+        assert [r["reason_code"] for r in b.get("escalations") or []] == ["irrops"]
+        assert (unused.get("escalations") or []) == []
+        return
+    assert a != seed
+    assert b != a
+
+
+def _summary(industry: str, state: dict[str, Any]) -> Any:
+    if industry == "control-industry":
+        return [r.get("date") for r in state.get("appointments") or []]
+    if industry == "healthcare":
+        return {
+            "appt_status": {r["id"]: r["status"] for r in state.get("appointments") or []},
+            "tool_events": len(state.get("tool_events") or []),
+        }
+    if industry == "finance":
+        return {
+            "escalations": [
+                {k: r.get(k) for k in ("id", "reason_code", "member_id") if k in r or True}
+                for r in (state.get("escalations") or [])
+            ],
+            "tool_events": len(state.get("tool_events") or []),
+        }
+    if industry == "legal":
+        return {
+            "messages": [
+                {k: r.get(k) for k in ("id", "for_whom", "message", "caller_id")}
+                for r in (state.get("messages") or state.get("voicemails") or [])
+            ],
+            "escalations": len(state.get("escalations") or []),
+            "tool_events": len(state.get("tool_events") or []),
+        }
+    if industry == "travel":
+        return {
+            "escalations": [
+                {k: r.get(k) for k in ("id", "reason_code", "confirmation_code")}
+                for r in (state.get("escalations") or [])
+            ],
+            "tool_events": len(state.get("tool_events") or []),
+        }
+    keys = sorted(state)
+    return {k: (len(state[k]) if isinstance(state[k], list) else type(state[k]).__name__) for k in keys}
+
+
+def test_harness_dispatch_hits_per_call_files(tmp_path: Path) -> None:
+    """OpenAI / Grok / Twilio dispatch against a live control-industry server."""
+    data_dir = tmp_path / "control"
+    data_dir.mkdir()
+    port = 18200
+    url = f"http://127.0.0.1:{port}"
+    proc = _start_isolated("control-industry", port, data_dir)
+    os.environ["TOOL_SERVER_URL"] = url
+    try:
+        seed = _state(url, "unused")
+        _dispatch_openai(url, "675", "08/15/2026")
+        _dispatch_grok(url, "676", "08/16/2026")
+        _dispatch_twilio(url, "678", "08/18/2026")
+        a, b, c = _state(url, "675"), _state(url, "676"), _state(url, "678")
+        unused = _state(url, "unused")
+        assert [r["date"] for r in a["appointments"]] == ["08/15/2026"]
+        assert [r["date"] for r in b["appointments"]] == ["08/16/2026"]
+        assert [r["date"] for r in c["appointments"]] == ["08/18/2026"]
+        assert unused == seed
+        names = {p.name for p in _db_files(data_dir)}
+        assert {"675.db", "676.db", "678.db", "unused.db"} <= names
+        inodes = {p.stat().st_ino for p in _db_files(data_dir) if p.stem in {"675", "676", "678"}}
+        assert len(inodes) == 3
+    finally:
+        _stop(proc)
+
+
+def _dispatch_openai(url: str, call_id: str, date: str) -> None:
+    family = ROOT / "voice-agent-harnesses" / "openai"
+    if str(family) not in sys.path:
+        sys.path.insert(0, str(family))
+    import harness as openai_harness
+
+    openai_harness.TOOL_SERVER_URL = url
+    set_call_id(call_id)
+    import asyncio
+
+    result = asyncio.run(
+        openai_harness.dispatch_industry_tool("schedule_appointment", {"date": date})
+    )
+    assert result.get("success") is True, result
+
+
+def _dispatch_grok(url: str, call_id: str, date: str) -> None:
+    import asyncio
+    import importlib.util
+
+    family = ROOT / "voice-agent-harnesses" / "grok"
+    spec = importlib.util.spec_from_file_location("mivas_grok_harness", family / "harness.py")
+    assert spec is not None and spec.loader is not None
+    grok = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(grok)
+    set_call_id(call_id)
+    bp = {
+        "agents": {"scheduler": {"tools": [{"name": "schedule_appointment"}]}},
+        "catalog": {"schedule_appointment": {}},
+    }
+    result, stop = asyncio.run(
+        grok._execute_tool("schedule_appointment", {"date": date}, bp, {"agent": "scheduler"})
+    )
+    assert stop is False
+    assert result.get("success") is True, result
+
+
+def _dispatch_twilio(url: str, call_id: str, date: str) -> None:
+    family = ROOT / "voice-agent-harnesses" / "twilio"
+    import importlib
+
+    spec = importlib.util.spec_from_file_location("mivas_twilio_harness", family / "harness.py")
+    assert spec and spec.loader
+    twilio = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(twilio)
+    set_call_id(call_id)
+    import asyncio
+
+    # twilio reads TOOL_SERVER_URL at import — patch the helper
+    orig = twilio.tool_server_url
+    twilio.tool_server_url = lambda: url  # type: ignore[assignment]
+    try:
+        result = asyncio.run(twilio.dispatch_industry_tool("schedule_appointment", {"date": date}))
+    finally:
+        twilio.tool_server_url = orig
+    assert result.get("success") is True, result

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -18,7 +18,9 @@ from run import (  # noqa: E402
     pair_websocket_url,
     parse_agents,
     render_agents_yaml,
+    replica_count,
     slug,
+    tools_replica_count,
 )
 
 
@@ -45,7 +47,8 @@ def test_parse_agents_rejects_bad_entry() -> None:
         parse_agents("openai:healthcare")  # missing runtime slash
 
 
-def test_render_agents_yaml_two_pairs() -> None:
+def test_render_agents_yaml_two_pairs(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MIVAS_REPLICAS", raising=False)
     yaml_text = render_agents_yaml(
         [
             ("openai/realtime-2.1", "healthcare"),
@@ -53,18 +56,27 @@ def test_render_agents_yaml_two_pairs() -> None:
         ],
         "LoadBalancer",
     )
-    assert yaml_text.count("kind: Deployment") == 2
-    assert yaml_text.count("kind: Service") == 2
+    assert yaml_text.count("kind: Deployment") == 4
+    assert yaml_text.count("kind: Service") == 4
     assert "name: tools" in yaml_text
     assert "---" in yaml_text
     assert f"name: mivas-{slug('openai/realtime-2.1', 'healthcare')}" in yaml_text
+    assert f"name: mivas-{slug('openai/realtime-2.1', 'healthcare')}-tools" in yaml_text
     assert f"name: mivas-{slug('nvidia/nemotron', 'control-industry')}" in yaml_text
+    assert f"name: mivas-{slug('nvidia/nemotron', 'control-industry')}-tools" in yaml_text
     assert 'mivas.harness_family: "openai"' in yaml_text
     assert 'mivas.harness_runtime: "realtime-2.1"' in yaml_text
     assert 'mivas.harness_family: "nvidia"' in yaml_text
     assert 'mivas.harness_runtime: "nemotron"' in yaml_text
     assert "__SLUG__" not in yaml_text
     assert "__HARNESS_RUNTIME__" not in yaml_text
+    assert "Thank you for calling Straus Dermatology." in yaml_text
+    assert "Welcome to Bluejay's Repair Services!" in yaml_text
+    assert "__TWILIO_WELCOME_GREETING__" not in yaml_text
+    assert yaml_text.count("\n  replicas: 1\n") == 4
+    assert "__REPLICAS__" not in yaml_text
+    assert "__TOOLS_REPLICAS__" not in yaml_text
+    assert "http://mivas-" in yaml_text and "-tools:8000" in yaml_text
 
 
 def test_stable_ingress_urls(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -92,6 +104,18 @@ def test_stable_ingress_urls(monkeypatch: pytest.MonkeyPatch) -> None:
     assert 'alb.ingress.kubernetes.io/healthcheck-port: "8000"' in yaml_text
     assert "https://otlp.getbluejay.ai/v1/traces" in yaml_text
     assert "https://api.getbluejay.ai/v1" in yaml_text
+    assert "maxUnavailable: 0" in yaml_text
+    assert "maxSurge: 1" in yaml_text
+    assert (
+        "alb.ingress.kubernetes.io/target-group-attributes: "
+        "load_balancing.algorithm.type=least_outstanding_requests"
+    ) in yaml_text
+    assert "stickiness.enabled" not in yaml_text
+    assert f"name: mivas-{s}-tools" in yaml_text
+    assert "path: /tools" in yaml_text
+    assert "path: /state" in yaml_text
+    assert "path: /snapshot" in yaml_text
+    assert yaml_text.index("path: /tools") < yaml_text.index("path: /\n")
 
 
 def test_worker_families_skip_ingress(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -109,12 +133,14 @@ def test_worker_families_skip_ingress(monkeypatch: pytest.MonkeyPatch) -> None:
         "ClusterIP",
     )
     # "kind: Ingress" is a prefix of IngressClass / IngressClassParams; match the
-    # resource kind line exactly.
-    assert yaml_text.count("\nkind: Ingress\n") == 1
-    assert yaml_text.count("kind: Deployment") == 3
+    # resource kind line exactly. CHIRP pair gets chirp+tools Ingress; workers
+    # get tools-only Ingress (Pipecat Cloud POSTs https://host/tools/...).
+    assert yaml_text.count("\nkind: Ingress\n") == 3
+    assert yaml_text.count("kind: Deployment") == 6
     assert "host: openai-realtime-2-1-control-industry.benchmarks.example.com" in yaml_text
-    assert "livekit-cascaded-control-industry.benchmarks.example.com" not in yaml_text
-    assert "pipecat-openai-realtime-2-1-control-industry.benchmarks.example.com" not in yaml_text
+    assert "host: livekit-cascaded-control-industry.benchmarks.example.com" in yaml_text
+    assert "host: pipecat-openai-realtime-2-1-control-industry.benchmarks.example.com" in yaml_text
+    assert yaml_text.count("path: /tools") == 3
     assert 'name: MIVAS_MODE\n              value: "chirp"' in yaml_text
     assert 'name: MIVAS_MODE\n              value: "agent"' in yaml_text
     from run import pair_host, pair_mivas_mode, pair_needs_ingress
@@ -122,7 +148,28 @@ def test_worker_families_skip_ingress(monkeypatch: pytest.MonkeyPatch) -> None:
     assert pair_needs_ingress("openai/realtime-2.1")
     assert not pair_needs_ingress("livekit/cascaded")
     assert pair_mivas_mode("pipecat/cascaded") == "agent"
+    assert pair_mivas_mode("openai/realtime-2.1") == "chirp"
     assert pair_host("livekit/cascaded", "control-industry") is None
+    from run import pair_dns_host, pair_public_url
+
+    assert (
+        pair_dns_host("livekit/cascaded", "control-industry")
+        == "livekit-cascaded-control-industry.benchmarks.example.com"
+    )
+    assert pair_public_url("pipecat/cascaded", "control-industry") == (
+        "https://pipecat-cascaded-control-industry.benchmarks.example.com"
+    )
+
+
+def test_twilio_ingress_is_conversationrelay() -> None:
+    from run import ingress_adapter, pair_mivas_mode
+
+    harness = "twilio/conversationrelay-gpt4.1"
+    assert pair_mivas_mode(harness) == "conversationrelay"
+    assert ingress_adapter(harness).name == "conversationrelay.py"
+    yaml_text = render_agents_yaml([(harness, "control-industry")], "LoadBalancer")
+    assert 'name: MIVAS_MODE\n              value: "conversationrelay"' in yaml_text
+    assert 'name: MIVAS_MODE\n              value: "chirp"' not in yaml_text
 
 
 def test_image_ref_registry(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -148,3 +195,46 @@ def test_ecr_registry_host() -> None:
         == "148660429236.dkr.ecr.us-west-1.amazonaws.com"
     )
     assert _ecr_registry_host("ghcr.io/bluejay/mivas-bench") is None
+
+
+def test_replica_count_defaults_to_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MIVAS_REPLICAS", raising=False)
+    assert replica_count() == 1
+    monkeypatch.setenv("MIVAS_REPLICAS", "")
+    assert replica_count() == 1
+    monkeypatch.setenv("MIVAS_REPLICAS", " 2 ")
+    assert replica_count() == 2
+
+
+def test_replica_count_rejects_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MIVAS_REPLICAS", "0")
+    with pytest.raises(ValueError, match="MIVAS_REPLICAS"):
+        replica_count()
+    monkeypatch.setenv("MIVAS_REPLICAS", "-1")
+    with pytest.raises(ValueError, match="MIVAS_REPLICAS"):
+        replica_count()
+    monkeypatch.setenv("MIVAS_REPLICAS", "two")
+    with pytest.raises(ValueError, match="MIVAS_REPLICAS"):
+        replica_count()
+
+
+def test_render_respects_mivas_replicas(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MIVAS_REPLICAS", "3")
+    yaml_text = render_agents_yaml(
+        [("openai/realtime-2.1", "control-industry")],
+        "LoadBalancer",
+    )
+    s = slug("openai/realtime-2.1", "control-industry")
+    assert f"name: mivas-{s}-tools" in yaml_text
+    assert "\n  replicas: 3\n" in yaml_text
+    assert "\n  replicas: 1\n" in yaml_text
+    assert f"http://mivas-{s}-tools:8000" in yaml_text
+    assert "__REPLICAS__" not in yaml_text
+    assert "__TOOLS_REPLICAS__" not in yaml_text
+    assert tools_replica_count() == 1
+
+
+def test_tools_replicas_must_be_one(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MIVAS_TOOLS_REPLICAS", "2")
+    with pytest.raises(ValueError, match="MIVAS_TOOLS_REPLICAS"):
+        tools_replica_count()

--- a/tests/test_call_id.py
+++ b/tests/test_call_id.py
@@ -1,0 +1,131 @@
+"""call_id helper in isolation — no harness imported."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNTIME = ROOT / "runtime"
+if str(RUNTIME) not in sys.path:
+    sys.path.insert(0, str(RUNTIME))
+
+from call_id import (  # noqa: E402
+    CALL_ID,
+    HEADER,
+    begin_session,
+    bind_provider,
+    end_session,
+    for_provider,
+    headers,
+    log_tool_post,
+    log_ws_accept,
+    pod_name,
+    provider_id_from_payload,
+    provider_id_from_request,
+    reset,
+    set_call_id,
+    sole_session,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_call_id() -> None:
+    reset()
+    yield
+    reset()
+
+
+def test_set_call_id_uses_bluejay_id() -> None:
+    assert set_call_id("675") == "675"
+    assert CALL_ID.get() == "675"
+    assert headers() == {HEADER: "675"}
+
+
+def test_set_call_id_mints_when_missing() -> None:
+    minted = set_call_id(None)
+    assert minted.startswith("call_")
+    assert len(minted) > 5
+    assert headers()[HEADER] == minted
+    assert set_call_id("") != ""
+    assert set_call_id("  ") != "  "
+
+
+def test_headers_never_empty() -> None:
+    reset()
+    got = headers()
+    assert HEADER in got
+    assert got[HEADER]
+    assert not got[HEADER].isspace()
+
+
+def test_headers_explicit_id_wins() -> None:
+    set_call_id("675")
+    assert headers("676") == {HEADER: "676"}
+    assert CALL_ID.get() == "675"
+
+
+def test_bind_and_for_provider_roundtrip() -> None:
+    bind_provider("vapi-aaa", "675")
+    bind_provider("vapi-bbb", "676")
+    assert for_provider("vapi-aaa") == "675"
+    assert CALL_ID.get() == "675"
+    assert for_provider("vapi-bbb") == "676"
+    assert CALL_ID.get() == "676"
+
+
+def test_two_provider_calls_do_not_clobber() -> None:
+    bind_provider("a", "675")
+    bind_provider("b", "676")
+    assert for_provider("a") == "675"
+    assert for_provider("b") == "676"
+    assert for_provider("a") == "675"
+
+
+def test_sole_session_used_when_provider_unknown() -> None:
+    begin_session("675", session_key="ws-1")
+    assert sole_session() == "675"
+    assert for_provider("mystery") == "675"
+
+
+def test_two_sessions_block_sole_fallback() -> None:
+    begin_session("675", session_key="ws-1")
+    begin_session("676", session_key="ws-2")
+    assert sole_session() is None
+    minted = for_provider("mystery")
+    assert minted not in {"675", "676"}
+    assert minted.startswith("call_")
+
+
+def test_end_session_restores_sole() -> None:
+    begin_session("675", session_key="ws-1")
+    begin_session("676", session_key="ws-2")
+    end_session("ws-2")
+    assert sole_session() == "675"
+
+
+def test_provider_id_from_payload() -> None:
+    assert provider_id_from_payload({"call": {"id": "vapi-1"}}) == "vapi-1"
+    assert provider_id_from_payload({"call": {"call_id": "retell-1"}}) == "retell-1"
+    assert provider_id_from_payload({"call_id": "x"}) == "x"
+    assert provider_id_from_payload({"date": "08/15/2026"}) is None
+    assert provider_id_from_payload(None) is None
+
+
+def test_provider_id_from_request() -> None:
+    assert provider_id_from_request({"call_id": "body"}) == "body"
+    assert provider_id_from_request({}, query={"call_id": "q"}) == "q"
+    assert provider_id_from_request({}, headers={"x-call-id": "hdr"}) == "hdr"
+    assert provider_id_from_request({"date": "08/15/2026"}) is None
+
+
+def test_pinning_logs_include_pod(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    monkeypatch.setenv("HOSTNAME", "mivas-openai-aaa")
+    assert pod_name() == "mivas-openai-aaa"
+    log_ws_accept("675")
+    log_tool_post("675", path="/tools/schedule_appointment")
+    out = capsys.readouterr().out
+    assert "call_id: ws_accept sim=675 pod=mivas-openai-aaa" in out
+    assert "call_id: tool_post sim=675 pod=mivas-openai-aaa path=/tools/schedule_appointment" in out

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -1,0 +1,209 @@
+"""DBService in isolation — no industry tool_server imported.
+
+Callers (industry routes) still do `with db.connect() as conn: conn.execute(...)`.
+These tests only assert the file-per-call behavior behind that connection.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNTIME = ROOT / "runtime"
+if str(RUNTIME) not in sys.path:
+    sys.path.insert(0, str(RUNTIME))
+
+from db_service import CallIdError, DBService  # noqa: E402
+
+SCHEMA = """
+CREATE TABLE items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL
+);
+"""
+SEED = "INSERT INTO items (name) VALUES ('seeded');"
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> DBService:
+    schema = tmp_path / "schema.sql"
+    seed = tmp_path / "seed.sql"
+    schema.write_text(SCHEMA)
+    seed.write_text(SEED)
+    return DBService(schema_path=schema, seed_path=seed, data_dir=tmp_path)
+
+
+def test_ensure_creates_schema_and_seed(db: DBService, tmp_path: Path) -> None:
+    path = db.ensure("675")
+    assert path.is_file()
+    conn = sqlite3.connect(path)
+    try:
+        names = [r[0] for r in conn.execute("SELECT name FROM items ORDER BY id")]
+    finally:
+        conn.close()
+    assert names == ["seeded"]
+    assert path.parent == tmp_path / "calls"
+    assert path.name == "675.db"
+
+
+def test_second_ensure_does_not_reseed(db: DBService) -> None:
+    path = db.ensure("675")
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("INSERT INTO items (name) VALUES ('written')")
+        conn.commit()
+    finally:
+        conn.close()
+    again = db.ensure("675")
+    assert again == path
+    conn = sqlite3.connect(again)
+    try:
+        names = [r[0] for r in conn.execute("SELECT name FROM items ORDER BY id")]
+    finally:
+        conn.close()
+    assert names == ["seeded", "written"]
+
+
+def test_distinct_ids_are_isolated(db: DBService) -> None:
+    a = db.ensure("675")
+    b = db.ensure("676")
+    assert a != b
+    conn = sqlite3.connect(a)
+    try:
+        conn.execute("INSERT INTO items (name) VALUES ('only-a')")
+        conn.commit()
+    finally:
+        conn.close()
+    conn = sqlite3.connect(b)
+    try:
+        names = [r[0] for r in conn.execute("SELECT name FROM items ORDER BY id")]
+    finally:
+        conn.close()
+    assert names == ["seeded"]
+
+
+def test_concurrent_ensure_creates_one_file(db: DBService) -> None:
+    from concurrent.futures import ThreadPoolExecutor
+
+    paths: list[Path] = []
+
+    def once() -> None:
+        paths.append(db.ensure("675"))
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(lambda _: once(), range(16)))
+    assert len({p.resolve() for p in paths}) == 1
+    files = list((db.data_dir / "calls").glob("*.db"))
+    assert len(files) == 1
+    conn = sqlite3.connect(paths[0])
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM items").fetchone()[0]
+    finally:
+        conn.close()
+    assert n == 1  # seed applied once, not 16 times
+
+
+def test_empty_and_path_ids_are_rejected(db: DBService) -> None:
+    for bad in ("", "   ", "../evil", "..", "foo/bar", "a" * 65):
+        with pytest.raises(CallIdError):
+            db.ensure(bad)
+
+
+def test_connect_sees_seed_and_persists_writes(db: DBService) -> None:
+    with db.scope("675"):
+        with db.connect() as conn:
+            names = [r["name"] for r in conn.execute("SELECT name FROM items ORDER BY id")]
+            assert names == ["seeded"]
+            conn.execute("INSERT INTO items (name) VALUES ('written')")
+    with db.scope("675"):
+        with db.connect() as conn:
+            names = [r["name"] for r in conn.execute("SELECT name FROM items ORDER BY id")]
+    assert names == ["seeded", "written"]
+
+
+def test_connect_without_call_id_is_rejected(db: DBService) -> None:
+    with pytest.raises(CallIdError):
+        with db.connect():
+            pass
+
+
+def test_shared_mode_allows_missing_call_id(tmp_path: Path) -> None:
+    schema = tmp_path / "schema.sql"
+    seed = tmp_path / "seed.sql"
+    schema.write_text(SCHEMA)
+    seed.write_text(SEED)
+    db = DBService(schema_path=schema, seed_path=seed, data_dir=tmp_path, shared=True)
+    with db.connect() as conn:
+        conn.execute("INSERT INTO items (name) VALUES ('debug')")
+    with db.connect() as conn:
+        names = [r["name"] for r in conn.execute("SELECT name FROM items ORDER BY id")]
+    assert names == ["seeded", "debug"]
+
+
+def test_middleware_scopes_header_and_rejects_miss(db: DBService) -> None:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    app = FastAPI()
+    app.middleware("http")(db.http_middleware)
+    db.mount_cluster_routes(app)
+
+    @app.get("/health")
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/count")
+    def count() -> dict[str, int]:
+        with db.connect() as conn:
+            n = conn.execute("SELECT COUNT(*) AS n FROM items").fetchone()["n"]
+        return {"n": n}
+
+    @app.post("/write")
+    def write() -> dict[str, str]:
+        with db.connect() as conn:
+            conn.execute("INSERT INTO items (name) VALUES ('x')")
+        return {"ok": "true"}
+
+    client = TestClient(app)
+    assert client.get("/health").status_code == 200
+    assert client.get("/count").status_code == 400
+    assert client.get("/count", headers={"X-Mivas-Call-Id": "675"}).json() == {"n": 1}
+    assert client.post("/write", headers={"X-Mivas-Call-Id": "675"}).status_code == 200
+    assert client.get("/count?call_id=675").json() == {"n": 2}
+    assert client.get("/count", headers={"X-Mivas-Call-Id": "676"}).json() == {"n": 1}
+    assert client.get("/count", headers={"X-Mivas-Call-Id": "../evil"}).status_code == 400
+    bind = client.post("/bind", json={"provider_call_id": "vapi-1", "sim_id": "675"})
+    assert bind.status_code == 200, bind.text
+    assert client.get("/bind/vapi-1").json()["sim_id"] == "675"
+    assert client.get("/bind/missing").status_code == 404
+    a = {"appointments": [{"date": "08/18/2026"}]}
+    b = {"appointments": [{"date": "09/01/2026"}]}
+    assert client.post("/snapshot", json={"call_id": "675", "state": a}).status_code == 200
+    assert client.post("/snapshot", json={"call_id": "676", "state": b}).status_code == 200
+    assert client.get("/snapshot/675").json() == a
+    assert client.get("/snapshot/676").json() == b
+    assert client.get("/snapshot/677").status_code == 404
+    assert client.post("/snapshot", json={"call_id": "675"}).status_code == 400
+    assert client.get("/snapshot/bad.id").status_code == 400
+
+
+def test_for_industry_uses_env_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    industry = tmp_path / "pack"
+    db_dir = industry / "db"
+    db_dir.mkdir(parents=True)
+    (db_dir / "schema.sql").write_text(SCHEMA)
+    (db_dir / "seed.sql").write_text(SEED)
+    data = tmp_path / "data"
+    monkeypatch.setenv("MIVAS_DB_PATH", str(data / "industry.db"))
+    monkeypatch.delenv("MIVAS_DB_SHARED", raising=False)
+    db = DBService.for_industry(industry)
+    path = db.ensure("675")
+    assert path == data / "calls" / "675.db"
+    assert path.is_file()
+    with pytest.raises(CallIdError):
+        with db.connect():
+            pass

--- a/tests/test_harness_tool_headers.py
+++ b/tests/test_harness_tool_headers.py
@@ -1,0 +1,291 @@
+"""Every harness POST to the industry tool server carries X-Mivas-Call-Id."""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import importlib.util
+import sys
+from collections.abc import Coroutine
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+from unittest.mock import patch
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNTIME = ROOT / "runtime"
+HARNESSES = ROOT / "voice-agent-harnesses"
+if str(RUNTIME) not in sys.path:
+    sys.path.insert(0, str(RUNTIME))
+
+from call_id import HEADER, bind_provider, for_provider, reset, set_call_id  # noqa: E402
+
+FAMILIES = (
+    "openai",
+    "gemini",
+    "vapi",
+    "retell",
+    "bland",
+    "cartesia",
+    "elevenlabs",
+    "twilio",
+    "grok",
+    "nvidia",
+    "assemblyai",
+    "deepgram",
+    "livekit",
+    "pipecat",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_call_id() -> None:
+    reset()
+    yield
+    reset()
+
+
+class _FakeResp:
+    def json(self) -> dict[str, Any]:
+        return {"ok": True, "success": True}
+
+
+class _RecordingClient:
+    posts: list[dict[str, Any]] = []
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    async def __aenter__(self) -> _RecordingClient:
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    async def post(self, url: str, json: Any = None, headers: Any = None) -> _FakeResp:
+        _RecordingClient.posts.append({"url": url, "json": json, "headers": headers or {}})
+        return _FakeResp()
+
+
+@contextmanager
+def _family_harness(family: str) -> Iterator[Any]:
+    family_dir = HARNESSES / family
+    saved = {name: sys.modules[name] for name in ("harness", "report") if name in sys.modules}
+    sys.modules.pop("harness", None)
+    sys.modules.pop("report", None)
+    sys.path.insert(0, str(family_dir))
+    sys.path.insert(0, str(RUNTIME))
+    try:
+        spec = importlib.util.spec_from_file_location(
+            f"mivas_{family}_harness", family_dir / "harness.py"
+        )
+        assert spec is not None and spec.loader is not None
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = mod
+        spec.loader.exec_module(mod)
+        yield mod
+    finally:
+        if str(family_dir) in sys.path:
+            sys.path.remove(str(family_dir))
+        sys.modules.pop("harness", None)
+        sys.modules.pop("report", None)
+        sys.modules.pop(f"mivas_{family}_harness", None)
+        sys.modules.update(saved)
+
+
+def _run(coro: Coroutine[Any, Any, Any]) -> Any:
+    return asyncio.run(coro)
+
+
+def test_no_harness_posts_appointments_for_industry_tools() -> None:
+    offenders: list[str] = []
+    for path in HARNESSES.rglob("*.py"):
+        if path.name == "report.py":
+            continue
+        text = path.read_text()
+        if "/appointments" not in text:
+            continue
+        tree = ast.parse(text)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            src = ast.get_source_segment(text, node) or ""
+            if "/appointments" in src and (
+                "tool_server" in src or "TOOL_SERVER" in src or "tool_server_url" in src
+            ):
+                offenders.append(f"{path.relative_to(ROOT)}: {src.splitlines()[0][:80]}")
+    assert offenders == []
+
+
+def test_every_tool_server_post_sets_call_id_header() -> None:
+    offenders: list[str] = []
+    for path in HARNESSES.rglob("*.py"):
+        if path.name == "report.py":
+            continue
+        text = path.read_text()
+        if "/tools/" not in text or ".post(" not in text:
+            continue
+        lines = text.splitlines()
+        for i, line in enumerate(lines):
+            if ".post(" not in line:
+                continue
+            window = "\n".join(lines[max(0, i - 4) : i + 12])
+            if "/tools/" not in window:
+                continue
+            if "TOOL_SERVER" not in window and "tool_server" not in window:
+                continue
+            if HEADER not in window and "tool_headers(" not in window and "headers(" not in window:
+                rel = path.relative_to(ROOT)
+                offenders.append(f"{rel}:{i + 1}: {line.strip()[:100]}")
+    assert offenders == []
+
+
+def test_platform_webhooks_bind_bluejay_id() -> None:
+    for family in ("vapi", "retell", "bland", "cartesia"):
+        text = (HARNESSES / family / "adapters" / "chirp.py").read_text()
+        assert "for_provider" in text, family
+        assert "begin_session" in text, family
+        assert "bind_provider" in text, family
+
+
+def test_cartesia_run_tool_keeps_webhook_bind() -> None:
+    """The Line webhook pins CALL_ID; run_tool must not for_provider(None) and mint."""
+    _RecordingClient.posts = []
+    try:
+        with _family_harness("cartesia") as harness:
+            bind_provider("sid_abc", "675")
+            for_provider("sid_abc")
+            with patch("httpx.AsyncClient", _RecordingClient):
+                _run(harness.run_tool("schedule_appointment", {"date": "08/15/2026"}))
+    except ModuleNotFoundError as e:
+        pytest.skip(str(e))
+    _assert_posted_header("675")
+
+
+def test_cartesia_line_tools_carry_provider_call_id() -> None:
+    """Line POSTs must include Cartesia call_id so a random replica can hit the bind store."""
+    text = (HARNESSES / "cartesia" / "line_agent" / "main.py").read_text()
+    assert "call_request" in text
+    assert "?call_id=" in text
+    assert "X-Call-Id" in text or "X-Cartesia-Call-Id" in text
+    harness = (HARNESSES / "cartesia" / "harness.py").read_text()
+    assert "src_digest" in harness
+    chirp = (HARNESSES / "cartesia" / "adapters" / "chirp.py").read_text()
+    assert "_record_line_tools" in chirp
+    assert "emit_span=False" in chirp
+    assert '"stream_id": resolved' in chirp
+
+
+def _assert_posted_header(expected: str) -> None:
+    assert _RecordingClient.posts, "expected a tool-server POST"
+    last = _RecordingClient.posts[-1]
+    assert "/tools/" in last["url"], last["url"]
+    assert "/appointments" not in last["url"], last["url"]
+    assert last["headers"].get(HEADER) == expected, last["headers"]
+
+
+@pytest.mark.parametrize("family", FAMILIES)
+def test_family_dispatch_sends_bluejay_header(family: str) -> None:
+    _RecordingClient.posts = []
+    try:
+        with _family_harness(family) as harness:
+            _dispatch_family(family, harness)
+    except ModuleNotFoundError as e:
+        pytest.skip(str(e))
+    _assert_posted_header("675")
+
+
+def test_vapi_two_calls_do_not_cross_headers() -> None:
+    _RecordingClient.posts = []
+    try:
+        with _family_harness("vapi") as harness:
+            bind_provider("vapi-aaa", "675")
+            bind_provider("vapi-bbb", "676")
+            with patch("httpx.AsyncClient", _RecordingClient):
+                _run(
+                    harness._execute_tool(
+                        "schedule_appointment",
+                        {"date": "08/15/2026"},
+                        for_provider("vapi-aaa"),
+                    )
+                )
+                _run(
+                    harness._execute_tool(
+                        "schedule_appointment",
+                        {"date": "08/16/2026"},
+                        for_provider("vapi-bbb"),
+                    )
+                )
+    except ModuleNotFoundError as e:
+        pytest.skip(str(e))
+    assert [p["headers"].get(HEADER) for p in _RecordingClient.posts] == ["675", "676"]
+
+
+def _dispatch_family(family: str, harness: Any) -> None:
+    set_call_id("675")
+    with patch("httpx.AsyncClient", _RecordingClient):
+        if family == "openai":
+            _run(harness.dispatch_industry_tool("schedule_appointment", {"date": "08/15/2026"}))
+            return
+        if family == "gemini":
+            _run(harness._dispatch("schedule_appointment", {"date": "08/15/2026"}))
+            return
+        if family == "vapi":
+            bind_provider("vapi-aaa", "675")
+            _run(
+                harness._execute_tool(
+                    "schedule_appointment", {"date": "08/15/2026"}, for_provider("vapi-aaa")
+                )
+            )
+            return
+        if family in {"retell", "bland", "cartesia", "elevenlabs"}:
+            _run(harness._execute_tool("schedule_appointment", {"date": "08/15/2026"}))
+            return
+        if family == "twilio":
+            _run(harness.dispatch_industry_tool("schedule_appointment", {"date": "08/15/2026"}))
+            return
+        if family in {"assemblyai", "deepgram"}:
+            _run(harness._dispatch("schedule_appointment", {"date": "08/15/2026"}))
+            return
+        if family == "livekit":
+            _run(harness._execute("schedule_appointment", {"date": "08/15/2026"}, local=False))
+            return
+        if family == "pipecat":
+            bp = {
+                "agents": {
+                    "receptionist": {
+                        "tools": [{"name": "schedule_appointment"}],
+                    }
+                },
+                "catalog": {"schedule_appointment": {}},
+            }
+            _run(
+                harness._execute_tool(
+                    "schedule_appointment",
+                    {"date": "08/15/2026"},
+                    bp,
+                    {"agent": "receptionist"},
+                )
+            )
+            return
+        if family in {"grok", "nvidia"}:
+            bp = {
+                "agents": {
+                    "scheduler": {
+                        "tools": [{"name": "schedule_appointment"}],
+                    }
+                },
+                "catalog": {"schedule_appointment": {}},
+            }
+            _run(
+                harness._execute_tool(
+                    "schedule_appointment",
+                    {"date": "08/15/2026"},
+                    bp,
+                    {"agent": "scheduler"},
+                )
+            )
+            return
+        raise AssertionError(f"no dispatcher for {family}")

--- a/tests/test_industry_contract.py
+++ b/tests/test_industry_contract.py
@@ -37,7 +37,7 @@ KNOWN_GAPS: dict[str, set[str]] = {
 
 REQUIRED_FILES = {"README.md", "agent_blueprint.json", "tools.json",
                   "tool_server.py", "requirements.txt"}
-ALLOWED_EXTRA = {"agent_blueprint.mmd", "db", "system-prompts", "docs", "__pycache__"}
+ALLOWED_EXTRA = {"agent_blueprint.mmd", "db", "system-prompts", "docs", "__pycache__", ".DS_Store"}
 
 
 def _industry_params():
@@ -79,8 +79,10 @@ def _tool_flags(name: str) -> dict[str, dict]:
 def _load_tool_server(name: str):
     """Import tool_server.py under a unique module name with a temp DB."""
     original = os.environ.get("MIVAS_DB_PATH")
+    original_shared = os.environ.get("MIVAS_DB_SHARED")
     tmp = tempfile.mkdtemp(prefix=f"mivas-contract-{name}-")
     os.environ["MIVAS_DB_PATH"] = str(Path(tmp) / "runtime.db")
+    os.environ["MIVAS_DB_SHARED"] = "1"
     try:
         mod_name = f"contract_tool_server_{name.replace('-', '_')}"
         sys.modules.pop(mod_name, None)
@@ -95,6 +97,10 @@ def _load_tool_server(name: str):
             os.environ.pop("MIVAS_DB_PATH", None)
         else:
             os.environ["MIVAS_DB_PATH"] = original
+        if original_shared is None:
+            os.environ.pop("MIVAS_DB_SHARED", None)
+        else:
+            os.environ["MIVAS_DB_SHARED"] = original_shared
 
 
 @industry
@@ -141,7 +147,7 @@ def test_server_boots_and_serves_fixtures(industry: str) -> None:
     module = _load_tool_server(industry)
     with TestClient(module.app) as client:
         assert client.get("/health").status_code == 200
-        state = client.get("/state")
+        state = client.get("/state", headers={"X-Mivas-Call-Id": "contract"})
         assert state.status_code == 200
         assert isinstance(state.json(), dict)
 
@@ -171,7 +177,12 @@ def test_selfcheck_passes(industry: str) -> None:
     if "selfcheck" in _gaps(industry):
         pytest.skip(f"{industry} has no --selfcheck yet (KNOWN_GAPS)")
     with tempfile.TemporaryDirectory() as tmp:
-        env = {**os.environ, "MIVAS_DB_PATH": str(Path(tmp) / "runtime.db")}
+        env = {
+            **os.environ,
+            "MIVAS_DB_PATH": str(Path(tmp) / "runtime.db"),
+            "PYTHONPATH": str(ROOT / "runtime")
+            + (os.pathsep + os.environ["PYTHONPATH"] if os.environ.get("PYTHONPATH") else ""),
+        }
         proc = subprocess.run(
             [sys.executable, str(INDUSTRY_ROOT / industry / "tool_server.py"),
              "--selfcheck"],

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,113 @@
+"""B3: capture_final freezes GET /state onto GET /snapshot/{id}."""
+
+from __future__ import annotations
+
+import json
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+import uvicorn
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNTIME = ROOT / "runtime"
+if str(RUNTIME) not in sys.path:
+    sys.path.insert(0, str(RUNTIME))
+
+from db_service import DBService  # noqa: E402
+from snapshot import capture_final  # noqa: E402
+
+SCHEMA = """
+CREATE TABLE items (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL
+);
+"""
+SEED = "INSERT INTO items (name) VALUES ('seeded');"
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> DBService:
+    schema = tmp_path / "schema.sql"
+    seed = tmp_path / "seed.sql"
+    schema.write_text(SCHEMA)
+    seed.write_text(SEED)
+    return DBService(schema_path=schema, seed_path=seed, data_dir=tmp_path)
+
+
+def _app(db: DBService) -> FastAPI:
+    app = FastAPI()
+    app.middleware("http")(db.http_middleware)
+    db.mount_cluster_routes(app)
+
+    @app.get("/health")
+    def health() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.get("/state")
+    def state() -> dict[str, list[str]]:
+        with db.connect() as conn:
+            names = [r["name"] for r in conn.execute("SELECT name FROM items ORDER BY id")]
+        return {"items": names}
+
+    @app.post("/write")
+    def write(name: str) -> dict[str, str]:
+        with db.connect() as conn:
+            conn.execute("INSERT INTO items (name) VALUES (?)", (name,))
+        return {"ok": "true"}
+
+    return app
+
+
+def test_snapshots_do_not_substitute_a_second_call(db: DBService) -> None:
+    client = TestClient(_app(db))
+    client.post("/write", headers={"X-Mivas-Call-Id": "675"}, params={"name": "alpha"})
+    client.post("/write", headers={"X-Mivas-Call-Id": "676"}, params={"name": "beta"})
+    a = client.get("/state", params={"call_id": "675"}).json()
+    b = client.get("/state", params={"call_id": "676"}).json()
+    assert a == {"items": ["seeded", "alpha"]}
+    assert b == {"items": ["seeded", "beta"]}
+    assert client.post("/snapshot", json={"call_id": "675", "state": a}).status_code == 200
+    assert client.post("/snapshot", json={"call_id": "676", "state": b}).status_code == 200
+    assert client.get("/snapshot/675").json() == a
+    assert client.get("/snapshot/676").json() == b
+    assert client.get("/snapshot/675").json() != client.get("/snapshot/676").json()
+
+
+def test_capture_final_writes_snapshot(
+    db: DBService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import socket
+
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+
+    app = _app(db)
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    thread = threading.Thread(target=server.run, daemon=True)
+    thread.start()
+    for _ in range(80):
+        if server.started:
+            break
+        thread.join(0.05)
+    assert server.started, "uvicorn failed to start"
+    monkeypatch.setenv("TOOL_SERVER_URL", f"http://127.0.0.1:{port}")
+
+    client = TestClient(app)
+    client.post(
+        "/write", headers={"X-Mivas-Call-Id": "721435"}, params={"name": "booked"}
+    )
+    dumped = capture_final("721435")
+    assert dumped == {"items": ["seeded", "booked"]}
+    frozen = json.loads((db.calls_dir / "721435.final.json").read_text())
+    assert frozen == dumped
+    assert client.get("/snapshot/721435").json() == dumped
+
+    server.should_exit = True
+    thread.join(timeout=5)

--- a/tests/test_tool_server.py
+++ b/tests/test_tool_server.py
@@ -23,13 +23,20 @@ INDUSTRIES = ("control-industry", "finance", "healthcare", "legal", "travel")
 
 
 @contextmanager
-def _load_tool_server(industry: str):
+def _load_tool_server(industry: str, *, shared: bool = True):
     """Import industries/<industry>/tool_server.py under a unique module name,
     pointing MIVAS_DB_PATH at a temp file (DB_PATH is read at import).
-    Restores the previous MIVAS_DB_PATH value and deletes the temp dir on exit."""
+    Restores the previous MIVAS_DB_PATH value and deletes the temp dir on exit.
+    shared=True (default) keeps existing tests working without a call-id header.
+    Isolation tests pass shared=False and send X-Mivas-Call-Id."""
     original = os.environ.get("MIVAS_DB_PATH")
+    original_shared = os.environ.get("MIVAS_DB_SHARED")
     with tempfile.TemporaryDirectory(prefix=f"mivas-{industry}-") as tmp:
         os.environ["MIVAS_DB_PATH"] = str(Path(tmp) / "runtime.db")
+        if shared:
+            os.environ["MIVAS_DB_SHARED"] = "1"
+        else:
+            os.environ.pop("MIVAS_DB_SHARED", None)
         try:
             name = f"tool_server_{industry.replace('-', '_')}"
             if name in sys.modules:
@@ -45,6 +52,10 @@ def _load_tool_server(industry: str):
                 os.environ.pop("MIVAS_DB_PATH", None)
             else:
                 os.environ["MIVAS_DB_PATH"] = original
+            if original_shared is None:
+                os.environ.pop("MIVAS_DB_SHARED", None)
+            else:
+                os.environ["MIVAS_DB_SHARED"] = original_shared
 
 
 def _tool_flags(industry: str) -> dict[str, dict[str, Any]]:
@@ -268,8 +279,9 @@ def test_healthcare_calls_are_isolated() -> None:
 
     Without X-Mivas-Call-Id isolation, call B's get_account_balance reads call A's
     verified patient and call B's cancel hits a row A already cancelled.
+    GET /state is scoped the same way so evals dump one conversation, not the pod.
     """
-    with _load_tool_server("healthcare") as module, TestClient(module.app) as client:
+    with _load_tool_server("healthcare", shared=False) as module, TestClient(module.app) as client:
         def tool(name: str, args: dict[str, Any], call: str | None = None) -> dict[str, Any]:
             headers = {"X-Mivas-Call-Id": call} if call else {}
             resp = client.post(f"/tools/{name}", json={"arguments": args}, headers=headers)
@@ -313,6 +325,25 @@ def test_healthcare_calls_are_isolated() -> None:
         # financing gate: only Maria clears $250
         assert tool("offer_financing", {"amount_cents": 48000}, "call_b")["data"]["eligible"] is True
         assert tool("offer_financing", {"amount_cents": 12500}, "call_a")["data"]["eligible"] is False
+
+        def state(call: str) -> dict[str, Any]:
+            resp = client.get("/state", params={"call_id": call})
+            assert resp.status_code == 200, resp.text
+            return resp.json()
+
+        dumped = state("call_d")
+        seed = state("call_fresh")
+        by_header = client.get("/state", headers={"X-Mivas-Call-Id": "call_d"})
+        assert by_header.status_code == 200
+        assert by_header.json() == dumped
+        statuses = {row["id"]: row["status"] for row in dumped["appointments"]}
+        seed_statuses = {row["id"]: row["status"] for row in seed["appointments"]}
+        assert statuses[3] == "cancelled"
+        assert seed_statuses[3] == "booked"
+        assert seed_statuses == {
+            row["id"]: row["status"] for row in state("call_a")["appointments"]
+        }
+        assert client.get("/state").status_code == 400
 
 
 def test_healthcare_flow_through_dispatch() -> None:
@@ -423,6 +454,111 @@ def test_travel_guards_survive_dispatch() -> None:
         assert tool("confirm_change", {"confirmation_token": token})["data"]["status"] == "changed"
         reuse = tool("confirm_change", {"confirmation_token": token})
         assert reuse["ok"] is False and reuse["error_code"] == "TOKEN_ALREADY_USED"
+
+
+def test_control_industry_calls_are_isolated() -> None:
+    """Two overlapping bookings must not share a SQLite file."""
+    with _load_tool_server("control-industry", shared=False) as module:
+        with TestClient(module.app) as client:
+            def book(call: str, date: str) -> dict[str, Any]:
+                resp = client.post(
+                    "/tools/schedule_appointment",
+                    json={"arguments": {"date": date}},
+                    headers={"X-Mivas-Call-Id": call},
+                )
+                assert resp.status_code == 200, resp.text
+                return resp.json()
+
+            def state(call: str) -> dict[str, Any]:
+                resp = client.get("/state", headers={"X-Mivas-Call-Id": call})
+                assert resp.status_code == 200, resp.text
+                return resp.json()
+
+            assert book("675", "08/15/2026")["success"] is True
+            assert book("676", "08/16/2026")["success"] is True
+            a = state("675")["appointments"]
+            b = state("676")["appointments"]
+            c = state("677")["appointments"]
+            assert [row["date"] for row in a] == ["08/15/2026"]
+            assert [row["date"] for row in b] == ["08/16/2026"]
+            assert c == []
+
+
+def test_state_query_alias_scopes_control_industry() -> None:
+    """Evals dump one conversation via GET /state?call_id= — no prior tool still seed."""
+    with _load_tool_server("control-industry", shared=False) as module:
+        with TestClient(module.app) as client:
+            booked = client.post(
+                "/tools/schedule_appointment",
+                json={"arguments": {"date": "08/15/2026"}},
+                headers={"X-Mivas-Call-Id": "675"},
+            )
+            assert booked.status_code == 200, booked.text
+            assert booked.json()["success"] is True
+
+            via_query = client.get("/state?call_id=675")
+            via_header = client.get("/state", headers={"X-Mivas-Call-Id": "675"})
+            untouched = client.get("/state?call_id=676")
+            assert via_query.status_code == 200, via_query.text
+            assert via_header.json() == via_query.json()
+            assert [row["date"] for row in via_query.json()["appointments"]] == [
+                "08/15/2026"
+            ]
+            assert untouched.status_code == 200, untouched.text
+            assert untouched.json()["appointments"] == []
+            assert client.get("/state").status_code == 400
+
+
+def test_missing_call_id_is_400() -> None:
+    with _load_tool_server("control-industry", shared=False) as module:
+        with TestClient(module.app) as client:
+            assert client.get("/health").status_code == 200
+            assert client.get("/state").status_code == 400
+            assert client.post(
+                "/tools/schedule_appointment",
+                json={"arguments": {"date": "08/15/2026"}},
+            ).status_code == 400
+
+
+def test_industry_writes_do_not_leak_across_call_ids() -> None:
+    """Each industry: a write on call A is invisible to call B; call C matches seed."""
+    writers: dict[str, list[tuple[str, dict[str, Any]]]] = {
+        "control-industry": [("schedule_appointment", {"date": "08/15/2026"})],
+        "healthcare": [("log_call_disposition", {"intents": "booking"})],
+        "finance": [("escalate_to_human", {"reason_code": "caller_request"})],
+        "legal": [
+            ("lookup_caller", {"full_name": "Dana Whitfield", "phone": "5105550142"}),
+            ("take_message", {"for_whom": "reception", "message": "please call back"}),
+        ],
+        "travel": [("escalate_to_human", {"reason_code": "caller_request"})],
+    }
+    for industry, steps in writers.items():
+        with _load_tool_server(industry, shared=False) as module:
+            with TestClient(module.app) as client:
+                def tool(call: str) -> None:
+                    for name, args in steps:
+                        resp = client.post(
+                            f"/tools/{name}",
+                            json={"arguments": args},
+                            headers={"X-Mivas-Call-Id": call},
+                        )
+                        assert resp.status_code == 200, (
+                            f"{industry}/{name}: {resp.text[:200]}"
+                        )
+
+                def state(call: str) -> dict[str, Any]:
+                    resp = client.get("/state", headers={"X-Mivas-Call-Id": call})
+                    assert resp.status_code == 200, resp.text
+                    return resp.json()
+
+                seed = state("call_c")
+                tool("call_a")
+                after_a = state("call_a")
+                after_b = state("call_b")
+                after_c = state("call_c")
+                assert after_b == seed, industry
+                assert after_c == seed, industry
+                assert after_a != seed, industry
 
 
 if __name__ == "__main__":

--- a/tests/test_twilio_industry.py
+++ b/tests/test_twilio_industry.py
@@ -1,0 +1,74 @@
+"""Twilio harness must load healthcare (and other packs), not only control-industry."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FAMILY = ROOT / "voice-agent-harnesses" / "twilio"
+if str(FAMILY) not in sys.path:
+    sys.path.insert(0, str(FAMILY))
+
+from adapters.conversationrelay import build_app  # noqa: E402
+from harness import demo, load_blueprint, sim_id_from_mapping, twilio_sip_uri, welcome_greeting  # noqa: E402
+
+
+def test_demo_healthcare() -> None:
+    demo(ROOT / "industries" / "healthcare")
+    bp = load_blueprint(ROOT / "industries" / "healthcare")
+    assert bp["start"] == "reception"
+    assert "identity" in bp["agents"]
+
+
+def test_welcome_healthcare(monkeypatch) -> None:
+    monkeypatch.setenv("INDUSTRY", "healthcare")
+    monkeypatch.setenv("INDUSTRY_DIR", str(ROOT / "industries" / "healthcare"))
+    monkeypatch.setenv("TWILIO_WELCOME_GREETING", "Welcome to Bluejay's Repair Services!")
+    assert welcome_greeting() == "Thank you for calling Straus Dermatology."
+
+
+def test_sip_uri_is_one_domain_per_industry() -> None:
+    assert twilio_sip_uri("healthcare") == (
+        "sip:mivas@mivas-twilio-healthcare.sip.twilio.com"
+    )
+    assert twilio_sip_uri("control-industry") == (
+        "sip:mivas@mivas-twilio-control-industry.sip.twilio.com"
+    )
+
+
+def test_sim_id_from_twilio_sip_form() -> None:
+    assert sim_id_from_mapping({"SipHeader_X-Simulation-Result-Id": "720488"}) == "720488"
+    assert sim_id_from_mapping({"SipHeader_X_Simulation_Result_Id": "720488"}) == "720488"
+    assert sim_id_from_mapping({"simulation_result_id": "720488"}) == "720488"
+    assert (
+        sim_id_from_mapping(
+            {"SipHeader_X-Custom-Headers": json.dumps({"X-Simulation-Result-Id": "720488"})}
+        )
+        == "720488"
+    )
+    assert sim_id_from_mapping({"CallSid": "CA123", "To": "sip:mivas@example.sip.twilio.com"}) == ""
+
+
+def test_twiml_stamps_bluejay_sim_id(monkeypatch) -> None:
+    monkeypatch.setenv("PUBLIC_URL", "https://twilio-test.example")
+    monkeypatch.setenv("INDUSTRY", "control-industry")
+    from fastapi.testclient import TestClient
+
+    client = TestClient(build_app("control-industry"))
+    r = client.post(
+        "/",
+        data={"CallSid": "CA1", "SipHeader_X-Simulation-Result-Id": "720488"},
+    )
+    assert r.status_code == 200
+    assert "ConversationRelay" in r.text
+    assert "simulation_result_id=720488" in r.text
+    assert 'name="simulation_result_id" value="720488"' in r.text
+
+    got = client.get(
+        "/",
+        params={"CallSid": "CA2", "SipHeader_X-Simulation-Result-Id": "720489"},
+    )
+    assert got.status_code == 200
+    assert "simulation_result_id=720489" in got.text

--- a/voice-agent-harnesses/README.md
+++ b/voice-agent-harnesses/README.md
@@ -18,6 +18,34 @@ The server answers with the envelope its `tools.json` `outputSchema` declares
 (e.g. `{"ok": bool, "data": ..., "error_code": ..., "<caller|patient>_safe_message": ...}`;
 control-industry uses `{"success": ..., ...}`). An unknown tool name is a 404.
 
+### Per-call database (conversation id)
+
+Every industry tool call is namespaced to **one Bluejay simulation result id**
+(the same value Bluejay already puts on the CHIRP WebSocket upgrade as
+`X-Simulation-Result-Id`, or on LiveKit job metadata). That id is the
+conversation key for SQLite, traces, and evals — not a provider call id
+(Vapi `call.id`, Retell `call_id`, …).
+
+1. CHIRP (or the LiveKit worker) reads `X-Simulation-Result-Id`. If Bluejay
+   omitted it, the harness mints `call_{uuid}` and logs; it never sends an
+   empty id.
+2. Every `POST {TOOL_SERVER_URL}/tools/{name}` includes
+   `X-Mivas-Call-Id: <simulation_result_id>`.
+3. The tool server `DBService` uses that header as the DB key. First touch
+   for an id copies `db/schema.sql` + `db/seed.sql` into
+   `{MIVAS_DB_PATH.parent}/calls/{id}.db`; later tools reuse the file.
+4. `GET /health` is global (no id). `GET /state` and domain REST routes take
+   the same header or `?call_id=` so evals dump **that** conversation.
+5. Missing `X-Mivas-Call-Id` on `POST /tools/*` is **400**, except when
+   `MIVAS_DB_SHARED=1` (local `--check` / `tests/converse.py`), which keeps a
+   single debug DB.
+6. Session / handoff tools still never hit the tool server.
+
+Platform harnesses (vapi/retell/bland/cartesia) receive tools as a webhook on
+`{PUBLIC_URL}/tool/{name}`. That request does not inherit the CHIRP
+connection: the adapter must map the provider call id back to the Bluejay
+simulation result id and send **that** as `X-Mivas-Call-Id`.
+
 Tool kinds, from the blueprint entry's flags:
 
 - **industry** (default): dispatched to `POST /tools/{name}` as above. No
@@ -30,7 +58,19 @@ Tool kinds, from the blueprint entry's flags:
   tool server.
 
 The industry's REST routes (`GET /health`, `GET /state`, the domain routes)
-remain for evals and debugging — harnesses only speak `/tools/{name}`.
+remain for evals and debugging — harnesses only speak `/tools/{name}`. After
+each call the harness freezes `GET /state` onto `GET /snapshot/{id}` on the
+tools replica. Evals load that snapshot (or live `/state?call_id=`) through
+the public hostname; both paths hit the tools Service, not a random CHIRP pod.
+
+Concurrency on EKS is `max_concurrent ≈ MIVAS_REPLICAS × in_process_ws_limit`
+(default replicas `1`; start `in_process_ws_limit` at 2–4). Raising replicas
+is how overlapping Bluejay calls stay on isolated SQLite files without sharing
+one process. Proven pairs (openai × control-industry, cartesia/line ×
+control-industry) run at `MIVAS_REPLICAS=3` / `MIVAS_TOOLS_REPLICAS=1`. Leave
+the default at 1 for unused pairs. Do not set `MIVAS_REPLICAS>1` on
+vapi/retell/bland until those families are live-proven; cartesia is proven.
+See [docs/per-call-db-and-replicas.md](../docs/per-call-db-and-replicas.md).
 
 Platform harnesses (vapi/retell/bland/cartesia) receive tool invocations as
 provider webhooks on `{PUBLIC_URL}/tool/{name}` and forward them to

--- a/voice-agent-harnesses/assemblyai/adapters/chirp.py
+++ b/voice-agent-harnesses/assemblyai/adapters/chirp.py
@@ -18,7 +18,7 @@ import websockets
 from websockets.asyncio.server import serve
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from harness import WS_URL, industry_path, load_blueprint, run_tool, session_config  # noqa: E402
+from harness import WS_URL, industry_path, load_blueprint, run_tool, session_config, set_call_id  # noqa: E402
 from report import end_speech_span, start_speech_span, traced_run  # noqa: E402
 
 W, R_OUT, R_CHIRP = 2, 24_000, 16_000
@@ -53,6 +53,7 @@ async def _bridge(ws, model: str, industry: str) -> None:
     sim_id = _simulation_result_id(ws)
     if sim_id:
         print(f"chirp sim_result_id={sim_id}", flush=True)
+    set_call_id(sim_id)
 
     key = os.environ.get("ASSEMBLYAI_API_KEY")
     if not key:

--- a/voice-agent-harnesses/assemblyai/harness.py
+++ b/voice-agent-harnesses/assemblyai/harness.py
@@ -17,6 +17,14 @@ from typing import Any
 import httpx
 import websockets
 
+for _root in (Path("/app"), *Path(__file__).resolve().parents):
+    _runtime = _root / "runtime"
+    if (_runtime / "call_id.py").is_file():
+        if str(_runtime) not in sys.path:
+            sys.path.insert(0, str(_runtime))
+        break
+from call_id import headers as tool_headers, set_call_id  # noqa: E402
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TOOL_SERVER_URL = os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
 WS_URL = "wss://agents.assemblyai.com/v1/ws"
@@ -122,7 +130,11 @@ def _tool_entry(bp: dict[str, Any], agent: str, name: str) -> dict[str, Any] | N
 async def _dispatch(name: str, args: dict[str, Any]) -> dict[str, Any]:
     """Generic dispatch: POST /tools/{name}; the server's envelope is the result."""
     async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.post(f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args})
+        resp = await client.post(
+            f"{TOOL_SERVER_URL}/tools/{name}",
+            json={"arguments": args},
+            headers=tool_headers(),
+        )
         return resp.json()
 
 

--- a/voice-agent-harnesses/bland/adapters/chirp.py
+++ b/voice-agent-harnesses/bland/adapters/chirp.py
@@ -32,7 +32,18 @@ import websockets
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from harness import ensure_agent, industry_path, load_blueprint, run_tool, session_ws_url  # noqa: E402
+from harness import (  # noqa: E402
+    begin_session,
+    bind_provider,
+    end_session,
+    ensure_agent,
+    for_provider,
+    industry_path,
+    load_blueprint,
+    provider_id_from_request,
+    run_tool,
+    session_ws_url,
+)
 from report import end_speech_span, start_speech_span, traced_run  # noqa: E402
 
 W, R_BLAND, R_CHIRP = 2, 44_100, 16_000
@@ -68,6 +79,7 @@ async def tool_webhook(name: str, request: Request) -> dict:
         args = await request.json()
     except Exception:
         args = {}
+    for_provider(provider_id_from_request(args, query=request.query_params, headers=request.headers))
     result = await run_tool(name, {k: v for k, v in (args or {}).items() if v not in (None, "")})
     print(f"chirp tool {name} args={args} -> {result}", flush=True)
     return result
@@ -98,111 +110,119 @@ async def _bridge(ws: WebSocket, sim_id: str | None) -> None:
     url = await session_ws_url(CFG["agent_id"])
     end = asyncio.Event()
     sent = {"to_bland": 0, "to_chirp": 0}
+    session_key = uuid.uuid4().hex
+    resolved = begin_session(sim_id, session_key=session_key)
 
-    async with traced_run(workflow, simulation_result_id=sim_id, model=model):
-        async with websockets.connect(url, max_size=None) as bland:
+    try:
+        async with traced_run(workflow, simulation_result_id=sim_id, model=model):
+            async with websockets.connect(url, max_size=None) as bland:
 
-            async def inbound() -> None:
-                """chirp 16 kHz pcm → Bland 44.1 kHz; Bluejay speech.* → customer.speech."""
-                up = None
-                customer = None
-
-                def _close_customer() -> None:
-                    nonlocal customer
-                    end_speech_span(customer)
+                async def inbound() -> None:
+                    """chirp 16 kHz pcm → Bland 44.1 kHz; Bluejay speech.* → customer.speech."""
+                    up = None
                     customer = None
 
-                try:
-                    while not end.is_set():
-                        msg = await ws.receive()
-                        if msg["type"] == "websocket.disconnect":
-                            break
-                        if (pcm := msg.get("bytes")):
-                            out, up = audioop.ratecv(pcm, W, 1, R_CHIRP, R_BLAND, up)
-                            if out:
-                                await bland.send(out)
-                                sent["to_bland"] += len(out)
-                            continue
-                        if not msg.get("text"):
-                            continue
-                        try:
-                            event = json.loads(msg["text"])
-                        except json.JSONDecodeError:
-                            continue
-                        etype = event.get("type")
-                        if etype == "speech.started":
-                            _close_customer()
-                            uid = (event.get("data") or {}).get("utterance_id") or f"c_{uuid.uuid4().hex[:12]}"
-                            customer = start_speech_span(uid, speaker="customer")
-                        elif etype == "speech.completed":
-                            _close_customer()
-                finally:
-                    _close_customer()
-                    end.set()
-                    with contextlib.suppress(Exception):
-                        await bland.close()
+                    def _close_customer() -> None:
+                        nonlocal customer
+                        end_speech_span(customer)
+                        customer = None
 
-            async def outbound() -> None:
-                """Bland 44.1 kHz pcm → chirp 16 kHz; RMS gate drives agent.speech."""
-                down = None
-                utt: str | None = None
-                speech = None
-                last_loud = 0.0
-
-                async def _close_utt() -> None:
-                    nonlocal utt, speech
-                    if utt:
+                    try:
+                        while not end.is_set():
+                            msg = await ws.receive()
+                            if msg["type"] == "websocket.disconnect":
+                                break
+                            if (pcm := msg.get("bytes")):
+                                out, up = audioop.ratecv(pcm, W, 1, R_CHIRP, R_BLAND, up)
+                                if out:
+                                    await bland.send(out)
+                                    sent["to_bland"] += len(out)
+                                continue
+                            if not msg.get("text"):
+                                continue
+                            try:
+                                event = json.loads(msg["text"])
+                            except json.JSONDecodeError:
+                                continue
+                            etype = event.get("type")
+                            if etype == "speech.started":
+                                _close_customer()
+                                uid = (event.get("data") or {}).get("utterance_id") or f"c_{uuid.uuid4().hex[:12]}"
+                                customer = start_speech_span(uid, speaker="customer")
+                            elif etype == "speech.completed":
+                                _close_customer()
+                    finally:
+                        _close_customer()
+                        end.set()
                         with contextlib.suppress(Exception):
-                            await ws.send_text(_event("speech.completed", {"utterance_id": utt}))
-                    end_speech_span(speech)
-                    utt, speech = None, None
+                            await bland.close()
 
-                try:
-                    async for msg in bland:
-                        if end.is_set():
-                            break
-                        if isinstance(msg, str):
-                            # `payload` is a dict for update frames, a bare string for callID.
-                            payload = (json.loads(msg) or {}).get("payload")
-                            if isinstance(payload, dict) and payload.get("text"):
-                                print(f"bland {payload.get('type')}: {payload['text']}", flush=True)
-                            continue
-                        if not msg:
-                            continue
-                        now = time.monotonic()
-                        if audioop.rms(msg, W) >= AGENT_RMS_ON:
-                            last_loud = now
-                            if utt is None:
-                                utt = f"u_{uuid.uuid4().hex[:12]}"
-                                speech = start_speech_span(utt, speaker="agent")
-                                await ws.send_text(_event("speech.started", {"utterance_id": utt}))
-                        elif utt and now - last_loud > AGENT_SILENCE_S:
-                            await _close_utt()
-                        out, down = audioop.ratecv(msg, W, 1, R_BLAND, R_CHIRP, down)
-                        if out:
-                            await ws.send_bytes(out)
-                            sent["to_chirp"] += len(out)
-                finally:
-                    await _close_utt()
-                    end.set()
-                    with contextlib.suppress(Exception):
-                        await ws.close(1000)
+                async def outbound() -> None:
+                    """Bland 44.1 kHz pcm → chirp 16 kHz; RMS gate drives agent.speech."""
+                    down = None
+                    utt: str | None = None
+                    speech = None
+                    last_loud = 0.0
 
-            tasks = [asyncio.create_task(inbound()), asyncio.create_task(outbound())]
-            done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-            for t in pending:
-                t.cancel()
-            await asyncio.gather(*pending, return_exceptions=True)
-            print(
-                f"chirp audio bytes to_bland={sent['to_bland']} to_chirp={sent['to_chirp']}",
-                flush=True,
-            )
-            for t in done:
-                exc = None if t.cancelled() else t.exception()
-                if exc is not None and not type(exc).__name__.startswith(
-                    ("ConnectionClosed", "WebSocketDisconnect")
-                ):
-                    raise exc
+                    async def _close_utt() -> None:
+                        nonlocal utt, speech
+                        if utt:
+                            with contextlib.suppress(Exception):
+                                await ws.send_text(_event("speech.completed", {"utterance_id": utt}))
+                        end_speech_span(speech)
+                        utt, speech = None, None
+
+                    try:
+                        async for msg in bland:
+                            if end.is_set():
+                                break
+                            if isinstance(msg, str):
+                                # `payload` is a dict for update frames, a bare string for callID.
+                                payload = (json.loads(msg) or {}).get("payload")
+                                if isinstance(payload, str) and payload.strip():
+                                    bind_provider(payload.strip(), resolved)
+                                    print(f"bland callID={payload.strip()}", flush=True)
+                                elif isinstance(payload, dict) and payload.get("text"):
+                                    print(f"bland {payload.get('type')}: {payload['text']}", flush=True)
+                                continue
+                            if not msg:
+                                continue
+                            now = time.monotonic()
+                            if audioop.rms(msg, W) >= AGENT_RMS_ON:
+                                last_loud = now
+                                if utt is None:
+                                    utt = f"u_{uuid.uuid4().hex[:12]}"
+                                    speech = start_speech_span(utt, speaker="agent")
+                                    await ws.send_text(_event("speech.started", {"utterance_id": utt}))
+                            elif utt and now - last_loud > AGENT_SILENCE_S:
+                                await _close_utt()
+                            out, down = audioop.ratecv(msg, W, 1, R_BLAND, R_CHIRP, down)
+                            if out:
+                                await ws.send_bytes(out)
+                                sent["to_chirp"] += len(out)
+                    finally:
+                        await _close_utt()
+                        end.set()
+                        with contextlib.suppress(Exception):
+                            await ws.close(1000)
+
+                tasks = [asyncio.create_task(inbound()), asyncio.create_task(outbound())]
+                done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+                for t in pending:
+                    t.cancel()
+                await asyncio.gather(*pending, return_exceptions=True)
+                print(
+                    f"chirp audio bytes to_bland={sent['to_bland']} to_chirp={sent['to_chirp']}",
+                    flush=True,
+                )
+                for t in done:
+                    exc = None if t.cancelled() else t.exception()
+                    if exc is not None and not type(exc).__name__.startswith(
+                        ("ConnectionClosed", "WebSocketDisconnect")
+                    ):
+                        raise exc
+    finally:
+        end_session(session_key)
 
 
 def main(model: str | None = None) -> None:

--- a/voice-agent-harnesses/bland/harness.py
+++ b/voice-agent-harnesses/bland/harness.py
@@ -20,11 +20,30 @@ from __future__ import annotations
 import json
 import os
 import re
+import sys
 from collections.abc import Iterable
 from pathlib import Path
 from typing import Any
 
 import httpx
+
+for _root in (Path("/app"), *Path(__file__).resolve().parents):
+    _runtime = _root / "runtime"
+    if (_runtime / "call_id.py").is_file():
+        if str(_runtime) not in sys.path:
+            sys.path.insert(0, str(_runtime))
+        break
+from call_id import (  # noqa: E402
+    begin_session,
+    bind_provider,
+    end_session,
+    for_provider,
+    headers as tool_headers,
+    provider_id_from_payload,
+    provider_id_from_request,
+    set_call_id,
+    unbind_provider,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HARNESS_DIR = Path(__file__).resolve().parent
@@ -419,7 +438,11 @@ async def _execute_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
     if flags.get("handoff") or flags.get("session"):
         return {"success": True}
     async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.post(f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args})
+        resp = await client.post(
+            f"{TOOL_SERVER_URL}/tools/{name}",
+            json={"arguments": args},
+            headers=tool_headers(),
+        )
         return resp.json()
 
 

--- a/voice-agent-harnesses/cartesia/README.md
+++ b/voice-agent-harnesses/cartesia/README.md
@@ -37,11 +37,18 @@ routing. `end_call` is Line's built-in.
 ## Tools
 
 `schedule_appointment` is a Line `http_server_tool` pointed at `{PUBLIC_URL}/tool/schedule_appointment`,
-i.e. back at `adapters/chirp.py`. Tools execute provider-side, so this round trip is what puts the
-appointment in the industry tool server *and* produces the `execute_tool` span. `TOOL_BASE_URL` is
-pushed to the deployed agent with `cartesia env set` and read per call (`get_agent` runs per call),
-so a new cloudflared tunnel needs no redeploy. Handoff and `end_call` never leave Cartesia — those
-spans are reconstructed from `turn_ended.tool_calls`.
+i.e. back at `adapters/chirp.py`. `get_agent` runs per call and bakes Line's
+`CallRequest.call_id` (a `sid_*` stream id, not the `ac_*` calls-API id) onto
+that URL (`?call_id=`) plus `X-Call-Id` / `X-Cartesia-Call-Id`. The CHIRP
+bridge sends Bluejay's simulation result id as Cartesia `stream_id` on `start`
+and binds both `ack.call_id` and `ack.stream_id` into the tools bind store, so
+a webhook that lands on a different replica can still POST `X-Mivas-Call-Id`
+as the Bluejay id. `TOOL_BASE_URL` is
+pushed with `cartesia env set` and read per call, so a new cloudflared tunnel needs no redeploy.
+A change to `line_agent/main.py` (or blueprint) triggers `cartesia deploy` via a source digest.
+New replicas skip `env set` / `deploy` when the cloud agent is already Ready (`CARTESIA_REDEPLOY=1` forces both).
+Handoff and `end_call` never leave Cartesia — those spans are reconstructed from
+`turn_ended.tool_calls`.
 
 ## Transport
 

--- a/voice-agent-harnesses/cartesia/adapters/chirp.py
+++ b/voice-agent-harnesses/cartesia/adapters/chirp.py
@@ -33,7 +33,17 @@ import websockets
 from fastapi import FastAPI, Request, WebSocket
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from harness import ensure_agent, industry_path, load_blueprint, run_tool  # noqa: E402
+from harness import (  # noqa: E402
+    begin_session,
+    bind_provider,
+    end_session,
+    ensure_agent,
+    for_provider,
+    industry_path,
+    load_blueprint,
+    provider_id_from_request,
+    run_tool,
+)
 from report import (  # noqa: E402
     end_speech_span,
     finish_tool_span,
@@ -77,9 +87,12 @@ def _authorized(ws: WebSocket) -> bool:
 
 @app.post("/tool/{name}")
 async def tool_webhook(name: str, request: Request) -> dict[str, Any]:
-    """Line's http_server_tool calls this; it produces the execute_tool span."""
+    """Line's http_server_tool calls this. SQLite only — the execute_tool span is
+    emitted on the CHIRP WebSocket from turn_ended.tool_calls so it stays on the
+    voice.call tree even when ALB sends this POST to a sibling replica."""
     args = await request.json() if await request.body() else {}
-    result = await run_tool(name, dict(args))
+    for_provider(provider_id_from_request(args, query=request.query_params, headers=request.headers))
+    result = await run_tool(name, dict(args), emit_span=False)
     print(f"chirp tool {name} args={args} -> {result}", flush=True)
     return result
 
@@ -106,6 +119,9 @@ async def _bridge(ws: WebSocket) -> None:
     if sim_id:
         print(f"chirp sim_result_id={sim_id}", flush=True)
 
+    session_key = uuid.uuid4().hex
+    resolved = begin_session(sim_id, session_key=session_key)
+
     url = STREAM_URL.format(agent_id=STATE["agent_id"], version=CARTESIA_VERSION)
     end = asyncio.Event()
     agent_span = None
@@ -114,136 +130,164 @@ async def _bridge(ws: WebSocket) -> None:
     audio = {"in": 0, "out": 0}
     seen_tools: set[str] = set()
 
-    async with traced_run(workflow, simulation_result_id=sim_id, model=model):
-        async with websockets.connect(
-            url, additional_headers={"Authorization": f"Bearer {os.environ['CARTESIA_API_KEY']}"}
-        ) as agent_ws:
-            await agent_ws.send(
-                json.dumps({"event": "start", "config": _start_config()})
-            )
+    try:
+        async with traced_run(workflow, simulation_result_id=sim_id, model=model):
+            async with websockets.connect(
+                url, additional_headers={"Authorization": f"Bearer {os.environ['CARTESIA_API_KEY']}"}
+            ) as agent_ws:
+                await agent_ws.send(
+                    json.dumps(
+                        {
+                            "event": "start",
+                            "stream_id": resolved,
+                            "config": _start_config(),
+                        }
+                    )
+                )
 
-            async def inbound() -> None:
-                """Bluejay pcm → media_input; Bluejay speech.* → customer.speech."""
-                nonlocal customer_span
-                try:
-                    while not end.is_set():
-                        msg = await ws.receive()
-                        if msg["type"] == "websocket.disconnect":
-                            break
-                        if (pcm := msg.get("bytes")):
-                            audio["in"] += len(pcm)
-                            await agent_ws.send(
-                                json.dumps(
-                                    {
-                                        "event": "media_input",
-                                        "media": {"payload": base64.b64encode(pcm).decode()},
-                                    }
+                async def inbound() -> None:
+                    """Bluejay pcm → media_input; Bluejay speech.* → customer.speech."""
+                    nonlocal customer_span
+                    try:
+                        while not end.is_set():
+                            msg = await ws.receive()
+                            if msg["type"] == "websocket.disconnect":
+                                break
+                            if (pcm := msg.get("bytes")):
+                                audio["in"] += len(pcm)
+                                await agent_ws.send(
+                                    json.dumps(
+                                        {
+                                            "event": "media_input",
+                                            "media": {"payload": base64.b64encode(pcm).decode()},
+                                        }
+                                    )
                                 )
-                            )
-                            continue
-                        if not msg.get("text"):
-                            continue
-                        try:
-                            event = json.loads(msg["text"])
-                        except json.JSONDecodeError:
-                            continue
-                        if event.get("type") == "speech.started":
-                            end_speech_span(customer_span)
-                            uid = (event.get("data") or {}).get("utterance_id") or f"c_{uuid.uuid4().hex[:12]}"
-                            customer_span = start_speech_span(uid, speaker="customer")
-                            print(f"chirp customer speech.started {uid}", flush=True)
-                        elif event.get("type") == "speech.completed":
-                            end_speech_span(customer_span)
-                            customer_span = None
-                finally:
-                    end_speech_span(customer_span)
-                    customer_span = None
-                    end.set()
-                    with contextlib.suppress(Exception):
-                        await agent_ws.close()
+                                continue
+                            if not msg.get("text"):
+                                continue
+                            try:
+                                event = json.loads(msg["text"])
+                            except json.JSONDecodeError:
+                                continue
+                            if event.get("type") == "speech.started":
+                                end_speech_span(customer_span)
+                                uid = (event.get("data") or {}).get("utterance_id") or f"c_{uuid.uuid4().hex[:12]}"
+                                customer_span = start_speech_span(uid, speaker="customer")
+                                print(f"chirp customer speech.started {uid}", flush=True)
+                            elif event.get("type") == "speech.completed":
+                                end_speech_span(customer_span)
+                                customer_span = None
+                    finally:
+                        end_speech_span(customer_span)
+                        customer_span = None
+                        end.set()
+                        with contextlib.suppress(Exception):
+                            await agent_ws.close()
 
-            async def outbound() -> None:
-                """Cartesia turn/audio events → chirp pcm + speech.* + tool spans."""
-                nonlocal agent_span, utt
-                try:
-                    async for raw in agent_ws:
-                        if end.is_set():
-                            break
-                        event = json.loads(raw)
-                        etype = event.get("event")
-                        if etype == "media_output":
-                            pcm = base64.b64decode(event["media"]["payload"])
-                            if pcm:
-                                audio["out"] += len(pcm)
-                                await ws.send_bytes(pcm)
-                        elif etype == "turn_started" and event["turn_started"]["role"] == "assistant":
-                            utt = f"u_{uuid.uuid4().hex[:12]}"
-                            agent_span = start_speech_span(utt, speaker="agent")
-                            await ws.send_text(_event("speech.started", {"utterance_id": utt}))
-                        elif etype == "turn_ended" and event["turn_ended"]["role"] == "assistant":
-                            turn = event["turn_ended"]
-                            print(f"chirp agent: {turn.get('text')!r}", flush=True)
-                            if agent_span is not None:
-                                agent_span.set_attribute("mivas.speech.text", turn.get("text") or "")
-                            end_speech_span(agent_span)
-                            agent_span = None
-                            if utt:
-                                await ws.send_text(_event("speech.completed", {"utterance_id": utt}))
-                                utt = None
-                            _record_native_tools(turn.get("tool_calls") or [], seen_tools)
-                        elif etype == "turn_ended":
-                            turn = event["turn_ended"]
-                            print(f"chirp {turn['role']}: {turn.get('text')!r}", flush=True)
-                        elif etype == "clear":
-                            # Cartesia barge-in: the caller started talking over the agent.
-                            print(f"chirp clear (interrupted={bool(utt)})", flush=True)
-                            if utt:
+                async def outbound() -> None:
+                    """Cartesia turn/audio events → chirp pcm + speech.* + tool spans."""
+                    nonlocal agent_span, utt
+                    try:
+                        async for raw in agent_ws:
+                            if end.is_set():
+                                break
+                            event = json.loads(raw)
+                            etype = event.get("event")
+                            if etype == "media_output":
+                                pcm = base64.b64decode(event["media"]["payload"])
+                                if pcm:
+                                    audio["out"] += len(pcm)
+                                    await ws.send_bytes(pcm)
+                            elif etype == "turn_started" and event["turn_started"]["role"] == "assistant":
+                                utt = f"u_{uuid.uuid4().hex[:12]}"
+                                agent_span = start_speech_span(utt, speaker="agent")
+                                await ws.send_text(_event("speech.started", {"utterance_id": utt}))
+                            elif etype == "turn_ended" and event["turn_ended"]["role"] == "assistant":
+                                turn = event["turn_ended"]
+                                print(f"chirp agent: {turn.get('text')!r}", flush=True)
+                                if agent_span is not None:
+                                    agent_span.set_attribute("mivas.speech.text", turn.get("text") or "")
                                 end_speech_span(agent_span)
                                 agent_span = None
-                                await ws.send_text(_event("speech.completed", {"utterance_id": utt}))
-                                utt = None
-                        elif etype == "ack":
-                            print(f"chirp cartesia call_id={event.get('call_id')}", flush=True)
-                        elif etype in ("error", "call_ended", "end_call"):
-                            print(f"chirp cartesia {etype}: {raw[:300]}", flush=True)
-                            break
-                finally:
-                    end_speech_span(agent_span)
-                    agent_span = None
-                    end.set()
-                    with contextlib.suppress(Exception):
-                        await ws.close(1000)
+                                if utt:
+                                    await ws.send_text(_event("speech.completed", {"utterance_id": utt}))
+                                    utt = None
+                                _record_line_tools(turn.get("tool_calls") or [], seen_tools)
+                            elif etype == "turn_ended":
+                                turn = event["turn_ended"]
+                                print(f"chirp {turn['role']}: {turn.get('text')!r}", flush=True)
+                            elif etype == "clear":
+                                # Cartesia barge-in: the caller started talking over the agent.
+                                print(f"chirp clear (interrupted={bool(utt)})", flush=True)
+                                if utt:
+                                    end_speech_span(agent_span)
+                                    agent_span = None
+                                    await ws.send_text(_event("speech.completed", {"utterance_id": utt}))
+                                    utt = None
+                            elif etype == "ack":
+                                for key in ("call_id", "stream_id"):
+                                    cid = event.get(key)
+                                    if cid:
+                                        bind_provider(str(cid), resolved)
+                                print(
+                                    f"chirp cartesia call_id={event.get('call_id')} "
+                                    f"stream_id={event.get('stream_id')}",
+                                    flush=True,
+                                )
+                            elif etype in ("error", "call_ended", "end_call"):
+                                print(f"chirp cartesia {etype}: {raw[:300]}", flush=True)
+                                break
+                    finally:
+                        end_speech_span(agent_span)
+                        agent_span = None
+                        end.set()
+                        with contextlib.suppress(Exception):
+                            await ws.close(1000)
 
-            tasks = [asyncio.create_task(inbound()), asyncio.create_task(outbound())]
-            done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-            for t in pending:
-                t.cancel()
-            await asyncio.gather(*pending, return_exceptions=True)
-            print(f"chirp audio bytes in={audio['in']} out={audio['out']}", flush=True)
-            for t in done:
-                exc = None if t.cancelled() else t.exception()
-                if exc is not None and not type(exc).__name__.startswith(
-                    ("ConnectionClosed", "WebSocketDisconnect")
-                ):
-                    raise exc
+                tasks = [asyncio.create_task(inbound()), asyncio.create_task(outbound())]
+                done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+                for t in pending:
+                    t.cancel()
+                await asyncio.gather(*pending, return_exceptions=True)
+                print(f"chirp audio bytes in={audio['in']} out={audio['out']}", flush=True)
+                for t in done:
+                    exc = None if t.cancelled() else t.exception()
+                    if exc is not None and not type(exc).__name__.startswith(
+                        ("ConnectionClosed", "WebSocketDisconnect")
+                    ):
+                        raise exc
+    finally:
+        end_session(session_key)
 
 
-def _record_native_tools(calls: list[dict[str, Any]], seen: set[str]) -> None:
-    """Line-native tools (handoff, end_call) run inside Cartesia and never hit the
-    webhook, so their only trace is the turn they were reported on. A handoff is
-    reported again on the target agent's first turn — dedupe on the call id."""
+def _record_line_tools(calls: list[dict[str, Any]], seen: set[str]) -> None:
+    """Every Line tool on this turn, including http_server_tool.
+
+    Handoff/end_call never hit our webhook. schedule_appointment does, but that
+    POST lands on a random replica whose process has the wrong (or no)
+    voice.call root. Reconstruct the execute_tool span here so Bluejay actuals
+    attach to this call's trace. Dedupe on Line's tool-call id — a handoff is
+    reported again on the target agent's first turn.
+    """
     for call in calls:
         name = call.get("name") or call.get("tool_name")
-        if not name or name not in STATE["native_tools"]:
+        if not name:
             continue
         key = str(call.get("id") or name)
         if key in seen:
             continue
         seen.add(key)
         args = call.get("arguments") or call.get("args") or {}
+        result = call.get("result")
+        if result is None:
+            result = {"success": True, "source": "line"}
+        ok = True
+        if isinstance(result, dict):
+            ok = bool(result.get("ok", result.get("success", True)))
         print(f"chirp line tool {name} {args}", flush=True)
         with tool_span(name, args, call_id=call.get("id")) as span:
-            finish_tool_span(span, {"success": True, "source": "line"}, ok=True)
+            finish_tool_span(span, result, ok=ok)
 
 
 def main(model: str | None = None) -> None:

--- a/voice-agent-harnesses/cartesia/harness.py
+++ b/voice-agent-harnesses/cartesia/harness.py
@@ -23,11 +23,30 @@ import json
 import os
 import re
 import subprocess
+import sys
 import time
 from pathlib import Path
 from typing import Any
 
 import httpx
+
+for _root in (Path("/app"), *Path(__file__).resolve().parents):
+    _runtime = _root / "runtime"
+    if (_runtime / "call_id.py").is_file():
+        if str(_runtime) not in sys.path:
+            sys.path.insert(0, str(_runtime))
+        break
+from call_id import (  # noqa: E402
+    begin_session,
+    bind_provider,
+    end_session,
+    for_provider,
+    headers as tool_headers,
+    provider_id_from_payload,
+    provider_id_from_request,
+    set_call_id,
+    unbind_provider,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HARNESS_DIR = Path(__file__).resolve().parent
@@ -115,6 +134,17 @@ def _ensure_auth() -> None:
         )
 
 
+def _line_src_digest() -> str:
+    """Hash the deployed Line agent so a main.py change triggers `cartesia deploy`."""
+    hasher = hashlib.sha256()
+    for rel in ("main.py", "pyproject.toml", "blueprint.json"):
+        path = AGENT_DIR / rel
+        if path.is_file():
+            hasher.update(rel.encode())
+            hasher.update(path.read_bytes())
+    return hasher.hexdigest()[:16]
+
+
 def ensure_agent(industry_dir: str | Path, *, public_url: str | None = None) -> str:
     """Deploy (once per industry) and refresh the deployed agent's environment.
 
@@ -150,17 +180,40 @@ def ensure_agent(industry_dir: str | Path, *, public_url: str | None = None) -> 
     # `env set` rolls a new deployment version (~2 min), so only push on change —
     # by digest, so the cache file never holds the API key it carries.
     digest = hashlib.sha256(json.dumps(env, sort_keys=True).encode()).hexdigest()[:16]
+    src_digest = _line_src_digest()
     needs_env_set = agent_changed or cached_entry.get("env_digest") != digest
-    needs_deploy = created_new or agent_changed or bool(os.environ.get("CARTESIA_REDEPLOY"))
+    needs_deploy = (
+        created_new
+        or agent_changed
+        or bool(os.environ.get("CARTESIA_REDEPLOY"))
+        or cached_entry.get("src_digest") != src_digest
+    )
+    # New pods have an empty emptyDir cache, so both digests always miss.
+    # Re-running `env set` / `deploy` 3× races Cartesia's API (HTTP 500). Skip
+    # when the cloud agent is already Ready unless CARTESIA_REDEPLOY=1 (use
+    # that when line_agent/ or TOOL_BASE_URL actually changed).
+    already_ready = False
+    if not created_new and not os.environ.get("CARTESIA_REDEPLOY"):
+        try:
+            status = _cli("status", agent_id)
+        except SystemExit:
+            status = ""
+        already_ready = bool(re.search(r"Status\s+Ready", status))
     if needs_env_set:
-        _cli("env", "set", "--agent-id", agent_id, *[f"{k}={v}" for k, v in env.items()])
+        if already_ready:
+            print(f"cartesia skip env set, {agent_id} already Ready", flush=True)
+        else:
+            _cli("env", "set", "--agent-id", agent_id, *[f"{k}={v}" for k, v in env.items()])
         cache.setdefault(name, {}).update(agent_id=agent_id, env_digest=digest)
         AGENT_CACHE_PATH.write_text(json.dumps(cache, indent=2) + "\n")
 
     if needs_deploy:
-        print(f"cartesia deploy {agent_id} …", flush=True)
-        print(_cli("deploy", "--agent-id", agent_id, str(AGENT_DIR)), flush=True)
-        cache.setdefault(name, {})["agent_id"] = agent_id
+        if already_ready:
+            print(f"cartesia skip deploy, {agent_id} already Ready", flush=True)
+        else:
+            print(f"cartesia deploy {agent_id} …", flush=True)
+            print(_cli("deploy", "--agent-id", agent_id, str(AGENT_DIR)), flush=True)
+        cache.setdefault(name, {}).update(agent_id=agent_id, src_digest=src_digest)
         AGENT_CACHE_PATH.write_text(json.dumps(cache, indent=2) + "\n")
 
     # `env set` and `deploy` both roll a new version; calls hit the old one (or
@@ -183,16 +236,35 @@ async def _execute_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
     run_tool's `default=False` fallback (not an exception here) is what turns
     it into a failure, matching how the other harnesses handle the same case."""
     async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.post(f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args})
+        resp = await client.post(
+            f"{TOOL_SERVER_URL}/tools/{name}",
+            json={"arguments": args},
+            headers=tool_headers(),
+        )
         return resp.json()
 
 
-async def run_tool(name: str, args: dict[str, Any], *, call_id: str | None = None) -> dict[str, Any]:
+async def run_tool(
+    name: str,
+    args: dict[str, Any],
+    *,
+    call_id: str | None = None,
+    emit_span: bool = True,
+) -> dict[str, Any]:
     """Run an industry tool under an execute_tool span. Never raises — a failed
     tool must not take down the bridge before OTel flushes."""
     from report import finish_tool_span, tool_span
+    if not emit_span:
+        if call_id:
+            for_provider(call_id)
+        try:
+            return await _execute_tool(name, args)
+        except Exception as e:
+            return {"success": False, "error": f"{type(e).__name__}: {e}"}
     with tool_span(name, args, call_id=call_id) as span:
         try:
+            if call_id:
+                for_provider(call_id)
             result = await _execute_tool(name, args)
             ok = bool(result.get("ok", result.get("success", False)))
             finish_tool_span(span, result, ok=ok)

--- a/voice-agent-harnesses/cartesia/line_agent/main.py
+++ b/voice-agent-harnesses/cartesia/line_agent/main.py
@@ -9,16 +9,18 @@ handoff tool (`agent_as_handoff`), so the scheduler takes over inside Line with
 no bridge-side routing. `end_call` is Line's built-in.
 
 `schedule_appointment` is an `http_server_tool` pointed at the harness webhook
-(`$TOOL_BASE_URL/tool/schedule_appointment`) rather than a local function: that
+(`$TOOL_BASE_URL/tool/schedule_appointment?call_id=<ac_*>`) rather than a local function: that
 webhook is what emits the `execute_tool` span and forwards to the industry tool
-server. TOOL_BASE_URL is the ephemeral cloudflared URL, re-pushed with
-`cartesia env set` on every chirp boot, and read per call (get_agent runs per
-call) so a new tunnel needs no redeploy.
+server. `get_agent` runs per call and bakes Cartesia's call id onto the URL and
+`X-Call-Id` headers so a random CHIRP replica can resolve the Bluejay sim id via
+the tools bind store. TOOL_BASE_URL is the ephemeral cloudflared URL, re-pushed with
+`cartesia env set` on every chirp boot, and read per call so a new tunnel needs no redeploy.
 """
 
 import json
 import os
 from pathlib import Path
+from urllib.parse import quote
 
 from line.llm_agent import (
     LlmAgent,
@@ -37,32 +39,50 @@ GREETING = os.getenv("MIVAS_GREETING", "Welcome to Bluejay's Repair Services!")
 HANDOFF_INTRO = "Hey, when do you want to schedule your repair appointment?"
 
 
-def _tool_url(name: str) -> str:
+def _call_id(call_request: CallRequest | None) -> str | None:
+    cid = getattr(call_request, "call_id", None) if call_request is not None else None
+    if cid is None:
+        return None
+    text = str(cid).strip()
+    return text or None
+
+
+def _tool_url(name: str, call_id: str | None = None) -> str:
     base = os.environ.get("TOOL_BASE_URL", "").rstrip("/")
     if not base:
         raise RuntimeError("TOOL_BASE_URL unset — run `cartesia env set --agent-id … TOOL_BASE_URL=…`")
-    return f"{base}/tool/{name}"
+    url = f"{base}/tool/{name}"
+    if call_id:
+        return f"{url}?call_id={quote(str(call_id), safe='')}"
+    return url
 
 
-def _http_tool(name: str) -> object:
+def _http_tool(name: str, call_id: str | None) -> object:
     spec = BLUEPRINT["catalog"][name]
     schema = dict(spec.get("inputSchema") or {"type": "object"})
     schema.pop("additionalProperties", None)
+    extra: dict = {}
+    if call_id:
+        extra["headers"] = {
+            "X-Call-Id": str(call_id),
+            "X-Cartesia-Call-Id": str(call_id),
+        }
     return http_server_tool(
         name=name,
         description=spec.get("description", name),
-        url=_tool_url(name),
+        url=_tool_url(name, call_id),
         method="POST",
         request_body_schema=schema,
+        **extra,
     )
 
 
-def _build(agent_name: str) -> LlmAgent:
+def _build(agent_name: str, call_id: str | None) -> LlmAgent:
     entry = BLUEPRINT["agents"][agent_name]
     tools = []
     for t in entry["tools"]:
         if t.get("handoff"):
-            target = _build(t["handoff_to"])
+            target = _build(t["handoff_to"], call_id)
             tools.append(
                 agent_as_handoff(
                     target,
@@ -73,7 +93,7 @@ def _build(agent_name: str) -> LlmAgent:
         elif t.get("session") or t["name"] == "end_call":
             tools.append(end_call)
         else:
-            tools.append(_http_tool(t["name"]))
+            tools.append(_http_tool(t["name"], call_id))
     return LlmAgent(
         model=MODEL,
         api_key=os.environ["OPENAI_API_KEY"],
@@ -86,7 +106,7 @@ def _build(agent_name: str) -> LlmAgent:
 
 
 async def get_agent(env: AgentEnv, call_request: CallRequest) -> LlmAgent:
-    return _build(BLUEPRINT["start"])
+    return _build(BLUEPRINT["start"], _call_id(call_request))
 
 
 app = VoiceAgentApp(get_agent=get_agent)

--- a/voice-agent-harnesses/deepgram/adapters/chirp.py
+++ b/voice-agent-harnesses/deepgram/adapters/chirp.py
@@ -18,7 +18,7 @@ import websockets
 from websockets.asyncio.server import serve
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from harness import WS_URL, industry_path, load_blueprint, run_tool, settings_payload  # noqa: E402
+from harness import WS_URL, industry_path, load_blueprint, run_tool, set_call_id, settings_payload  # noqa: E402
 from report import end_speech_span, start_speech_span, traced_run  # noqa: E402
 
 W, R_OUT, R_CHIRP = 2, 24_000, 16_000
@@ -63,6 +63,7 @@ async def _bridge(ws, model: str, industry: str) -> None:
     sim_id = _simulation_result_id(ws)
     if sim_id:
         print(f"chirp sim_result_id={sim_id}", flush=True)
+    set_call_id(sim_id)
 
     key = os.environ.get("DEEPGRAM_API_KEY")
     if not key:

--- a/voice-agent-harnesses/deepgram/harness.py
+++ b/voice-agent-harnesses/deepgram/harness.py
@@ -12,11 +12,20 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
 import httpx
 import websockets
+
+for _root in (Path("/app"), *Path(__file__).resolve().parents):
+    _runtime = _root / "runtime"
+    if (_runtime / "call_id.py").is_file():
+        if str(_runtime) not in sys.path:
+            sys.path.insert(0, str(_runtime))
+        break
+from call_id import headers as tool_headers, set_call_id  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TOOL_SERVER_URL = os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
@@ -140,7 +149,11 @@ def _tool_entry(bp: dict[str, Any], agent: str, name: str) -> dict[str, Any] | N
 async def _dispatch(name: str, args: dict[str, Any]) -> dict[str, Any]:
     """Generic dispatch: POST /tools/{name}; the server's envelope is the result."""
     async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.post(f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args})
+        resp = await client.post(
+            f"{TOOL_SERVER_URL}/tools/{name}",
+            json={"arguments": args},
+            headers=tool_headers(),
+        )
         return resp.json()
 
 

--- a/voice-agent-harnesses/elevenlabs/adapters/chirp.py
+++ b/voice-agent-harnesses/elevenlabs/adapters/chirp.py
@@ -22,7 +22,7 @@ import websockets
 from websockets.asyncio.server import serve
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from harness import ensure_agents, get_signed_url, industry_path, load_blueprint, run_tool  # noqa: E402
+from harness import ensure_agents, get_signed_url, industry_path, load_blueprint, run_tool, set_call_id  # noqa: E402
 from report import (  # noqa: E402
     end_speech_span,
     finish_tool_span,
@@ -63,6 +63,7 @@ async def _bridge(ws, model: str, industry: str) -> None:
     sim_id = _simulation_result_id(ws)
     if sim_id:
         print(f"chirp sim_result_id={sim_id}", flush=True)
+    set_call_id(sim_id)
 
     ids = ensure_agents(industry_dir)
     signed_url = await get_signed_url(ids["receptionist_id"])

--- a/voice-agent-harnesses/elevenlabs/harness.py
+++ b/voice-agent-harnesses/elevenlabs/harness.py
@@ -20,6 +20,14 @@ from typing import Any
 import httpx
 import websockets
 
+for _root in (Path("/app"), *Path(__file__).resolve().parents):
+    _runtime = _root / "runtime"
+    if (_runtime / "call_id.py").is_file():
+        if str(_runtime) not in sys.path:
+            sys.path.insert(0, str(_runtime))
+        break
+from call_id import headers as tool_headers, set_call_id  # noqa: E402
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HARNESS_DIR = Path(__file__).resolve().parent
 TOOL_SERVER_URL = os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
@@ -328,7 +336,11 @@ async def _execute_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
     Chirp bridge's ElevenLabs error check uses the same fallback as
     `run_session` and correctly marks guarded/policy failures as errors."""
     async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.post(f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args})
+        resp = await client.post(
+            f"{TOOL_SERVER_URL}/tools/{name}",
+            json={"arguments": args},
+            headers=tool_headers(),
+        )
         result = resp.json()
         if isinstance(result, dict) and "success" not in result and "ok" in result:
             result["success"] = result["ok"]

--- a/voice-agent-harnesses/gemini/adapters/chirp.py
+++ b/voice-agent-harnesses/gemini/adapters/chirp.py
@@ -19,7 +19,7 @@ from google.genai import types
 from websockets.asyncio.server import serve
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from harness import CALL_ID, industry_path, live_config, load_blueprint, run_tool  # noqa: E402
+from harness import industry_path, live_config, load_blueprint, run_tool, set_call_id  # noqa: E402
 from report import end_speech_span, start_speech_span, traced_run  # noqa: E402
 
 W, R_OUT, R_CHIRP = 2, 24_000, 16_000
@@ -58,7 +58,7 @@ async def _bridge(ws, model: str, industry: str) -> None:
     sim_id = _simulation_result_id(ws)
     # One state-API namespace per call: concurrent digital humans must not share
     # an identity pin or a DB.
-    CALL_ID.set(sim_id or f"call_{uuid.uuid4().hex[:12]}")
+    set_call_id(sim_id)
     if sim_id:
         print(f"chirp sim_result_id={sim_id}", flush=True)
 

--- a/voice-agent-harnesses/gemini/harness.py
+++ b/voice-agent-harnesses/gemini/harness.py
@@ -10,13 +10,20 @@ import asyncio
 import json
 import os
 import sys
-from contextvars import ContextVar
 from pathlib import Path
 from typing import Any
 
 import httpx
 import google.genai as genai
 from google.genai import types
+
+for _root in (Path("/app"), *Path(__file__).resolve().parents):
+    _runtime = _root / "runtime"
+    if (_runtime / "call_id.py").is_file():
+        if str(_runtime) not in sys.path:
+            sys.path.insert(0, str(_runtime))
+        break
+from call_id import headers as tool_headers, set_call_id  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TOOL_SERVER_URL = os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
@@ -157,19 +164,13 @@ def _tool_entry(bp: dict[str, Any], agent: str, name: str,
     return None
 
 
-# Set once per CHIRP connection so the state API can isolate this call's DB and
-# identity pin from every other call in flight. Industries that keep no per-call
-# state ignore the header.
-CALL_ID: ContextVar[str] = ContextVar("mivas_call_id", default="")
-
-
 async def _dispatch(name: str, args: dict[str, Any]) -> dict[str, Any]:
     """Generic dispatch: POST /tools/{name}; the server's envelope is the result."""
-    call_id = CALL_ID.get()
-    headers = {"X-Mivas-Call-Id": call_id} if call_id else None
     async with httpx.AsyncClient(timeout=30.0) as client:
         resp = await client.post(
-            f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args}, headers=headers
+            f"{TOOL_SERVER_URL}/tools/{name}",
+            json={"arguments": args},
+            headers=tool_headers(),
         )
         return resp.json()
 

--- a/voice-agent-harnesses/grok/harness.py
+++ b/voice-agent-harnesses/grok/harness.py
@@ -17,11 +17,20 @@ import datetime as _dt
 import json
 import os
 import re
+import sys
 import uuid
 from pathlib import Path
 from typing import Any
 
 import httpx
+
+for _root in (Path("/app"), *Path(__file__).resolve().parents):
+    _runtime = _root / "runtime"
+    if (_runtime / "call_id.py").is_file():
+        if str(_runtime) not in sys.path:
+            sys.path.insert(0, str(_runtime))
+        break
+from call_id import headers as tool_headers, set_call_id  # noqa: E402
 
 # Verbal booking confirm without a function-call event (same failure mode as
 # hosted VoiceChat). Recover schedule_appointment for tool-server + OTel.
@@ -304,18 +313,16 @@ async def _execute_tool(
         state["agent"] = target
         return {"success": True, "role": target}, False
 
-    if name == "schedule_appointment":
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            resp = await client.post(
-                f"{tool_server_url()}/appointments", json={"date": args["date"]}
-            )
-            resp.raise_for_status()
-            return {"success": True, "date": resp.json()["date"]}, False
-
     if name == "end_call" or is_session_tool(bp, state["agent"], name):
         return {"success": True}, True
 
-    return {"success": False, "error": f"unknown tool {name}"}, False
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(
+            f"{tool_server_url()}/tools/{name}",
+            json={"arguments": args},
+            headers=tool_headers(),
+        )
+        return resp.json(), False
 
 
 async def run_tool(

--- a/voice-agent-harnesses/grok/voice/adapters/chirp.py
+++ b/voice-agent-harnesses/grok/voice/adapters/chirp.py
@@ -54,6 +54,7 @@ from harness import (  # noqa: E402
     load_blueprint,
     nudge_greeting,
     run_tool,
+    set_call_id,
     tool_names,
     ws_url,
 )
@@ -296,6 +297,7 @@ async def _bridge(ws, industry: str, model: str) -> None:
     sim_id = _simulation_result_id(ws)
     if sim_id:
         _log(f"chirp sim_result_id={sim_id}")
+    set_call_id(sim_id)
 
     _log(
         f"grok ws={ws_url(model)} agents={list(bp['agents'])} start={bp['start']} "

--- a/voice-agent-harnesses/livekit/harness.py
+++ b/voice-agent-harnesses/livekit/harness.py
@@ -28,6 +28,7 @@ import json
 import logging
 import os
 import re
+import sys
 from pathlib import Path
 from typing import Any, Callable
 
@@ -45,6 +46,14 @@ from livekit.agents import (
 )
 
 import report
+
+for _root in (Path("/app"), *Path(__file__).resolve().parents):
+    _runtime = _root / "runtime"
+    if (_runtime / "call_id.py").is_file():
+        if str(_runtime) not in sys.path:
+            sys.path.insert(0, str(_runtime))
+        break
+from call_id import begin_session, headers as tool_headers, set_call_id  # noqa: E402
 
 logger = logging.getLogger("mivas.livekit")
 
@@ -132,7 +141,11 @@ async def _execute(name: str, args: dict[str, Any], *, local: bool) -> dict[str,
         # the span is the artifact
         return {"success": True}
     async with httpx.AsyncClient(timeout=30.0) as client:
-        r = await client.post(f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args})
+        r = await client.post(
+            f"{TOOL_SERVER_URL}/tools/{name}",
+            json={"arguments": args},
+            headers=tool_headers(),
+        )
         return r.json()
 
 
@@ -377,6 +390,8 @@ async def run_call(
     """
     sim_result_id = sim_result_id_from_job_metadata(ctx.job.metadata)
     logger.info("job start room=%s sim_result_id=%s model=%s", ctx.room.name, sim_result_id, model)
+    set_call_id(sim_result_id)
+    begin_session(sim_result_id, session_key=getattr(ctx.room, "name", None) or "job")
 
     bp = load_blueprint()
     async with report.traced_run(

--- a/voice-agent-harnesses/nvidia/adapters/chirp.py
+++ b/voice-agent-harnesses/nvidia/adapters/chirp.py
@@ -24,7 +24,7 @@ from pipecat.transports.websocket.fastapi import (
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from chirp_serializer import ChirpFrameSerializer  # noqa: E402
 from bot import run_bot  # noqa: E402
-from harness import SAMPLE_RATE, industry_path  # noqa: E402
+from harness import SAMPLE_RATE, industry_path, set_call_id  # noqa: E402
 
 app = FastAPI(title="mivas nvidia nemotron chirp bridge")
 
@@ -56,6 +56,7 @@ async def chirp(ws: WebSocket) -> None:
     sim_id = _simulation_result_id(ws)
     if sim_id:
         logger.info("chirp sim_result_id={}", sim_id)
+    set_call_id(sim_id)
 
     async def emit(payload: str | bytes) -> None:
         if isinstance(payload, str):

--- a/voice-agent-harnesses/nvidia/bot.py
+++ b/voice-agent-harnesses/nvidia/bot.py
@@ -101,6 +101,8 @@ async def run_bot(
     *,
     simulation_result_id: str | None = None,
 ) -> None:
+    harness.set_call_id(simulation_result_id)
+    harness.begin_session(simulation_result_id, session_key=str(simulation_result_id or "job"))
     bp = harness.load_blueprint(industry)
     state: dict[str, Any] = {"agent": bp["start"]}
     observer = SpeechSpanObserver()

--- a/voice-agent-harnesses/nvidia/harness.py
+++ b/voice-agent-harnesses/nvidia/harness.py
@@ -15,10 +15,19 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
 import httpx
+
+for _root in (Path("/app"), *Path(__file__).resolve().parents):
+    _runtime = _root / "runtime"
+    if (_runtime / "call_id.py").is_file():
+        if str(_runtime) not in sys.path:
+            sys.path.insert(0, str(_runtime))
+        break
+from call_id import begin_session, headers as tool_headers, set_call_id  # noqa: E402
 
 HARNESS_DIR = Path(__file__).resolve().parent
 REPO_ROOT = HARNESS_DIR.parents[1] if len(HARNESS_DIR.parents) > 1 else HARNESS_DIR
@@ -128,18 +137,16 @@ async def _execute_tool(
         state["agent"] = target
         return {"success": True, "role": target}, False
 
-    if name == "schedule_appointment":
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            resp = await client.post(
-                f"{tool_server_url()}/appointments", json={"date": args["date"]}
-            )
-            resp.raise_for_status()
-            return {"success": True, "date": resp.json()["date"]}, False
-
     if name == "end_call" or is_session_tool(bp, state["agent"], name):
         return {"success": True}, True
 
-    return {"success": False, "error": f"unknown tool {name}"}, False
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(
+            f"{tool_server_url()}/tools/{name}",
+            json={"arguments": args},
+            headers=tool_headers(),
+        )
+        return resp.json(), False
 
 
 async def run_tool(

--- a/voice-agent-harnesses/nvidia/nemotron-voicechat/adapters/chirp.py
+++ b/voice-agent-harnesses/nvidia/nemotron-voicechat/adapters/chirp.py
@@ -29,7 +29,7 @@ from typing import Any
 from websockets.asyncio.server import serve
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-from harness import industry_path, load_blueprint  # noqa: E402
+from harness import industry_path, load_blueprint, set_call_id  # noqa: E402
 from report import end_speech_span, start_speech_span, traced_run  # noqa: E402
 from voicechat import (  # noqa: E402
     MODEL,
@@ -275,6 +275,7 @@ async def _bridge(ws, industry: str) -> None:
     industry_dir = industry_path(industry)
     workflow = f"mivas-{Path(industry_dir).name}-{MODEL}"
     sim_id = _simulation_result_id(ws)
+    set_call_id(sim_id)
     speak_first = speaks_first()
     kick_pcm = _load_kick_pcm() if speak_first else b""
 

--- a/voice-agent-harnesses/openai/adapters/chirp.py
+++ b/voice-agent-harnesses/openai/adapters/chirp.py
@@ -23,7 +23,7 @@ from agents.realtime import RealtimeModelSendRawMessage
 from websockets.asyncio.server import serve
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-from harness import CALL_ID, build_from_blueprint, industry_path  # noqa: E402
+from harness import build_from_blueprint, industry_path, log_ws_accept, set_call_id  # noqa: E402
 from report import traced_run  # noqa: E402
 
 W, R_IN, R_OUT = 2, 16_000, 24_000
@@ -64,12 +64,8 @@ async def _bridge(ws, model: str, industry: str) -> None:
     # Must match Realtime tracing.workflow_name pattern ^[A-Za-z0-9_ -]+$
     workflow = f"mivas {Path(industry_dir).name} {model}".replace(".", "-").replace("/", " ")
     sim_id = _simulation_result_id(ws)
-    if sim_id:
-        print(f"chirp sim_result_id={sim_id}", flush=True)
-    # One state-API namespace per call: concurrent digital humans must not share
-    # an identity pin or a DB. Contextvar, so every tool task under this bridge
-    # inherits it.
-    CALL_ID.set(sim_id or f"call_{uuid.uuid4().hex[:12]}")
+    resolved = set_call_id(sim_id)
+    log_ws_accept(resolved)
     async with traced_run(workflow, simulation_result_id=sim_id) as tracer:
         ctx: dict = {}
         up = down = None

--- a/voice-agent-harnesses/openai/harness.py
+++ b/voice-agent-harnesses/openai/harness.py
@@ -19,7 +19,7 @@ import asyncio
 import contextlib
 import json
 import os
-from contextvars import ContextVar
+import sys
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
@@ -30,6 +30,14 @@ from pydantic import Field, create_model
 
 from report import register_handoff_tool_names
 
+for _root in (Path("/app"), *Path(__file__).resolve().parents):
+    _runtime = _root / "runtime"
+    if (_runtime / "call_id.py").is_file():
+        if str(_runtime) not in sys.path:
+            sys.path.insert(0, str(_runtime))
+        break
+from call_id import headers as tool_headers, log_ws_accept, set_call_id  # noqa: E402
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TOOL_SERVER_URL = os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
 # Let farewell audio finish before tearing down Realtime after end_call.
@@ -39,19 +47,13 @@ END_CALL_CLOSE_DELAY_S = float(os.environ.get("MIVAS_END_CALL_CLOSE_DELAY_S", "2
 SessionMapper = Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]
 
 
-# Set once per CHIRP connection so the state API can isolate this call's DB and
-# identity pin from every other call in flight. Industries that keep no per-call
-# state ignore the header.
-CALL_ID: ContextVar[str] = ContextVar("mivas_call_id", default="")
-
-
 async def dispatch_industry_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
     """Generic dispatch: POST /tools/{name}; the server's envelope is the result."""
-    call_id = CALL_ID.get()
-    headers = {"X-Mivas-Call-Id": call_id} if call_id else None
     async with httpx.AsyncClient(timeout=30.0) as client:
         resp = await client.post(
-            f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args}, headers=headers
+            f"{TOOL_SERVER_URL}/tools/{name}",
+            json={"arguments": args},
+            headers=tool_headers(),
         )
         return resp.json()
 

--- a/voice-agent-harnesses/openai/report.py
+++ b/voice-agent-harnesses/openai/report.py
@@ -234,14 +234,26 @@ async def _relink_after_final(
             pass
         await asyncio.sleep(2.0)
     if final is not None and linked:
-        logger.info(
-            "relink not needed after %s — trace=%s still linked sim=%s final=%s",
-            early_status,
-            trace_id,
-            simulation_result_id,
-            final,
-        )
-        return
+        await asyncio.sleep(float(os.environ.get("MIVAS_RELINK_SETTLE_SECONDS", "15")))
+        try:
+            r = await client.get(
+                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
+                headers={"X-API-Key": key},
+            )
+            if r.status_code == 200:
+                result = (r.json() or {}).get("simulation_result") or {}
+                linked = trace_id in (result.get("trace_ids") or [])
+        except Exception:
+            pass
+        if linked:
+            logger.info(
+                "relink not needed after %s — trace=%s still linked sim=%s final=%s",
+                early_status,
+                trace_id,
+                simulation_result_id,
+                final,
+            )
+            return
     if final is None:
         logger.warning(
             "relink skipped — still not final after early upsert terminal=%s sim=%s",
@@ -720,6 +732,13 @@ async def traced_run(
             event_tracer.close()
     finally:
         flush()
+        if simulation_result_id:
+            try:
+                from snapshot import capture_final
+
+                await asyncio.to_thread(capture_final, str(simulation_result_id))
+            except Exception:
+                logger.exception("final snapshot failed sim=%s", simulation_result_id)
         if simulation_result_id and otel_tid:
             await post_trace_ids(simulation_result_id, otel_tid)
         elif simulation_result_id and not otel_tid:

--- a/voice-agent-harnesses/pipecat/adapters/livekit_worker.py
+++ b/voice-agent-harnesses/pipecat/adapters/livekit_worker.py
@@ -2,8 +2,9 @@
 
 Bluejay `connection_type=LIVEKIT` dispatches by `livekit_agent_name`. This process
 accepts those jobs, joins the assigned room over LiveKitTransport, and runs the
-existing `bot.run_bot` pipeline. The industry tool server stays in-process
-(`TOOL_SERVER_URL=http://127.0.0.1:8000`).
+existing `bot.run_bot` pipeline. Industry tools go to TOOL_SERVER_URL (ClusterIP
+`http://mivas-{slug}-tools:8000` on EKS). Pipecat Cloud bots use the public
+https://{host}/tools path instead.
 """
 
 from __future__ import annotations
@@ -117,6 +118,8 @@ def main() -> None:
         if not room_name:
             raise RuntimeError("LiveKit job has no room name")
         sim_id = sim_result_id_from_job_metadata(getattr(ctx.job, "metadata", None))
+        harness.set_call_id(sim_id)
+        harness.begin_session(sim_id, session_key=room_name)
         job_url, job_token = _job_url_and_token(ctx, agent_name, room_name)
         logger.info(
             "pipecat livekit job runtime=%s room=%s sim=%s",

--- a/voice-agent-harnesses/pipecat/bot.py
+++ b/voice-agent-harnesses/pipecat/bot.py
@@ -373,6 +373,8 @@ async def bot(args) -> None:
         os.environ["TOOL_SERVER_URL"] = str(body["tool_server_url"])
 
     sim_result_id = await report.resolve_simulation_result_id(body.get("simulation_id"))
+    harness.set_call_id(sim_result_id)
+    harness.begin_session(sim_result_id, session_key=str(sim_result_id or "job"))
     logger.info(
         "pipecat bot runtime={} model={} sim_result_id={} tool_server={}",
         runtime, harness.RUNTIMES[runtime], sim_result_id, harness.tool_server_url(),

--- a/voice-agent-harnesses/pipecat/harness.py
+++ b/voice-agent-harnesses/pipecat/harness.py
@@ -36,10 +36,19 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
 import httpx
+
+for _root in (Path("/app"), *Path(__file__).resolve().parents):
+    _runtime = _root / "runtime"
+    if (_runtime / "call_id.py").is_file():
+        if str(_runtime) not in sys.path:
+            sys.path.insert(0, str(_runtime))
+        break
+from call_id import begin_session, headers as tool_headers, set_call_id  # noqa: E402
 
 HARNESS_DIR = Path(__file__).resolve().parent
 # In the repo this is mivas-bench/; in the deployed image the harness IS the root.
@@ -170,7 +179,9 @@ async def _execute_tool(
 
     async with httpx.AsyncClient(timeout=30.0) as client:
         resp = await client.post(
-            f"{tool_server_url()}/tools/{name}", json={"arguments": args}
+            f"{tool_server_url()}/tools/{name}",
+            json={"arguments": args},
+            headers=tool_headers(),
         )
         return resp.json(), False
 

--- a/voice-agent-harnesses/retell/adapters/chirp.py
+++ b/voice-agent-harnesses/retell/adapters/chirp.py
@@ -35,13 +35,18 @@ from livekit import rtc
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from harness import (  # noqa: E402
+    begin_session,
+    bind_provider,
     create_web_call,
+    end_session,
     ensure_agent,
+    for_provider,
     industry_path,
     livekit_url,
     load_blueprint,
     report_platform_tools,
     run_tool,
+    unbind_provider,
 )
 from report import (  # noqa: E402
     end_speech_span,
@@ -64,6 +69,7 @@ async def tool_webhook(name: str, request: Request) -> dict:
     body = await request.json()
     args = dict(body.get("args") or {})
     call_id = (body.get("call") or {}).get("call_id")
+    for_provider(call_id)
     result = await run_tool(name, args, call_id=call_id)
     print(f"chirp tool {name} args={args} -> {result}", flush=True)
     return result
@@ -103,7 +109,10 @@ async def _bridge(ws: WebSocket) -> None:
     if sim_id:
         print(f"chirp sim_result_id={sim_id}", flush=True)
 
+    session_key = uuid.uuid4().hex
+    resolved = begin_session(sim_id, session_key=session_key)
     call = create_web_call(CFG["agent_id"])
+    bind_provider(call["call_id"], resolved)
     print(f"chirp retell call_id={call['call_id']}", flush=True)
 
     end = asyncio.Event()
@@ -114,140 +123,144 @@ async def _bridge(ws: WebSocket) -> None:
     customer_otel = None
     agent_bytes = 0
 
-    async with traced_run(CFG["workflow"], simulation_result_id=sim_id, model=CFG["model"]):
-        room = rtc.Room()
+    try:
+        async with traced_run(CFG["workflow"], simulation_result_id=sim_id, model=CFG["model"]):
+            room = rtc.Room()
 
-        def _agent_start() -> None:
-            nonlocal agent_otel, agent_utt, agent_started
-            if agent_utt is not None:
-                return
-            agent_utt = f"u_{uuid.uuid4().hex[:12]}"
-            agent_started = time.monotonic()
-            agent_otel = start_speech_span(agent_utt, speaker="agent")
-            outq.put_nowait(_event("speech.started", {"utterance_id": agent_utt}))
+            def _agent_start() -> None:
+                nonlocal agent_otel, agent_utt, agent_started
+                if agent_utt is not None:
+                    return
+                agent_utt = f"u_{uuid.uuid4().hex[:12]}"
+                agent_started = time.monotonic()
+                agent_otel = start_speech_span(agent_utt, speaker="agent")
+                outq.put_nowait(_event("speech.started", {"utterance_id": agent_utt}))
 
-        def _agent_stop(*, force: bool = False) -> None:
-            """Retell fires a spurious start/stop pair ~250 ms before each real turn;
-            a sub-BLIP_S utterance is that artifact, so hold the span open for the
-            real audio instead of littering the waterfall with 20 ms spans."""
-            nonlocal agent_otel, agent_utt
-            if agent_utt is None:
-                return
-            if not force and time.monotonic() - agent_started < BLIP_S:
-                return
-            end_speech_span(agent_otel)
-            outq.put_nowait(_event("speech.completed", {"utterance_id": agent_utt}))
-            agent_otel, agent_utt = None, None
+            def _agent_stop(*, force: bool = False) -> None:
+                """Retell fires a spurious start/stop pair ~250 ms before each real turn;
+                a sub-BLIP_S utterance is that artifact, so hold the span open for the
+                real audio instead of littering the waterfall with 20 ms spans."""
+                nonlocal agent_otel, agent_utt
+                if agent_utt is None:
+                    return
+                if not force and time.monotonic() - agent_started < BLIP_S:
+                    return
+                end_speech_span(agent_otel)
+                outq.put_nowait(_event("speech.completed", {"utterance_id": agent_utt}))
+                agent_otel, agent_utt = None, None
 
-        @room.on("data_received")
-        def _on_data(packet: rtc.DataPacket) -> None:
-            try:
-                event = json.loads(bytes(packet.data).decode())
-            except (UnicodeDecodeError, json.JSONDecodeError):
-                return
-            etype = event.get("event_type")
-            if etype == "agent_start_talking":
-                _agent_start()
-            elif etype == "agent_stop_talking":
-                _agent_stop()
-            elif etype not in ("update", None):
-                print(f"chirp retell data {etype}", flush=True)
+            @room.on("data_received")
+            def _on_data(packet: rtc.DataPacket) -> None:
+                try:
+                    event = json.loads(bytes(packet.data).decode())
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    return
+                etype = event.get("event_type")
+                if etype == "agent_start_talking":
+                    _agent_start()
+                elif etype == "agent_stop_talking":
+                    _agent_stop()
+                elif etype not in ("update", None):
+                    print(f"chirp retell data {etype}", flush=True)
 
-        @room.on("track_subscribed")
-        def _on_track(track: rtc.Track, *_a) -> None:
-            if track.kind == rtc.TrackKind.KIND_AUDIO:
-                asyncio.create_task(_pump(track))
+            @room.on("track_subscribed")
+            def _on_track(track: rtc.Track, *_a) -> None:
+                if track.kind == rtc.TrackKind.KIND_AUDIO:
+                    asyncio.create_task(_pump(track))
 
-        @room.on("disconnected")
-        def _on_disconnected(*_a) -> None:
-            end.set()
-
-        @room.on("participant_disconnected")
-        def _on_participant_gone(*_a) -> None:
-            end.set()
-
-        async def _pump(track: rtc.Track) -> None:
-            nonlocal agent_bytes
-            async for ev in rtc.AudioStream(track, sample_rate=RATE, num_channels=CHANNELS):
-                pcm = bytes(ev.frame.data)
-                agent_bytes += len(pcm)
-                outq.put_nowait(pcm)
-
-        await room.connect(
-            livekit_url(), call["access_token"], options=rtc.RoomOptions(auto_subscribe=True)
-        )
-        source = rtc.AudioSource(RATE, CHANNELS)
-        await room.local_participant.publish_track(
-            rtc.LocalAudioTrack.create_audio_track("chirp", source),
-            rtc.TrackPublishOptions(source=rtc.TrackSource.SOURCE_MICROPHONE),
-        )
-
-        async def inbound() -> None:
-            """chirp pcm → LiveKit mic track; Bluejay speech.* → customer.speech spans."""
-            nonlocal customer_otel
-            caller_bytes = 0
-            try:
-                while True:
-                    msg = await ws.receive()
-                    if msg["type"] == "websocket.disconnect":
-                        break
-                    pcm = msg.get("bytes")
-                    if pcm:
-                        caller_bytes += len(pcm)
-                        await source.capture_frame(
-                            rtc.AudioFrame(pcm, RATE, CHANNELS, len(pcm) // 2)
-                        )
-                        continue
-                    text = msg.get("text")
-                    if not text:
-                        continue
-                    try:
-                        event = json.loads(text)
-                    except json.JSONDecodeError:
-                        continue
-                    etype = event.get("type")
-                    if etype == "speech.started":
-                        end_speech_span(customer_otel)
-                        uid = (event.get("data") or {}).get("utterance_id") or f"c_{uuid.uuid4().hex[:12]}"
-                        customer_otel = start_speech_span(uid, speaker="customer")
-                    elif etype == "speech.completed":
-                        end_speech_span(customer_otel)
-                        customer_otel = None
-            finally:
-                end_speech_span(customer_otel)
-                customer_otel = None
-                print(f"chirp caller_bytes={caller_bytes}", flush=True)
+            @room.on("disconnected")
+            def _on_disconnected(*_a) -> None:
                 end.set()
 
-        async def sender() -> None:
-            """single queue keeps speech.* text frames ordered against agent pcm."""
-            while True:
-                item = await outq.get()
-                if isinstance(item, bytes):
-                    await ws.send_bytes(item)
-                else:
-                    await ws.send_text(item)
+            @room.on("participant_disconnected")
+            def _on_participant_gone(*_a) -> None:
+                end.set()
 
-        tasks = [
-            asyncio.create_task(inbound()),
-            asyncio.create_task(sender()),
-            asyncio.create_task(end.wait()),
-        ]
-        done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-        for t in pending:
-            t.cancel()
-        await asyncio.gather(*pending, return_exceptions=True)
-        _agent_stop(force=True)
-        end_speech_span(customer_otel)
-        await room.disconnect()
-        print(f"chirp agent_bytes={agent_bytes}", flush=True)
-        # the edge transition and end_call ran inside Retell — read them off the
-        # call record so they land on the waterfall next to the webhook tool.
-        backfilled = await report_platform_tools(call["call_id"], CFG["bp"])
-        print(f"chirp platform tools {backfilled}", flush=True)
-        for t in done:
-            if not t.cancelled() and t.exception() is not None:
-                raise t.exception()  # type: ignore[misc]
+            async def _pump(track: rtc.Track) -> None:
+                nonlocal agent_bytes
+                async for ev in rtc.AudioStream(track, sample_rate=RATE, num_channels=CHANNELS):
+                    pcm = bytes(ev.frame.data)
+                    agent_bytes += len(pcm)
+                    outq.put_nowait(pcm)
+
+            await room.connect(
+                livekit_url(), call["access_token"], options=rtc.RoomOptions(auto_subscribe=True)
+            )
+            source = rtc.AudioSource(RATE, CHANNELS)
+            await room.local_participant.publish_track(
+                rtc.LocalAudioTrack.create_audio_track("chirp", source),
+                rtc.TrackPublishOptions(source=rtc.TrackSource.SOURCE_MICROPHONE),
+            )
+
+            async def inbound() -> None:
+                """chirp pcm → LiveKit mic track; Bluejay speech.* → customer.speech spans."""
+                nonlocal customer_otel
+                caller_bytes = 0
+                try:
+                    while True:
+                        msg = await ws.receive()
+                        if msg["type"] == "websocket.disconnect":
+                            break
+                        pcm = msg.get("bytes")
+                        if pcm:
+                            caller_bytes += len(pcm)
+                            await source.capture_frame(
+                                rtc.AudioFrame(pcm, RATE, CHANNELS, len(pcm) // 2)
+                            )
+                            continue
+                        text = msg.get("text")
+                        if not text:
+                            continue
+                        try:
+                            event = json.loads(text)
+                        except json.JSONDecodeError:
+                            continue
+                        etype = event.get("type")
+                        if etype == "speech.started":
+                            end_speech_span(customer_otel)
+                            uid = (event.get("data") or {}).get("utterance_id") or f"c_{uuid.uuid4().hex[:12]}"
+                            customer_otel = start_speech_span(uid, speaker="customer")
+                        elif etype == "speech.completed":
+                            end_speech_span(customer_otel)
+                            customer_otel = None
+                finally:
+                    end_speech_span(customer_otel)
+                    customer_otel = None
+                    print(f"chirp caller_bytes={caller_bytes}", flush=True)
+                    end.set()
+
+            async def sender() -> None:
+                """single queue keeps speech.* text frames ordered against agent pcm."""
+                while True:
+                    item = await outq.get()
+                    if isinstance(item, bytes):
+                        await ws.send_bytes(item)
+                    else:
+                        await ws.send_text(item)
+
+            tasks = [
+                asyncio.create_task(inbound()),
+                asyncio.create_task(sender()),
+                asyncio.create_task(end.wait()),
+            ]
+            done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            for t in pending:
+                t.cancel()
+            await asyncio.gather(*pending, return_exceptions=True)
+            _agent_stop(force=True)
+            end_speech_span(customer_otel)
+            await room.disconnect()
+            print(f"chirp agent_bytes={agent_bytes}", flush=True)
+            # the edge transition and end_call ran inside Retell — read them off the
+            # call record so they land on the waterfall next to the webhook tool.
+            backfilled = await report_platform_tools(call["call_id"], CFG["bp"])
+            print(f"chirp platform tools {backfilled}", flush=True)
+            for t in done:
+                if not t.cancelled() and t.exception() is not None:
+                    raise t.exception()  # type: ignore[misc]
+    finally:
+        unbind_provider(call["call_id"])
+        end_session(session_key)
 
 
 def main(model: str | None = None) -> None:

--- a/voice-agent-harnesses/retell/harness.py
+++ b/voice-agent-harnesses/retell/harness.py
@@ -18,11 +18,29 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import sys
 import time
 from pathlib import Path
 from typing import Any
 
 import httpx
+
+for _root in (Path("/app"), *Path(__file__).resolve().parents):
+    _runtime = _root / "runtime"
+    if (_runtime / "call_id.py").is_file():
+        if str(_runtime) not in sys.path:
+            sys.path.insert(0, str(_runtime))
+        break
+from call_id import (  # noqa: E402
+    begin_session,
+    bind_provider,
+    end_session,
+    for_provider,
+    headers as tool_headers,
+    provider_id_from_payload,
+    set_call_id,
+    unbind_provider,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HARNESS_DIR = Path(__file__).resolve().parent
@@ -335,7 +353,11 @@ async def report_platform_tools(call_id: str, bp: dict[str, Any]) -> list[str]:
 async def _execute_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
     """Generic dispatch: POST /tools/{name}; the server's envelope is the result."""
     async with httpx.AsyncClient(timeout=30.0) as client:
-        resp = await client.post(f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args})
+        resp = await client.post(
+            f"{TOOL_SERVER_URL}/tools/{name}",
+            json={"arguments": args},
+            headers=tool_headers(),
+        )
         return resp.json()
 
 
@@ -345,6 +367,7 @@ async def run_tool(name: str, args: dict[str, Any], *, call_id: str | None = Non
     from report import finish_tool_span, tool_span
     with tool_span(name, args, call_id=call_id) as span:
         try:
+            for_provider(call_id)
             result = await _execute_tool(name, args)
             ok = bool(result.get("ok", result.get("success", True)))
             finish_tool_span(span, result, ok=ok)

--- a/voice-agent-harnesses/twilio/README.md
+++ b/voice-agent-harnesses/twilio/README.md
@@ -15,11 +15,11 @@ stack on answer.
 
 ```
 Bluejay DH (connection_type=SIP)
-  ──SIP INVITE──▶ sip:mivas@mivas-conversationrelay.sip.twilio.com
+  ──SIP INVITE──▶ sip:mivas@mivas-twilio-<industry>.sip.twilio.com
                        │ VoiceUrl webhook (POST /)
                        ▼
-            adapters/chirp.py  (TwiML <ConversationRelay>)
-                       │ wss://…/ws?simulation_result_id=…
+            adapters/conversationrelay.py  (TwiML <ConversationRelay>)
+                       │ wss://…/ws?simulation_result_id=<X-Simulation-Result-Id>
                        ▼
             GPT-4.1 chat.completions (+ tools)
                        │
@@ -76,14 +76,14 @@ set -a && source .env && set +a
 export PUBLIC_URL=https://<tunnel>.trycloudflare.com
 export INDUSTRY=control-industry TOOL_SERVER_URL=http://127.0.0.1:8000
 export CHIRP_PORT=8773 BLUEJAY_SERVICE_NAME=mivas-twilio PYTHONUNBUFFERED=1
-uv run python voice-agent-harnesses/twilio/conversationrelay-gpt4.1/adapters/chirp.py
+uv run python voice-agent-harnesses/twilio/conversationrelay-gpt4.1/adapters/conversationrelay.py
 ```
 
 After every cloudflared restart, update the SIP Domain `VoiceUrl` to the new tunnel
 (and keep `PUBLIC_URL` in sync).
 
 Bluejay agent: `connection_type=SIP`, `mode=VOICE`,
-`sip_uri=sip:mivas@mivas-conversationrelay.sip.twilio.com`,
+`sip_uri=sip:mivas@mivas-twilio-<industry>.sip.twilio.com`,
 plus matching `sip_username` / `sip_password` from the domain Credential List.
 
 ## Check
@@ -100,12 +100,12 @@ uv run python voice-agent-harnesses/twilio/conversationrelay-gpt4.1/agent.py con
 |---|---|
 | `HARNESS` | `twilio/conversationrelay-gpt4.1` |
 | CR port | `8773` |
-| `agent_id` | `32132` |
-| `simulation_id` | `30314` |
-| booker DH | `194589` (clone of `194508`) |
-| SIP Domain | `mivas-conversationrelay.sip.twilio.com` (`SD0fca4b2e1eeddb091a1852e7f7de8070`) |
+| `agent_id` | `32132` (control-industry) · `33377` (healthcare) |
+| `simulation_id` | `30314` (control) · `30350` (healthcare) |
+| booker DH | `194589` (control) · Alice `194981` / Jordan `194982` (healthcare copies; need a LiveKit caller `phone_number`) |
+| SIP Domain | control `mivas-twilio-control-industry.sip.twilio.com` (`SDfcf8684e6f7ea611ee406e22e0c58ef8`) · healthcare `mivas-twilio-healthcare.sip.twilio.com` (`SD3739cc402cb3d14e494f54df45dabe48`) |
 | Credential List | `mivas-conversationrelay-creds` (`CL4cce80ea0c40d4a12fa9af919dc225d4`) |
-| SIP URI | `sip:mivas@mivas-conversationrelay.sip.twilio.com` |
+| SIP URI | `sip:mivas@mivas-twilio-<industry>.sip.twilio.com` |
 | Username | `mivas` |
 | Legacy PSTN number | `+15054776173` — no longer the agent connection (kept on account) |
 
@@ -115,7 +115,8 @@ uv run python voice-agent-harnesses/twilio/conversationrelay-gpt4.1/agent.py con
 |---|---|
 | Offline `--check` | pass |
 | Local CR protocol smoke (`smoke_ws.py`) | pass — `handoff_to_scheduler` → `schedule_appointment{08/18/2026}` → `end_call` |
-| SIP Domain + Bluejay agent wired | pass — agent `32132` is `connection_type=SIP` |
+| SIP Domain + Bluejay agent wired | pass — `32132` → `sip:mivas@mivas-twilio-control-industry.sip.twilio.com`; `33377` → `sip:mivas@mivas-twilio-healthcare.sip.twilio.com` |
+| Bluejay SIP header → per-call DB | **pass** — run `229280` TwiML `sim=720552` / `720553` and `/data/calls/720552.db` + `720553.db`; healthcare run `229281` `sim=720554` / `720555` and matching files. `SipHeader_X-Simulation-Result-Id` is on the VoiceUrl POST. |
 | Bluejay SIP ≥3 (`run 227413` / `716977–716979`) | **pass** — all `COMPLETED`, `goal_success=true`, `08/18/2026`. Prod DB: exactly **1** `trace_id` on `test_results` + `sim_conversations`, **3** `tool_call_logs` (handoff/schedule/end once each), API `actual` counts = 1. CR logged 3× `update-simulation-result ok once` (no double POST). |
 
 Local protocol smoke (no SIP):
@@ -128,7 +129,8 @@ uv run python voice-agent-harnesses/twilio/conversationrelay-gpt4.1/smoke_ws.py
 ## Gotchas
 
 - ConversationRelay access requires Twilio Console onboarding (not instant on new accounts).
-- Tunnel URL churn: update SIP Domain VoiceUrl after every cloudflared restart.
+- Tunnel URL churn: update that pack’s SIP Domain VoiceUrl after every cloudflared restart.
+- One SIP Domain per industry (`mivas-twilio-control-industry`, `mivas-twilio-healthcare`, …). Do not share a VoiceUrl across packs. Legacy `mivas-conversationrelay` stays pointed at control as a fallback. DH copies of websocket healthcare patients start with `phone_number=null` and Bluejay SIP-dials `NO_CONNECTION` until a caller number is set.
 - Soft handoff keeps history — do **not** also cold-open the scheduler with a blind re-ask seed.
 - Audio barge-in/mute rules from PCM CHIRP harnesses do not apply; Twilio handles interrupts via `interrupt` messages (we truncate the last assistant turn).
 - Keep the industry tool server current — older `:8000` processes without `POST /tools/{name}` return FastAPI `{"detail":"Not Found"}` and the model may verbally “confirm” a booking that never landed.

--- a/voice-agent-harnesses/twilio/adapters/conversationrelay.py
+++ b/voice-agent-harnesses/twilio/adapters/conversationrelay.py
@@ -1,18 +1,18 @@
 """Twilio ConversationRelay bridge (TwiML + WebSocket) ↔ GPT-4.1.
 
-Named adapters/chirp.py to match the MIVAS family layout. Unlike PCM CHIRP
-harnesses, this process speaks the ConversationRelay JSON protocol:
+This is not Bluejay CHIRP. Bluejay dials SIP; Twilio POSTs TwiML here, then
+opens a ConversationRelay WebSocket:
 
-  Twilio SIP/phone call → GET/POST /  (TwiML <ConversationRelay>)
-                        → WS /ws      (setup / prompt / interrupt → text / end)
+  Twilio SIP INVITE → GET/POST /  (TwiML <ConversationRelay>)
+                    → WS /ws      (setup / prompt / interrupt → text / end)
 
 Soft multi-agent: one OpenAI chat session; handoff swaps system + tools while
 keeping history. Speak-first is ConversationRelay welcomeGreeting.
 
 Env:
   OPENAI_API_KEY, PUBLIC_URL|HOST, INDUSTRY, TOOL_SERVER_URL
-  CHIRP_PORT (default 8773), TWILIO_LLM_MODEL, TWILIO_WELCOME_GREETING
-  BLUEJAY_* for OTel
+  CHIRP_PORT (listen port, default 8773; k8s maps this to container port 8765)
+  TWILIO_LLM_MODEL, TWILIO_WELCOME_GREETING, BLUEJAY_* for OTel
 """
 
 from __future__ import annotations
@@ -26,7 +26,7 @@ import time
 import uuid
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qs
+from urllib.parse import parse_qs, parse_qsl
 
 from fastapi import FastAPI, Request, WebSocket, WebSocketDisconnect
 from fastapi.responses import PlainTextResponse, Response
@@ -46,7 +46,10 @@ from harness import (  # noqa: E402
     openai_tools_for_agent,
     public_base_url,
     run_tool,
+    sim_id_from_mapping,
+    sip_header_keys,
     transcript_blob,
+    set_call_id,
     truncate_assistant_on_interrupt,
     twiml_connect,
     welcome_greeting,
@@ -93,23 +96,15 @@ def build_app(industry: str | None = None) -> FastAPI:
                 scheme = "wss"
             ws = f"{scheme}://{host}/ws"
 
-        # Bluejay SIP → Twilio SIP Domain forwards X-* SIP headers as SipHeader_*.
-        sim_id = ""
-        try:
-            form = await request.form()
-            form_map = {str(k): str(v) for k, v in form.items()}
-        except Exception:
-            form_map = {}
-        for key in (
-            "SipHeader_X-Simulation-Result-Id",
-            "SipHeader_X-Simulation-Result-ID",
-            "SipHeader_X-Simulation-Result-id",
-        ):
-            if form_map.get(key):
-                sim_id = form_map[key].strip()
-                break
-        if not sim_id:
-            sim_id = (request.query_params.get("simulation_result_id") or "").strip()
+        # Bluejay LiveKit stamps X-Simulation-Result-Id on the SIP INVITE.
+        # Twilio VoiceUrl forwards X-* INVITE headers as SipHeader_* (POST form
+        # or GET query). Merge every source; empty form is common on GET.
+        webhook = await _twilio_webhook_params(request)
+        header_map = {str(k): str(v) for k, v in request.headers.items()}
+        sim_id = (
+            sim_id_from_mapping(webhook)
+            or sim_id_from_mapping(header_map)
+        )
         params: dict[str, str] = {}
         if sim_id:
             sep = "&" if "?" in ws else "?"
@@ -119,7 +114,10 @@ def build_app(industry: str | None = None) -> FastAPI:
         body = twiml_connect(ws_url=ws, parameters=params or None)
         print(
             f"TwiML → ConversationRelay url={ws} sim={sim_id or '-'} "
-            f"welcome={welcome_greeting()!r}",
+            f"method={request.method} ctype={request.headers.get('content-type') or '-'} "
+            f"welcome={welcome_greeting()!r} "
+            f"sip_headers={sip_header_keys(webhook) or sip_header_keys(header_map)} "
+            f"form_keys={','.join(sorted(webhook)) or '-'}",
             flush=True,
         )
         return Response(content=body, media_type="application/xml")
@@ -134,6 +132,29 @@ def build_app(industry: str | None = None) -> FastAPI:
 
         sim_id = _sim_id_from_ws(ws)
         call_sid: str | None = None
+        pending: dict[str, Any] | None = None
+        try:
+            raw = await asyncio.wait_for(ws.receive_text(), timeout=20.0)
+            try:
+                pending = json.loads(raw)
+            except json.JSONDecodeError:
+                log(f"bad json: {raw[:120]!r}")
+                pending = None
+            if pending and pending.get("type") == "setup":
+                call_sid = pending.get("callSid")
+                custom = pending.get("customParameters") or {}
+                sim_id = sim_id or sim_id_from_mapping(custom) or None
+                log(f"setup callSid={call_sid} sim={sim_id} from={pending.get('from')}")
+                pending = None
+        except TimeoutError:
+            log("no CR setup in 20s")
+        except WebSocketDisconnect:
+            log("WS closed before setup")
+            return
+
+        # Pin X-Mivas-Call-Id to Bluejay's SIP header when present; mint only if omitted.
+        resolved = set_call_id(sim_id)
+        sim_id = resolved
         state: dict[str, Any] = {
             "agent": bp["start"],
             "mid_call": False,
@@ -148,25 +169,29 @@ def build_app(industry: str | None = None) -> FastAPI:
         workflow = f"mivas twilio {bp['industry_dir'].name} {MODEL}".replace(".", "-")
         log(f"WS open sim={sim_id} industry={bp['industry_dir'].name}")
 
-        async with traced_run(workflow, simulation_result_id=sim_id, model=MODEL) as root:
+        otel_sim = sim_id if str(sim_id).isdigit() else None
+        async with traced_run(workflow, simulation_result_id=otel_sim, model=MODEL) as root:
             state["_otel_root"] = root
             try:
                 while True:
-                    raw = await ws.receive_text()
-                    try:
-                        msg = json.loads(raw)
-                    except json.JSONDecodeError:
-                        log(f"bad json: {raw[:120]!r}")
-                        continue
+                    if pending is not None:
+                        msg = pending
+                        pending = None
+                    else:
+                        raw = await ws.receive_text()
+                        try:
+                            msg = json.loads(raw)
+                        except json.JSONDecodeError:
+                            log(f"bad json: {raw[:120]!r}")
+                            continue
                     mtype = msg.get("type")
                     if mtype == "setup":
                         call_sid = msg.get("callSid")
                         custom = msg.get("customParameters") or {}
                         if not sim_id:
-                            sim_id = (
-                                str(custom.get("simulation_result_id") or "").strip()
-                                or None
-                            )
+                            sim_id = sim_id_from_mapping(custom) or None
+                        if sim_id:
+                            set_call_id(sim_id)
                         log(f"setup callSid={call_sid} sim={sim_id} from={msg.get('from')}")
                     elif mtype == "prompt":
                         text = (msg.get("voicePrompt") or "").strip()
@@ -199,18 +224,32 @@ def build_app(industry: str | None = None) -> FastAPI:
     return app
 
 
+async def _twilio_webhook_params(request: Request) -> dict[str, str]:
+    """Twilio VoiceUrl params: GET query plus POST urlencoded body.
+
+    Do not use request.form() — Starlette requires python-multipart even for
+    application/x-www-form-urlencoded, which this image does not install.
+    """
+    merged: dict[str, str] = {}
+    for key, val in request.query_params.items():
+        if val not in (None, ""):
+            merged[str(key)] = str(val)
+    raw = (await request.body()).decode("utf-8", errors="replace")
+    if raw:
+        for key, val in parse_qsl(raw, keep_blank_values=False):
+            merged[str(key)] = str(val)
+    return merged
+
+
 def _sim_id_from_ws(ws: WebSocket) -> str | None:
     q = parse_qs(ws.scope.get("query_string", b"").decode())
-    for key in ("simulation_result_id", "sim_id"):
-        vals = q.get(key) or []
-        if vals and str(vals[0]).strip():
-            return str(vals[0]).strip()
+    flat = {k: (vals[0] if vals else "") for k, vals in q.items()}
+    found = sim_id_from_mapping(flat)
+    if found:
+        return found
     headers = dict(ws.headers) if hasattr(ws, "headers") else {}
-    for key in ("x-simulation-result-id", "X-Simulation-Result-Id"):
-        val = headers.get(key) or headers.get(key.lower())
-        if val:
-            return str(val).strip()
-    return None
+    found = sim_id_from_mapping({str(k): str(v) for k, v in headers.items()})
+    return found or None
 
 
 async def _send_text(ws: WebSocket, token: str, *, last: bool) -> None:

--- a/voice-agent-harnesses/twilio/conversationrelay-gpt4.1/adapters/conversationrelay.py
+++ b/voice-agent-harnesses/twilio/conversationrelay-gpt4.1/adapters/conversationrelay.py
@@ -1,4 +1,4 @@
-"""Shim → family adapters/chirp.py (ConversationRelay + GPT-4.1)."""
+"""Shim → family adapters/conversationrelay.py (TwiML + ConversationRelay WS)."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-from adapters.chirp import main  # noqa: E402
+from adapters.conversationrelay import main  # noqa: E402
 
 if __name__ == "__main__":
     main()

--- a/voice-agent-harnesses/twilio/conversationrelay-gpt4.1/agent.py
+++ b/voice-agent-harnesses/twilio/conversationrelay-gpt4.1/agent.py
@@ -34,7 +34,7 @@ if __name__ == "__main__":
     industry = next((a for a in sys.argv[1:] if not a.startswith("-")), "control-industry")
     industry_dir = Path(os.environ.get("INDUSTRY_DIR", str(industry_path(industry))))
     if "--check" in sys.argv:
-        demo()
+        demo(industry_dir)
         start, agents = build_agents(industry_dir)
         bp = load_blueprint(industry_dir)
         tools = advertised_tools(industry_dir)
@@ -45,11 +45,11 @@ if __name__ == "__main__":
             f"welcome={welcome_greeting()!r} tool_server={tool_server_url() or TOOL_SERVER_URL}"
         )
     else:
-        # Live traffic is served by adapters/chirp.py (TwiML + ConversationRelay WS).
+        # Live traffic is served by adapters/conversationrelay.py (TwiML + CR WS).
         print(
             "Run the ConversationRelay server:\n"
-            "  uv run python voice-agent-harnesses/twilio/conversationrelay-gpt4.1/adapters/chirp.py\n"
-            "Or: uv run python voice-agent-harnesses/twilio/adapters/chirp.py",
+            "  uv run python voice-agent-harnesses/twilio/conversationrelay-gpt4.1/adapters/conversationrelay.py\n"
+            "Or: uv run python voice-agent-harnesses/twilio/adapters/conversationrelay.py",
             file=sys.stderr,
         )
         sys.exit(2)

--- a/voice-agent-harnesses/twilio/conversationrelay-gpt4.1/smoke_ws.py
+++ b/voice-agent-harnesses/twilio/conversationrelay-gpt4.1/smoke_ws.py
@@ -1,6 +1,6 @@
 """Local ConversationRelay protocol smoke (no Twilio phone required).
 
-Connects to a running adapters/chirp.py and drives setup → prompt turns that
+Connects to a running adapters/conversationrelay.py and drives setup → prompt turns that
 should trigger handoff + schedule_appointment against the industry tool server.
 """
 

--- a/voice-agent-harnesses/twilio/harness.py
+++ b/voice-agent-harnesses/twilio/harness.py
@@ -18,10 +18,19 @@ import datetime as _dt
 import json
 import os
 import re
+import sys
 from pathlib import Path
 from typing import Any
 
 import httpx
+
+for _root in (Path("/app"), *Path(__file__).resolve().parents):
+    _runtime = _root / "runtime"
+    if (_runtime / "call_id.py").is_file():
+        if str(_runtime) not in sys.path:
+            sys.path.insert(0, str(_runtime))
+        break
+from call_id import headers as tool_headers, set_call_id  # noqa: E402
 
 HARNESS_DIR = Path(__file__).resolve().parent
 REPO_ROOT = HARNESS_DIR.parents[1] if len(HARNESS_DIR.parents) > 1 else HARNESS_DIR
@@ -145,8 +154,104 @@ def api_key() -> str:
     return key
 
 
+_PACK_WELCOME = {
+    "control-industry": DEFAULT_WELCOME,
+    "healthcare": "Thank you for calling Straus Dermatology.",
+    "finance": "Thank you for calling Copperline Credit Union.",
+    "legal": "Thank you for calling Halverson and Reed.",
+    "travel": "Thank you for calling Summit Air.",
+}
+
+
+def _industry_name() -> str:
+    named = os.environ.get("INDUSTRY", "").strip()
+    if named:
+        return named
+    env_dir = os.environ.get("INDUSTRY_DIR", "").strip()
+    if env_dir:
+        return Path(env_dir).name
+    return "control-industry"
+
+
 def welcome_greeting() -> str:
-    return os.environ.get("TWILIO_WELCOME_GREETING", DEFAULT_WELCOME).strip() or DEFAULT_WELCOME
+    raw = os.environ.get("TWILIO_WELCOME_GREETING", "").strip()
+    pack = _PACK_WELCOME.get(_industry_name(), "Hello.")
+    # k8s used to stamp the control-industry greeting on every industry.
+    if not raw or (raw == DEFAULT_WELCOME and _industry_name() != "control-industry"):
+        return pack
+    return raw
+
+
+TWILIO_SIP_HOST_SUFFIX = "sip.twilio.com"
+
+
+def twilio_sip_domain(industry: str | None = None) -> str:
+    """Twilio SIP Domain host for a pack: mivas-twilio-<industry>.sip.twilio.com."""
+    name = (industry or _industry_name()).strip() or "control-industry"
+    return f"mivas-twilio-{name}.{TWILIO_SIP_HOST_SUFFIX}"
+
+
+def twilio_sip_uri(industry: str | None = None, *, user: str = "mivas") -> str:
+    """Bluejay agent sip_uri: sip:mivas@mivas-twilio-<industry>.sip.twilio.com."""
+    return f"sip:{user}@{twilio_sip_domain(industry)}"
+
+
+def sim_id_from_mapping(mapping: dict[str, Any] | None) -> str:
+    """Bluejay X-Simulation-Result-Id from a Twilio webhook form or CR customParameters.
+
+    LiveKit puts the id on the SIP INVITE as X-Simulation-Result-Id. Twilio Programmable
+    Voice forwards X-* INVITE headers as SipHeader_<Name> on the VoiceUrl POST.
+    Nested JSON (SipHeader_X-Custom-Headers) is scanned too.
+    """
+    if not mapping:
+        return ""
+    exact = (
+        "SipHeader_X-Simulation-Result-Id",
+        "SipHeader_X-Simulation-Result-ID",
+        "SipHeader_X-Simulation-Result-id",
+        "X-Simulation-Result-Id",
+        "x-simulation-result-id",
+        "simulation_result_id",
+        "Simulation-Result-Id",
+    )
+    for key in exact:
+        val = mapping.get(key)
+        if val not in (None, "") and not isinstance(val, (dict, list)):
+            return str(val).strip()
+    nested: list[dict[str, Any]] = []
+    for key, val in mapping.items():
+        if isinstance(val, dict):
+            nested.append(val)
+            continue
+        if val in (None, "") or isinstance(val, list):
+            continue
+        norm = str(key).lower().replace("_", "-")
+        if "simulation-result-id" in norm:
+            return str(val).strip()
+        text = str(val).strip()
+        if text.startswith("{") and text.endswith("}"):
+            try:
+                blob = json.loads(text)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(blob, dict):
+                nested.append(blob)
+    for blob in nested:
+        found = sim_id_from_mapping(blob)
+        if found:
+            return found
+    return ""
+
+
+def sip_header_keys(mapping: dict[str, Any] | None) -> list[str]:
+    """Form/header names Twilio stamped from the SIP INVITE (for logs)."""
+    if not mapping:
+        return []
+    return sorted(
+        str(k)
+        for k in mapping
+        if str(k).lower().startswith("sipheader") or str(k).lower().startswith("x-")
+    )
 
 
 def public_base_url() -> str:
@@ -420,7 +525,9 @@ def infer_schedule_appointment(text: str) -> dict[str, Any] | None:
 async def dispatch_industry_tool(name: str, args: dict[str, Any]) -> dict[str, Any]:
     async with httpx.AsyncClient(timeout=30.0) as client:
         resp = await client.post(
-            f"{tool_server_url()}/tools/{name}", json={"arguments": args}
+            f"{tool_server_url()}/tools/{name}",
+            json={"arguments": args},
+            headers=tool_headers(),
         )
         return resp.json()
 
@@ -581,15 +688,15 @@ def twiml_connect(
     )
 
 
-def demo() -> None:
-    """Offline smoke used by agent.py --check."""
-    bp = load_blueprint("control-industry")
-    assert bp["start"] == "receptionist"
-    assert tool_names(bp, "receptionist") == ["handoff_to_scheduler", "end_call"]
-    assert tool_names(bp, "scheduler") == ["schedule_appointment", "end_call"]
-    assert handoff_target(bp, "receptionist", "handoff_to_scheduler") == "scheduler"
-    tools = openai_tools_for_agent(bp, "receptionist")
-    assert tools[0]["function"]["name"] == "handoff_to_scheduler"
+def demo(industry: str | Path | None = None) -> None:
+    """Offline smoke used by agent.py --check. Industry-agnostic plus control asserts."""
+    bp = load_blueprint(industry or os.environ.get("INDUSTRY") or "control-industry")
+    start = bp["start"]
+    assert start in bp["agents"], start
+    start_tools = tool_names(bp, start)
+    assert start_tools, start
+    tools = openai_tools_for_agent(bp, start)
+    assert [t["function"]["name"] for t in tools] == start_tools
     assert today_context_line()
     inferred = infer_schedule_appointment(
         "Your appointment is scheduled for 08/18/2026."
@@ -597,3 +704,7 @@ def demo() -> None:
     assert inferred == {"date": "08/18/2026"}, inferred
     xml = twiml_connect(ws_url="wss://example.trycloudflare.com/ws")
     assert "ConversationRelay" in xml and "wss://example.trycloudflare.com/ws" in xml
+    if start == "receptionist" and "scheduler" in bp["agents"]:
+        assert start_tools == ["handoff_to_scheduler", "end_call"]
+        assert tool_names(bp, "scheduler") == ["schedule_appointment", "end_call"]
+        assert handoff_target(bp, "receptionist", "handoff_to_scheduler") == "scheduler"

--- a/voice-agent-harnesses/vapi/adapters/chirp.py
+++ b/voice-agent-harnesses/vapi/adapters/chirp.py
@@ -31,11 +31,16 @@ from fastapi import FastAPI, Request, WebSocket
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from harness import (  # noqa: E402
+    begin_session,
+    bind_provider,
+    end_session,
     ensure_squad,
+    for_provider,
     industry_path,
     load_blueprint,
     run_tool,
     start_websocket_call,
+    unbind_provider,
     webhook_tool_names,
 )
 from report import (  # noqa: E402
@@ -84,6 +89,7 @@ async def tool_webhook(name: str, request: Request) -> dict[str, Any]:
     body = await request.json()
     message = _payload(body)
     vapi_call_id = ((message.get("call") or {}).get("id")) or None
+    for_provider(vapi_call_id)
     calls = message.get("toolCallList") or []
     results = []
     for call in calls:
@@ -125,6 +131,10 @@ async def _bridge(ws: WebSocket) -> None:
     if sim_id:
         print(f"chirp sim_result_id={sim_id}", flush=True)
 
+    session_key = uuid.uuid4().hex
+    resolved = begin_session(sim_id, session_key=session_key)
+    provider_id: str | None = None
+
     utt: str | None = None
     speech_otel = None
     customer_otel = None
@@ -132,111 +142,117 @@ async def _bridge(ws: WebSocket) -> None:
     end = asyncio.Event()
     audio_in = audio_out = 0
 
-    async with traced_run(workflow, simulation_result_id=sim_id, model=model):
-        call_url, call_id = await asyncio.to_thread(start_websocket_call, _cfg["squad_id"])
-        # webhook tool calls arrive with no OTel/ContextVar context; this is how they
-        # find this bridge's trace root instead of whichever one started last
-        bind_call(call_id)
-        print(f"chirp vapi call={call_id}", flush=True)
-        async with websockets.connect(call_url, max_size=None) as vapi_ws:
+    try:
+        async with traced_run(workflow, simulation_result_id=sim_id, model=model):
+            call_url, call_id = await asyncio.to_thread(start_websocket_call, _cfg["squad_id"])
+            # webhook tool calls arrive with no OTel/ContextVar context; this is how they
+            # find this bridge's trace root instead of whichever one started last
+            bind_call(call_id)
+            bind_provider(call_id, resolved)
+            provider_id = call_id
+            print(f"chirp vapi call={call_id}", flush=True)
+            async with websockets.connect(call_url, max_size=None) as vapi_ws:
 
-            async def inbound() -> None:
-                """chirp pcm + Bluejay speech.* → Vapi; customer.speech spans."""
-                nonlocal customer_otel, audio_in
-                try:
-                    while not end.is_set():
-                        msg = await ws.receive()
-                        if msg["type"] == "websocket.disconnect":
-                            break
-                        if msg.get("bytes"):
-                            audio_in += len(msg["bytes"])
-                            await vapi_ws.send(msg["bytes"])
-                            continue
-                        if not msg.get("text"):
-                            continue
-                        try:
-                            event = json.loads(msg["text"])
-                        except json.JSONDecodeError:
-                            continue
-                        etype = event.get("type")
-                        data = event.get("data") or {}
-                        if etype == "speech.started":
-                            end_speech_span(customer_otel)
-                            customer_otel = start_speech_span(
-                                data.get("utterance_id") or f"c_{uuid.uuid4().hex[:12]}",
-                                speaker="customer",
-                            )
-                        elif etype == "speech.completed":
-                            end_speech_span(customer_otel)
-                            customer_otel = None
-                finally:
-                    end_speech_span(customer_otel)
-                    customer_otel = None
-                    end.set()
-                    with contextlib.suppress(Exception):
-                        await vapi_ws.close()
+                async def inbound() -> None:
+                    """chirp pcm + Bluejay speech.* → Vapi; customer.speech spans."""
+                    nonlocal customer_otel, audio_in
+                    try:
+                        while not end.is_set():
+                            msg = await ws.receive()
+                            if msg["type"] == "websocket.disconnect":
+                                break
+                            if msg.get("bytes"):
+                                audio_in += len(msg["bytes"])
+                                await vapi_ws.send(msg["bytes"])
+                                continue
+                            if not msg.get("text"):
+                                continue
+                            try:
+                                event = json.loads(msg["text"])
+                            except json.JSONDecodeError:
+                                continue
+                            etype = event.get("type")
+                            data = event.get("data") or {}
+                            if etype == "speech.started":
+                                end_speech_span(customer_otel)
+                                customer_otel = start_speech_span(
+                                    data.get("utterance_id") or f"c_{uuid.uuid4().hex[:12]}",
+                                    speaker="customer",
+                                )
+                            elif etype == "speech.completed":
+                                end_speech_span(customer_otel)
+                                customer_otel = None
+                    finally:
+                        end_speech_span(customer_otel)
+                        customer_otel = None
+                        end.set()
+                        with contextlib.suppress(Exception):
+                            await vapi_ws.close()
 
-            async def outbound() -> None:
-                """Vapi audio + events → chirp pcm, speech.*, agent.speech spans."""
-                nonlocal utt, speech_otel, audio_out
-                try:
-                    async for raw in vapi_ws:
-                        if end.is_set():
-                            break
-                        if isinstance(raw, bytes):
-                            audio_out += len(raw)
-                            await ws.send_bytes(raw)
-                            continue
-                        try:
-                            event = json.loads(raw)
-                        except json.JSONDecodeError:
-                            continue
-                        etype = _msg_type(event)
-                        body = _payload(event)
-                        if etype == "speech-update" and body.get("role") == "assistant":
-                            if body.get("status") == "started" and utt is None:
-                                utt = f"u_{uuid.uuid4().hex[:12]}"
-                                speech_otel = start_speech_span(utt, speaker="agent")
-                                await ws.send_text(_event("speech.started", {"utterance_id": utt}))
-                            elif body.get("status") == "stopped" and utt:
-                                await ws.send_text(_event("speech.completed", {"utterance_id": utt}))
-                                end_speech_span(speech_otel)
-                                speech_otel, utt = None, None
-                        elif etype == "conversation-update":
-                            _trace_server_tools(body, seen_tools)
-                        elif etype == "transcript" and body.get("transcriptType") == "final":
-                            print(
-                                f"chirp transcript [{body.get('role')}] {body.get('transcript')}",
-                                flush=True,
-                            )
-                        elif etype in ("hangup", "end-of-call-report"):
-                            print(f"chirp vapi {etype}", flush=True)
-                            break
-                        elif etype == "status-update" and body.get("status") == "ended":
-                            print(f"chirp vapi ended: {body.get('endedReason')}", flush=True)
-                            break
-                        elif etype == "error":
-                            print(f"chirp vapi error: {body}", flush=True)
-                            break
-                finally:
-                    if utt:
-                        await ws.send_text(_event("speech.completed", {"utterance_id": utt}))
-                        end_speech_span(speech_otel)
-                        speech_otel, utt = None, None
-                    end.set()
-                    with contextlib.suppress(Exception):
-                        await ws.close(1000)
+                async def outbound() -> None:
+                    """Vapi audio + events → chirp pcm, speech.*, agent.speech spans."""
+                    nonlocal utt, speech_otel, audio_out
+                    try:
+                        async for raw in vapi_ws:
+                            if end.is_set():
+                                break
+                            if isinstance(raw, bytes):
+                                audio_out += len(raw)
+                                await ws.send_bytes(raw)
+                                continue
+                            try:
+                                event = json.loads(raw)
+                            except json.JSONDecodeError:
+                                continue
+                            etype = _msg_type(event)
+                            body = _payload(event)
+                            if etype == "speech-update" and body.get("role") == "assistant":
+                                if body.get("status") == "started" and utt is None:
+                                    utt = f"u_{uuid.uuid4().hex[:12]}"
+                                    speech_otel = start_speech_span(utt, speaker="agent")
+                                    await ws.send_text(_event("speech.started", {"utterance_id": utt}))
+                                elif body.get("status") == "stopped" and utt:
+                                    await ws.send_text(_event("speech.completed", {"utterance_id": utt}))
+                                    end_speech_span(speech_otel)
+                                    speech_otel, utt = None, None
+                            elif etype == "conversation-update":
+                                _trace_server_tools(body, seen_tools)
+                            elif etype == "transcript" and body.get("transcriptType") == "final":
+                                print(
+                                    f"chirp transcript [{body.get('role')}] {body.get('transcript')}",
+                                    flush=True,
+                                )
+                            elif etype in ("hangup", "end-of-call-report"):
+                                print(f"chirp vapi {etype}", flush=True)
+                                break
+                            elif etype == "status-update" and body.get("status") == "ended":
+                                print(f"chirp vapi ended: {body.get('endedReason')}", flush=True)
+                                break
+                            elif etype == "error":
+                                print(f"chirp vapi error: {body}", flush=True)
+                                break
+                    finally:
+                        if utt:
+                            await ws.send_text(_event("speech.completed", {"utterance_id": utt}))
+                            end_speech_span(speech_otel)
+                            speech_otel, utt = None, None
+                        end.set()
+                        with contextlib.suppress(Exception):
+                            await ws.close(1000)
 
-            tasks = [asyncio.create_task(inbound()), asyncio.create_task(outbound())]
-            done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-            for t in pending:
-                t.cancel()
-            await asyncio.gather(*pending, return_exceptions=True)
-            print(f"chirp audio in={audio_in}B out={audio_out}B", flush=True)
-            for t in done:
-                exc = None if t.cancelled() else t.exception()
-                if exc is not None and not type(exc).__name__.startswith("ConnectionClosed"):
-                    raise exc
+                tasks = [asyncio.create_task(inbound()), asyncio.create_task(outbound())]
+                done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+                for t in pending:
+                    t.cancel()
+                await asyncio.gather(*pending, return_exceptions=True)
+                print(f"chirp audio in={audio_in}B out={audio_out}B", flush=True)
+                for t in done:
+                    exc = None if t.cancelled() else t.exception()
+                    if exc is not None and not type(exc).__name__.startswith("ConnectionClosed"):
+                        raise exc
+    finally:
+        unbind_provider(provider_id)
+        end_session(session_key)
 
 
 def _trace_server_tools(body: dict, seen: set[str]) -> None:

--- a/voice-agent-harnesses/vapi/harness.py
+++ b/voice-agent-harnesses/vapi/harness.py
@@ -19,10 +19,27 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from pathlib import Path
 from typing import Any
 
 import httpx
+
+for _root in (Path("/app"), *Path(__file__).resolve().parents):
+    _runtime = _root / "runtime"
+    if (_runtime / "call_id.py").is_file():
+        if str(_runtime) not in sys.path:
+            sys.path.insert(0, str(_runtime))
+        break
+from call_id import (  # noqa: E402
+    begin_session,
+    bind_provider,
+    end_session,
+    for_provider,
+    headers as tool_headers,
+    set_call_id,
+    unbind_provider,
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 HARNESS_DIR = Path(__file__).resolve().parent
@@ -333,13 +350,14 @@ async def _execute_tool(
 ) -> dict[str, Any]:
     """Generic dispatch: POST /tools/{name}; the server's envelope is the result.
 
-    The Vapi call id becomes X-Mivas-Call-Id so the state API keeps this call's DB
-    and identity pin separate from every other call in flight.
+    `call_id` is the Bluejay simulation result id, looked up from the Vapi call
+    id on the webhook. Never a Vapi tool-call id.
     """
-    headers = {"X-Mivas-Call-Id": call_id} if call_id else None
     async with httpx.AsyncClient(timeout=30.0) as client:
         resp = await client.post(
-            f"{TOOL_SERVER_URL}/tools/{name}", json={"arguments": args}, headers=headers
+            f"{TOOL_SERVER_URL}/tools/{name}",
+            json={"arguments": args},
+            headers=tool_headers(call_id),
         )
         return resp.json()
 
@@ -364,7 +382,7 @@ async def run_tool(
     from report import finish_tool_span, tool_span
     with tool_span(name, args, call_id=call_id, vapi_call_id=vapi_call_id) as span:
         try:
-            result = await _execute_tool(name, args, vapi_call_id)
+            result = await _execute_tool(name, args, for_provider(vapi_call_id))
             ok = bool(result.get("ok", result.get("success", True)))
             finish_tool_span(span, result, ok=ok)
             return result


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Isolates state per call and splits tool servers from harness pods so agents can scale safely. Previously all calls shared one SQLite file inside the harness Deployment; now each call uses its own DB keyed by the Bluejay simulation result id, tool servers run in a dedicated Deployment/Service, and harness replicas avoid WebSocket drops.

- Per-call DBs via `runtime/db_service.py`: tool POSTs require `X-Mivas-Call-Id` (Bluejay `X-Simulation-Result-Id`); first touch copies `schema.sql` and `seed.sql` into `calls/{id}.db`; `GET /state` takes `?call_id=`; `GET /snapshot/{id}` exposes the final dump.
- Separate tools Deployment/Service/Ingress: adds `k8s/deployment-tools.yaml`, `k8s/service-tools.yaml`, and `k8s/ingress-tools.yaml`; `k8s/ingress.yaml` routes `/tools`, `/state`, `/snapshot`, `/health` to the tools Service; harness pods call `TOOL_SERVER_URL=http://mivas-__SLUG__-tools:8000`.
- Harness replicas enabled: `k8s/deployment.yaml` uses `replicas: __REPLICAS__` and a rolling update strategy (`maxUnavailable: 0`) to protect in-flight WebSockets; `MIVAS_REPLICAS` controls scale in `run.py`.
- Call-id plumbing via `runtime/call_id.py`: binds platform provider ids to the simulation id so webhooks can resolve and forward `X-Mivas-Call-Id`; harness bridges set the id on WS accept and include headers in all tool POSTs.
- Health and teardown: `runtime/harness_health.py` serves `/health` on harness pods; `runtime/snapshot.py` captures final state at teardown; `runtime/entrypoint.sh` supports `MIVAS_ROLE=tools|harness|combined`.
- Industries now import `DBService` and drop ad hoc SQLite; READMEs document `X-Mivas-Call-Id` and `?call_id=`; tests assert DB isolation, header propagation, snapshot capture, and YAML rendering.

**Migration**
- Always send `X-Mivas-Call-Id` on `POST {TOOL_SERVER_URL}/tools/{name}` and use `?call_id=` on `GET /state` and domain routes; missing header returns 400 on tools.
- Set `TOOL_SERVER_URL` to `http://mivas-<slug>-tools:8000` on harness pods. Configure `MIVAS_REPLICAS` for expected concurrency; proven pairs may use `3`.
- Re-apply with `run.py --apply` to create tools Deployments/Services and updated Ingress. Worker families use the tools-only public host from `k8s/ingress-tools.yaml`.
- Update Twilio references to `voice-agent-harnesses/twilio/adapters/conversationrelay.py` (renamed from `adapters/chirp.py`).

<sup>Written for commit 8676ea643388de66daf6f47365e402a567d3044c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/14?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

