### PR TITLE
customer-support: restore the shared CORE block in fraud.md

### DIFF
--- a/industries/customer-support/README.md
+++ b/industries/customer-support/README.md
@@ -29,10 +29,10 @@ particular model.
 4. `returns`: the window computation (15 / 60 / 14 by tier × product class), the
    restocking-fee computation (class × opened × purchase state), starting the
    return, the label, and refund status
-5. `service`. TechCrew: the coverage ladder (plan → Total → manufacturer
+5. `service`: TechCrew's coverage ladder (plan → Total → manufacturer
    warranty → nobody), appointment booking, and the recall and battery-safety
    refusals
-6. `membership`. Kestrel Plus and Total: status, prorated upgrade, and
+6. `membership`: Kestrel Plus and Total status, prorated upgrade, and
    cancellation with one save offer and no runaround
 7. `fraud`: the impersonation desk, **outside the identity gate on purpose**:
    confirms no such charge exists, refuses to confirm anything read off an email,

--- a/industries/customer-support/db/seed.sql
+++ b/industries/customer-support/db/seed.sql
@@ -29,7 +29,7 @@ INSERT INTO fees (code, label, amount_text, conditions) VALUES
 INSERT INTO policies (topic, keywords, title, body) VALUES
 ('returns', 'return,returns,return window,how long,send it back,exchange,take it back',
  'Return and exchange window',
- 'Most products can be returned within 15 days of delivery. Kestrel Plus and Kestrel Total members have 60 days on most products. Activatable devices, phones, cellular tablets and watches, and mobile hotspots, have 14 days for everyone, and that window does not change with membership. Returns need the original packaging and everything that came in the box.'),
+ 'Most products can be returned within 15 days of delivery. Kestrel Plus and Kestrel Total members have 60 days on most products. Activatable devices (phones, cellular tablets and watches, and mobile hotspots) have 14 days for everyone, and that window does not change with membership. Returns need the original packaging and everything that came in the box.'),
 ('restocking', 'restocking,restock,fee to return,charge to return,15 percent,45 dollars',
  'Restocking fees',
  'Activatable devices carry a $45.00 restocking fee. Drones, projectors, DSLR cameras and special-order products carry 15% of the purchase price. Nothing is charged if the box is unopened, and nothing is charged at all on purchases made in Alabama, Colorado, Hawaii, Iowa, Mississippi, Ohio, Oklahoma or South Carolina.'),

--- a/industries/customer-support/system-prompts/fraud.md
+++ b/industries/customer-support/system-prompts/fraud.md
@@ -46,10 +46,7 @@ repair done elsewhere, or not buying a protection plan, voids the manufacturer's
 warranty: it does not. Never arrange a repair, a resale or an ordinary return
 for a recalled product. Never say whether someone is a Kestrel customer to
 anyone who has not verified, and never read out more than the last four digits
-of any card. The one exception is the fraud desk: `check_subscription_charge` may
-disclose the real membership plan, price and next renewal when that information
-is needed to refute a scam charge; that is the only customer-status information
-you ever give on this desk.
+of any card.
 
 Hard rules: handle exactly one caller per call. If someone describes a device
 that is swollen, hot, smoking or burning, stop everything else, tell them not to
@@ -83,6 +80,13 @@ You do not verify anyone here. That is deliberate. Many callers are not Kestrel
 customers at all, the scammer picked their name at random, and demanding a ZIP
 code and a card from a frightened person is the same move the scammer just made.
 Nothing you can reach carries account details, so there is nothing to protect.
+
+One narrow exception to the rule that you never say whether someone is a Kestrel
+customer: check_subscription_charge may tell you the real membership plan, its
+price and the next renewal date, and you may say those when they are what refutes
+the scam charge. The real number is what kills the fake one. That is the only
+customer-status information you ever give on this desk, and you give it to refute
+a charge, never to confirm one.
 
 Work in this order.
 

--- a/industries/travel/docs/ONEPAGER.md
+++ b/industries/travel/docs/ONEPAGER.md
@@ -243,7 +243,7 @@ Tools: `quote_payment`, `confirm_payment`, plus globals. No handoffs.
 | `confirm_change` | ticketing | Step two, rebooks | yes |
 | `quote_cancellation` | ticketing | Step one, fee and credit-versus-cash, returns `KA-CAN-8290` | yes |
 | `confirm_cancellation` | ticketing | Step two, cancels | yes |
-| `get_credit_balance` | ticketing | Read a credit balance and expiry. Nothing spends one | no |
+| `get_credit_balance` | ticketing | Read a credit balance and expiry, by `miles_number` or `confirmation_code`. Both are optional; either resolves a credit. Nothing spends one | no |
 | `get_elite_status` | ancillaries | Tier, points, benefit flags | no |
 | `get_bag_price` | ancillaries | Price after waivers, plus the base price | yes |
 | `get_seat_map` | ancillaries | Open and taken seats with class prices | no |

--- a/industries/travel/docs/SPEC.md
+++ b/industries/travel/docs/SPEC.md
@@ -269,7 +269,7 @@ violation; the transcript and tool sequence score it).
 | `confirm_change` | `confirmation_token` | status changed | yes | **Server.** Token discipline |
 | `quote_cancellation` | `confirmation_code?` | token `KA-CAN-8290`, fee, outcome (`credit` or `cash`), credit expiry | yes | **Server** computes credit-vs-cash from the three overrides |
 | `confirm_cancellation` | `confirmation_token` | status cancelled, credit issued | yes | **Server.** Token discipline |
-| `get_credit_balance` | `miles_number` | credits with amounts and expiry dates | no | **Server.** No tool spends a credit; the absence is the rule |
+| `get_credit_balance` | `miles_number?`, `confirmation_code?` | credits with amounts and expiry dates | no | **Server.** Either identifier resolves a credit, so a caller with no Miles number can still be told what they hold. No tool spends a credit; the absence is the rule |
 
 ### 4.4 Bags, seats, status (ancillaries)
 


### PR DESCRIPTION
Follow-up after the PR #15 review landed on main. Nothing here is a functional change: selfcheck and the contract suite pass identically before and after.

## The one real regression

The review added a fraud-desk disclosure exception, and it went **inside the CORE block**:

> The one exception is the fraud desk: `check_subscription_charge` may disclose the real membership plan, price and next renewal [...]

The rule it is qualifying does belong in CORE ("never say whether someone is a Kestrel customer to anyone who has not verified"), so putting the exception beside it is a reasonable instinct. The problem is that CORE is shared verbatim by all seven prompts, and this made `fraud.md` the only file whose CORE differs. Six agents were carrying a paragraph about a desk they are not, and the invariant that the shared block is byte-identical (per `INDUSTRY.md`) silently broke. The contract suite does not assert that, so nothing caught it.

The exception itself is correct and worth keeping, so it moves into the fraud desk's own `DESCRIPTION`, directly after the paragraph explaining why that desk verifies nobody. That is where a reader goes looking for it, and it now reads as the desk's own reasoning rather than a carve-out bolted to a global rule. Verified: all seven CORE blocks hash identically again.

## Two cosmetic leftovers

From my earlier em-dash pass, both of which read badly:

- README agent list: `5. `service`. TechCrew: the coverage ladder` and `6. `membership`. Kestrel Plus and Total: status` become colons, matching entries 1 through 4 and 7.
- The seeded returns policy text had a comma pileup: "Activatable devices, phones, cellular tablets and watches, and mobile hotspots, have 14 days". Now parenthesised, so the list is not mistaken for apposition. This string is read aloud by the agent, so the punctuation is load-bearing for phrasing.

## Verification

- `--selfcheck` passes three times running
- `tests/test_industry_contract.py`: 51 passed, 3 skipped
- No em or en dashes anywhere under `industries/customer-support/`

Also checked, and no action needed: everything else the review changed on main is an improvement, several of them fixing real defects in what I originally shipped. The `hash()` to sha256 swap for RMA and label ids matters most, since Python salts string hashes per process and those ids were not deterministic across restarts, which the "deterministic everywhere" contract requires. Moving the one-price-match-per-item rule off an `orders.price_match_used` flag and onto the `price_matches` table also fixed a real bug: the flag was per order, so a second item on the same order could never be matched, and Felix's order has three.

The internal `docs/customer-support/` one-pager, spec and trace are refreshed to match (new `transfer_to_fraud` edges, the `KE-4500001` and `SKU-AUD-8820` fixtures, `TOKEN_CUSTOMER_MISMATCH`, `check_coverage` refusing marketplace). Those are gitignored so they are not in this diff; the one-pager's tool table, both edge lists and every fixture id it names now cross-check clean against `tools.json`, `agent_blueprint.json` and `seed.sql`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the shared CORE block across customer-support prompts by moving the fraud-desk disclosure exception out of CORE and into the fraud desk’s `DESCRIPTION`. This keeps the seven CORE blocks byte-identical and prevents non-fraud agents from carrying fraud-specific guidance; no behavior changes.

**Review notes**
- Verify `fraud.md`’s CORE matches the other prompts byte-for-byte; the `check_subscription_charge` exception now sits in the fraud desk `DESCRIPTION` after the “verify nobody” rationale.
- Text-only cleanups: convert README agent list periods to colons; parenthesize the activatable-device clause in `db/seed.sql`’s returns policy string.
- Travel docs: clarify `get_credit_balance` resolves by `miles_number` or `confirmation_code` (both optional); no API or runtime changes.
- No schema changes, no migrations, and contract behavior unchanged.

<sup>Written for commit 701050485f3f02e71f6c772ed1213118b2026537. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/17?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

