### PR TITLE
db_service: scope(fresh=True) so a selfcheck cannot inherit its own leftovers

### DIFF
--- a/industries/customer-support/tool_server.py
+++ b/industries/customer-support/tool_server.py
@@ -1508,11 +1508,8 @@ def dispatch_tool(tool_name: str, body: ToolCall) -> dict[str, Any]:
 # ------------------------------------------------------------------ selfcheck
 
 def selfcheck() -> None:
-    # DBService.ensure() reuses an existing db/calls/<id>.db, so a second run would
-    # inherit the rows this check mutates (delivery_date) and fail on assertions
-    # that passed the first time. Drop it so "fresh DB" is literal.
-    (db.calls_dir / "selfcheck.db").unlink(missing_ok=True)
-    with db.scope("selfcheck"):
+    """Every server-enforced guard, asserted against a fresh DB."""
+    with db.scope("selfcheck", fresh=True):
         _selfcheck()
 
 

--- a/industries/finance/tool_server.py
+++ b/industries/finance/tool_server.py
@@ -1053,7 +1053,7 @@ def dispatch_tool(tool_name: str, body: ToolCall) -> dict[str, Any]:
 
 def selfcheck() -> None:
     """Every server-enforced guard, asserted against a fresh DB."""
-    with db.scope("selfcheck"):
+    with db.scope("selfcheck", fresh=True):
         _selfcheck()
 
 

--- a/industries/legal/tool_server.py
+++ b/industries/legal/tool_server.py
@@ -602,7 +602,7 @@ def dispatch_tool(tool_name: str, body: ToolCall) -> dict[str, Any]:
 
 def selfcheck() -> None:
     """Every trap the port had to preserve, asserted against a fresh DB."""
-    with db.scope("selfcheck"):
+    with db.scope("selfcheck", fresh=True):
         _selfcheck()
 
 

--- a/industries/travel/tool_server.py
+++ b/industries/travel/tool_server.py
@@ -1391,7 +1391,8 @@ def dispatch_tool(tool_name: str, body: ToolCall) -> dict[str, Any]:
 # ------------------------------------------------------------------ selfcheck
 
 def selfcheck() -> None:
-    with db.scope("selfcheck"):
+    """Every trap the fare ladder turns on, asserted against a fresh DB."""
+    with db.scope("selfcheck", fresh=True):
         _selfcheck()
 
 

--- a/runtime/db_service.py
+++ b/runtime/db_service.py
@@ -3,6 +3,11 @@
 Handlers keep `with db.connect() as conn: conn.execute(...)`. This module is
 the only place that chooses a file: first touch of a call id copies schema.sql
 then seed.sql into `{data_dir}/calls/{id}.db`; later touches reuse it.
+
+Reuse is what a real call wants (many HTTP requests, one call id, one evolving
+DB). A repeatable check wants the opposite, so it says so at the call site:
+`with db.scope("selfcheck", fresh=True):` rebuilds the fixture from schema+seed
+before yielding.
 """
 
 from __future__ import annotations
@@ -80,9 +85,28 @@ class DBService:
             _write_fixture_db(path, self.schema_path, self.seed_path)
         return path
 
+    def _recreate(self, path: Path) -> Path:
+        """Replace path with a pristine fixture DB, atomically."""
+        with self._create_lock:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            # pid-unique so concurrent processes never share a half-built file;
+            # threads are serialised by _create_lock.
+            tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+            _unlink_db(tmp)
+            _write_fixture_db(tmp, self.schema_path, self.seed_path)
+            # Drop the old -wal/-shm first: a stale journal beside a new main
+            # file is the one combination sqlite would try to replay.
+            for suffix in ("-wal", "-shm"):
+                path.with_name(path.name + suffix).unlink(missing_ok=True)
+            os.replace(tmp, path)
+        return path
+
     @contextmanager
-    def scope(self, call_id: str) -> Iterator[str]:
+    def scope(self, call_id: str, *, fresh: bool = False) -> Iterator[str]:
+        """Bind call_id for this context. fresh=True rebuilds its fixture DB first."""
         safe = _normalise_call_id(call_id)
+        if fresh:
+            self._recreate(self.calls_dir / f"{safe}.db")
         token = _call_id.set(safe)
         try:
             yield safe
@@ -233,6 +257,12 @@ def _normalise_call_id(raw: str | None) -> str:
     if not _CALL_ID_OK.fullmatch(value):
         raise CallIdError(f"invalid call id {raw!r}")
     return value
+
+
+def _unlink_db(path: Path) -> None:
+    """Remove a sqlite file and its -wal/-shm sidecars."""
+    for p in (path, path.with_name(path.name + "-wal"), path.with_name(path.name + "-shm")):
+        p.unlink(missing_ok=True)
 
 
 def _write_fixture_db(path: Path, schema_path: Path, seed_path: Path) -> None:

--- a/tests/test_db_service.py
+++ b/tests/test_db_service.py
@@ -68,6 +68,42 @@ def test_second_ensure_does_not_reseed(db: DBService) -> None:
     assert names == ["seeded", "written"]
 
 
+def _names(db: DBService, call_id: str) -> list[str]:
+    with db.connect(call_id) as conn:
+        return [r[0] for r in conn.execute("SELECT name FROM items ORDER BY id")]
+
+
+def test_scope_fresh_rebuilds_fixture(db: DBService) -> None:
+    """A repeatable check must not inherit the previous run's mutations."""
+    with db.scope("selfcheck", fresh=True):
+        with db.connect() as conn:
+            conn.execute("UPDATE items SET name = 'mutated' WHERE name = 'seeded'")
+    assert _names(db, "selfcheck") == ["mutated"]
+    with db.scope("selfcheck", fresh=True):
+        assert _names(db, "selfcheck") == ["seeded"]
+
+
+def test_scope_fresh_clears_wal_sidecars(db: DBService) -> None:
+    path = db.ensure("selfcheck")
+    with db.connect("selfcheck") as conn:
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("INSERT INTO items (name) VALUES ('written')")
+    with db.scope("selfcheck", fresh=True):
+        assert _names(db, "selfcheck") == ["seeded"]
+    assert not path.with_name(path.name + "-wal").exists()
+    assert not path.with_name(path.name + "-shm").exists()
+    assert not list(path.parent.glob("*.tmp"))
+
+
+def test_scope_without_fresh_keeps_state(db: DBService) -> None:
+    """Real calls reuse their DB across requests — that must not change."""
+    with db.scope("675"):
+        with db.connect() as conn:
+            conn.execute("INSERT INTO items (name) VALUES ('written')")
+    with db.scope("675"):
+        assert _names(db, "675") == ["seeded", "written"]
+
+
 def test_distinct_ids_are_isolated(db: DBService) -> None:
     a = db.ensure("675")
     b = db.ensure("676")

--- a/tests/test_industry_contract.py
+++ b/tests/test_industry_contract.py
@@ -172,6 +172,8 @@ def test_dispatch_parity_both_directions(industry: str) -> None:
 
 @industry
 def test_selfcheck_passes(industry: str) -> None:
+    """Twice against the SAME MIVAS_DB_PATH: a selfcheck that mutates seeded rows
+    must not inherit its own leftovers from the previous run."""
     if "selfcheck" in _gaps(industry):
         pytest.skip(f"{industry} has no --selfcheck yet (KNOWN_GAPS)")
     with tempfile.TemporaryDirectory() as tmp:
@@ -181,11 +183,12 @@ def test_selfcheck_passes(industry: str) -> None:
             "PYTHONPATH": str(ROOT / "runtime")
             + (os.pathsep + os.environ["PYTHONPATH"] if os.environ.get("PYTHONPATH") else ""),
         }
-        proc = subprocess.run(
-            [sys.executable, str(INDUSTRY_ROOT / industry / "tool_server.py"),
-             "--selfcheck"],
-            capture_output=True, text=True, env=env, timeout=120)
-    assert proc.returncode == 0, proc.stdout + proc.stderr
+        for run in (1, 2):
+            proc = subprocess.run(
+                [sys.executable, str(INDUSTRY_ROOT / industry / "tool_server.py"),
+                 "--selfcheck"],
+                capture_output=True, text=True, env=env, timeout=120)
+            assert proc.returncode == 0, f"run {run}: " + proc.stdout + proc.stderr
 
 
 @industry


### PR DESCRIPTION
Fixes a defect that made every industry's `--selfcheck` pass once and then fail forever, with an assertion error that reads like a content bug and is really stale fixture state.

## The defect

`DBService` gives each call its own SQLite fixture database built from `schema.sql` + `seed.sql`. `ensure()` returns an existing `db/calls/<id>.db` untouched:

```python
def ensure(self, call_id: str) -> Path:
    path = self.calls_dir / f"{_normalise_call_id(call_id)}.db"
    if path.exists():
        return path
    ...
```

For a real call that is exactly right and must not change: one call makes many tool calls across many HTTP requests sharing one `X-Mivas-Call-Id`, and they all need the same evolving database.

Every selfcheck, though, runs inside `db.scope("selfcheck")`, which resolves to `db/calls/selfcheck.db`. So the second and every later run inherits whatever the first run wrote to *seeded reference rows*. `customer-support` mutates `orders.delivery_date`, and its second run died on an assertion the first had just passed. `finance`, `travel` and `legal` happen not to mutate seeded rows today, so they were one assertion away from the same trap.

The shared suite never caught it, because `test_selfcheck_passes` points `MIVAS_DB_PATH` at a fresh temp directory each time and so only ever exercised a first run. The bug only shows up the way a person actually runs it: the command every README documents, twice, against the industry's own `db/`.

## The fix

One kwarg: `DBService.scope(call_id, *, fresh: bool = False)`.

A `reset(call_id)` method was the obvious alternative and is worse. Every selfcheck already declares its scope in one line, so folding the flag into that line means the intent is stated at the only place that could state it, and it cannot be ordered wrongly or forgotten. A separate imperative call that has to happen *before* the scope is precisely the shape of the workaround being deleted here.

`ensure()` is untouched, so real-call reuse is unchanged. `fresh` defaults off, so an industry that copies the line gets the guarantee and one that forgets it gets today's behaviour rather than silent corruption.

Recreation is atomic: build into `<name>.db.<pid>.tmp`, drop the target's stale `-wal`/`-shm`, then `os.replace`. `os.replace` is atomic so no reader sees a half-seeded schema; pid-unique temp names mean two processes never share a build file; threads stay serialised by the existing `_create_lock`. Sidecars go *before* the replace, since a new main file beside an old journal is the one combination sqlite would try to replay.

All four industries with a selfcheck now pass `fresh=True`, and `customer-support`'s hand-rolled `selfcheck.db` unlink is deleted in favour of it.

## Verification

Three consecutive `--selfcheck` runs per industry, against each industry's own real `db/` directory rather than a temp dir:

| industry | run 1 | run 2 | run 3 |
|---|---|---|---|
| finance | rc=0 | rc=0 | rc=0 |
| travel | rc=0 | rc=0 | rc=0 |
| legal | rc=0 | rc=0 | rc=0 |
| customer-support | rc=0 | rc=0 | rc=0 |

No `.tmp` residue left in any `db/calls/`. `tests/test_industry_contract.py` and `tests/test_db_service.py`: 64 passed, 3 skipped.

**The new coverage is not vacuous, verified two ways.** Reverting only `runtime/db_service.py` to `origin/main` and leaving the `fresh=True` call sites: `test_scope_fresh_rebuilds_fixture` and `test_scope_fresh_clears_wal_sidecars` both fail with `TypeError: unexpected keyword argument 'fresh'`, while `test_scope_without_fresh_keeps_state` still passes, which is the point of that third test. And on the real content, with the reuse path restored, the `customer-support` selfcheck gives rc=0 then rc=1 on the exact assertion from the original report; with the fix, rc=0 three times against an already-dirty directory.

`test_selfcheck_passes` now runs `--selfcheck` twice against the same `MIVAS_DB_PATH`, so this class of bug fails in CI from now on instead of only on someone's second manual run.

## Reviewer notes

`tests/test_voicechat_toolcall_channel.py` has 3 failures on this branch. They also fail on pristine `origin/main` with nothing from this branch applied, so they are pre-existing in the NVIDIA voicechat harness and unrelated.

Rebased onto current main after PRs #15 and #16 landed. The travel rewrite reintroduced the unfixed call site over the original change, which is the one conflict, resolved by applying `fresh=True` to the rewritten file.

## Latent issues found and deliberately not fixed

- **`ensure()` and `_ensure_shared()` have a cross-process TOCTOU on a half-built database.** Both fast-path `if path.exists(): return path` *before* taking `_create_lock`, while `_write_fixture_db` creates the file at `sqlite3.connect(path)` and only then runs schema and seed. A second process can observe an existing-but-unseeded file and hand it to a caller. `test_concurrent_ensure_creates_one_file` only covers the in-process case, which the lock does handle. Fixing it needs the temp-then-claim trick used here but with `os.link` (which fails `FileExistsError` rather than clobbering) so a claim can never destroy a live call's data. That is a separate change with its own risk to real-call semantics.
- **`mount_cluster_routes` writes snapshots non-atomically** (`path.write_text(json.dumps(state))`), so a concurrent `GET /snapshot/{call_id}` can read a truncated file and 500. Same temp-plus-`os.replace` shape would close it.
- `for_industry` resolves `data_dir` to the process cwd when `MIVAS_DB_PATH` is a bare filename. Cosmetic footgun.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents selfchecks from inheriting stale SQLite state and failing on subsequent runs. Previously `db.scope("selfcheck")` reused `db/calls/selfcheck.db`; now `db.scope("selfcheck", fresh=True)` rebuilds the fixture before running, while normal calls still reuse their DB.

- Add `fresh` to `DBService.scope`. Rebuild the fixture atomically with a pid-unique temp file and `os.replace`, clearing `-wal`/`-shm` first; guarded by the existing create lock.
- Leave `ensure()` reuse semantics unchanged.
- Update `finance`, `travel`, and `legal` selfchecks to pass `fresh=True`; replace `customer-support`’s manual unlink with the new API.
- Strengthen tests: verify fresh rebuild, WAL sidecar cleanup, and unchanged reuse; run `--selfcheck` twice against the same `MIVAS_DB_PATH`.
- Migration: Selfchecks must call `db.scope("selfcheck", fresh=True)`. No changes required for real-call handlers.

<sup>Written for commit b3b8b0149b24b07ac5f6f8cd73767dbf392927e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/18?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

