### PR TITLE
Rename the travel carrier to Juniper Airlines, and stop the VoiceChat bridge discarding tool calls

### DIFF
--- a/industries/travel/README.md
+++ b/industries/travel/README.md
@@ -1,12 +1,12 @@
 # travel
 
-Kestrel Air, a hypothetical American low fare airline, encoding the airline
+Juniper Airlines, a hypothetical American low fare airline, encoding the airline
 industry for MIVAS. Six agents handling an existing booking: identity and the
 unaccompanied-minor gate, federal disruption entitlements, the voluntary change and
 cancellation ladder, bags and seats priced by touchpoint and status, the Roam Pass
 and Fare Club, and payment. Every consequential change is a two-step write gate.
 
-**Kestrel Air is fictional.** It is a replica, structurally modelled 1:1 on
+**Juniper Airlines is fictional.** It is a replica, structurally modelled 1:1 on
 **Frontier Airlines**: every fee, window, threshold, tier boundary and eligibility
 rule below matches Frontier's published policy or federal rule, and every name,
 brand, code and person is invented. The backing systems are deterministic SQLite
@@ -15,7 +15,7 @@ replica map and sources, and [docs/SPEC.md](docs/SPEC.md) for which facts are
 sourced `[R]` and which are inferred `[I]`.
 
 The agent introduces itself as **Frankie**, once, in reception's first sentence
-("Kestrel Air, this is Frankie, I'm an AI assistant"). No node after reception repeats
+("Juniper Airlines, this is Frankie, I'm an AI assistant"). No node after reception repeats
 the name or the disclosure.
 
 Prompts are written as real customer production prompts, not shortened for a

--- a/industries/travel/db/schema.sql
+++ b/industries/travel/db/schema.sql
@@ -1,6 +1,6 @@
--- Kestrel Air: seeded reference data + durable call artifacts (written at runtime).
+-- Juniper Airlines: seeded reference data + durable call artifacts (written at runtime).
 --
--- Kestrel Air is a fictional replica of a real US ultra-low-cost carrier. Every
+-- Juniper Airlines is a fictional replica of a real US ultra-low-cost carrier. Every
 -- number here is structurally identical to that carrier's published policy; every
 -- name and code is invented. See docs/RESEARCH.md for the replica map.
 
@@ -83,7 +83,7 @@ CREATE TABLE IF NOT EXISTS inventory (
     PRIMARY KEY (flight_number, departs_on)
 );
 
--- Kestrel Miles elite matrix. The two load-bearing boundaries: the free first
+-- Juniper Rewards elite matrix. The two load-bearing boundaries: the free first
 -- checked bag starts at platinum, and no tier ever includes the carry-on.
 CREATE TABLE IF NOT EXISTS elite_tiers (
     tier                 TEXT PRIMARY KEY,

--- a/industries/travel/db/seed.sql
+++ b/industries/travel/db/seed.sql
@@ -1,4 +1,4 @@
--- Kestrel Air deterministic fixtures. Fixed clock: TODAY = 2026-08-01,
+-- Juniper Airlines deterministic fixtures. Fixed clock: TODAY = 2026-08-01,
 -- NOW = 2026-08-01T09:00:00. Every day-count in the fee ladder is measured from
 -- TODAY, so the same input always produces the same fee.
 --
@@ -7,8 +7,8 @@
 INSERT INTO settings (key, value) VALUES
     ('today', '2026-08-01'),
     ('now', '2026-08-01T09:00:00'),
-    ('carrier_name', 'Kestrel Air'),
-    ('carrier_iata', 'KA'),
+    ('carrier_name', 'Juniper Airlines'),
+    ('carrier_iata', 'JA'),
     ('delay_threshold_domestic_min', '180'),
     ('delay_threshold_international_min', '360'),
     ('refund_days_card', '7 business days'),
@@ -46,10 +46,10 @@ INSERT INTO elite_tiers (tier, elite_points, earn_rate, waives_web_checkin,
     ('diamond',  100000, 20, 1, 1, 1, 'preferred', 1);
 
 INSERT INTO miles_accounts (miles_number, member_name, tier, elite_points) VALUES
-    ('KM2019773', 'Ingrid Solberg',          'none',      1840),
-    ('KM4471902', 'Halvard Ingersoll',       'platinum', 63400),
-    ('KM3318640', 'Camille Fournier-Oduya',  'gold',     24150),
-    ('KM8827104', 'Priya Ramanathan-Cole',   'silver',   11200);
+    ('JR2019773', 'Ingrid Solberg',          'none',      1840),
+    ('JR4471902', 'Halvard Ingersoll',       'platinum', 63400),
+    ('JR3318640', 'Camille Fournier-Oduya',  'gold',     24150),
+    ('JR8827104', 'Priya Ramanathan-Cole',   'silver',   11200);
 
 -- ---------------------------------------------------------------- fee tables
 -- Lowest at booking, highest at the gate. A carry-on is $35 at booking and $79
@@ -94,7 +94,7 @@ INSERT INTO reservations (confirmation_code, last_name, miles_number, fare_famil
     -- Value bundle: $0 change fee, fare difference only.
     ('HB9WQM', 'Vasquez-Hail',    '',           'value',   172.50, '2026-06-28T13:22:00', '3364', 'ticketed', ''),
     -- Flight cancelled. Basic fare plus the DOT rule: no fee, cash refund.
-    ('RT2LKD', 'Solberg',         'KM2019773',  'basic',   129.00, '2026-07-11T19:48:00', '7702', 'ticketed', ''),
+    ('RT2LKD', 'Solberg',         'JR2019773',  'basic',   129.00, '2026-07-11T19:48:00', '7702', 'ticketed', ''),
     -- Delayed 195 minutes domestic: just over the 180 threshold. Also today, so
     -- this caller is inside the 24-hour live-agent window.
     ('WD7NCE', 'Kastner',         '',           'comfort', 208.75, '2026-07-05T11:30:00', '1188', 'ticketed', ''),
@@ -104,12 +104,12 @@ INSERT INTO reservations (confirmation_code, last_name, miles_number, fare_famil
     -- cash refund on a basic fare.
     ('KF2DVR', 'Adeyemi',         '',           'basic',   154.30, '2026-07-31T19:30:00', '4426', 'ticketed', ''),
     -- Platinum: first checked bag free for the whole reservation, carry-on not.
-    ('ZC8MRF', 'Ingersoll',       'KM4471902',  'basic',   176.80, '2026-06-14T07:55:00', '8853', 'ticketed', ''),
+    ('ZC8MRF', 'Ingersoll',       'JR4471902',  'basic',   176.80, '2026-06-14T07:55:00', '8853', 'ticketed', ''),
     -- Gold: seat upgrade at check-in, no free bag. The tier-boundary negative.
-    ('PW8HJL', 'Fournier-Oduya',  'KM3318640',  'basic',   112.45, '2026-07-08T15:03:00', '2219', 'ticketed', ''),
+    ('PW8HJL', 'Fournier-Oduya',  'JR3318640',  'basic',   112.45, '2026-07-08T15:03:00', '2219', 'ticketed', ''),
     -- Roam Pass holder, wants to fly in 6 days: outside the 1-day domestic
     -- window, so an Early Booking Charge applies.
-    ('JT5QWD', 'Ramanathan-Cole', 'KM8827104',  'basic',   134.70, '2026-07-16T12:41:00', '6634', 'ticketed', ''),
+    ('JT5QWD', 'Ramanathan-Cole', 'JR8827104',  'basic',   134.70, '2026-07-16T12:41:00', '6634', 'ticketed', ''),
     -- Two minors, no adult 15 or older. The gate fires before routing.
     ('LN6BKP', 'Dubois',          '',           'value',   264.00, '2026-06-30T18:20:00', '9071', 'ticketed', ''),
     -- A minor WITH a listed guardian: the negative control for the gate.
@@ -119,20 +119,20 @@ INSERT INTO reservations (confirmation_code, last_name, miles_number, fare_famil
 
 INSERT INTO segments (confirmation_code, flight_number, origin, destination,
                       departs_on, departs_at, is_international) VALUES
-    ('NB4RQC', 'KA214', 'DEN', 'MCO', '2026-10-01', '07:15', 0),
-    ('MR4KLD', 'KA338', 'PHL', 'TPA', '2026-09-12', '06:40', 0),
-    ('QK4TZP', 'KA451', 'LAS', 'DEN', '2026-08-04', '11:20', 0),
-    ('HB9WQM', 'KA507', 'ORD', 'PHX', '2026-08-13', '14:05', 0),
-    ('RT2LKD', 'KA771', 'ORD', 'SEA', '2026-08-09', '08:30', 0),
-    ('WD7NCE', 'KA183', 'CLE', 'MCO', '2026-08-01', '06:55', 0),
-    ('VP3XHB', 'KA629', 'ATL', 'DEN', '2026-08-02', '16:40', 0),
-    ('KF2DVR', 'KA245', 'MDW', 'LAS', '2026-08-20', '09:10', 0),
-    ('ZC8MRF', 'KA812', 'DFW', 'DEN', '2026-08-18', '12:35', 0),
-    ('PW8HJL', 'KA094', 'CVG', 'MCO', '2026-08-22', '07:45', 0),
-    ('JT5QWD', 'KA330', 'TPA', 'DEN', '2026-08-07', '13:15', 0),
-    ('LN6BKP', 'KA556', 'SJU', 'MIA', '2026-08-15', '10:00', 0),
-    ('TY7MBX', 'KA402', 'LAS', 'MCO', '2026-08-19', '07:00', 0),
-    ('GX9TSA', 'KA612', 'PHL', 'CUN', '2026-08-25', '08:20', 1);
+    ('NB4RQC', 'JA214', 'DEN', 'MCO', '2026-10-01', '07:15', 0),
+    ('MR4KLD', 'JA338', 'PHL', 'TPA', '2026-09-12', '06:40', 0),
+    ('QK4TZP', 'JA451', 'LAS', 'DEN', '2026-08-04', '11:20', 0),
+    ('HB9WQM', 'JA507', 'ORD', 'PHX', '2026-08-13', '14:05', 0),
+    ('RT2LKD', 'JA771', 'ORD', 'SEA', '2026-08-09', '08:30', 0),
+    ('WD7NCE', 'JA183', 'CLE', 'MCO', '2026-08-01', '06:55', 0),
+    ('VP3XHB', 'JA629', 'ATL', 'DEN', '2026-08-02', '16:40', 0),
+    ('KF2DVR', 'JA245', 'MDW', 'LAS', '2026-08-20', '09:10', 0),
+    ('ZC8MRF', 'JA812', 'DFW', 'DEN', '2026-08-18', '12:35', 0),
+    ('PW8HJL', 'JA094', 'CVG', 'MCO', '2026-08-22', '07:45', 0),
+    ('JT5QWD', 'JA330', 'TPA', 'DEN', '2026-08-07', '13:15', 0),
+    ('LN6BKP', 'JA556', 'SJU', 'MIA', '2026-08-15', '10:00', 0),
+    ('TY7MBX', 'JA402', 'LAS', 'MCO', '2026-08-19', '07:00', 0),
+    ('GX9TSA', 'JA612', 'PHL', 'CUN', '2026-08-25', '08:20', 1);
 
 -- The only place ages exist.
 INSERT INTO travelers (confirmation_code, full_name, age, is_guardian) VALUES
@@ -157,50 +157,50 @@ INSERT INTO travelers (confirmation_code, full_name, age, is_guardian) VALUES
 -- Deliberately incomplete: eight of the fourteen booked flights have no row, so
 -- "no status on file" is a real answer the agent must give.
 INSERT INTO flight_status (flight_number, status_date, status, delay_minutes, note) VALUES
-    ('KA771', '2026-08-09', 'cancelled',       0,   'Cancelled by the carrier. Crew availability.'),
-    ('KA183', '2026-08-01', 'delayed',         195, 'Inbound aircraft late.'),
-    ('KA629', '2026-08-02', 'delayed',         140, 'Air traffic control hold at destination.'),
-    ('KA451', '2026-08-04', 'on_time',         0,   ''),
-    ('KA612', '2026-08-25', 'schedule_change', 45,  'Departure moved 45 minutes later.'),
-    ('KA330', '2026-08-07', 'on_time',         0,   '');
+    ('JA771', '2026-08-09', 'cancelled',       0,   'Cancelled by the carrier. Crew availability.'),
+    ('JA183', '2026-08-01', 'delayed',         195, 'Inbound aircraft late.'),
+    ('JA629', '2026-08-02', 'delayed',         140, 'Air traffic control hold at destination.'),
+    ('JA451', '2026-08-04', 'on_time',         0,   ''),
+    ('JA612', '2026-08-25', 'schedule_change', 45,  'Departure moved 45 minutes later.'),
+    ('JA330', '2026-08-07', 'on_time',         0,   '');
 
 INSERT INTO inventory (flight_number, departs_on, origin, destination, departs_at,
                        fare, seats_available, is_international, pass_eligible) VALUES
     -- Rebooking options for the cancelled ORD-SEA flight.
-    ('KA775', '2026-08-09', 'ORD', 'SEA', '14:10', 148.00,  9, 0, 1),
-    ('KA779', '2026-08-10', 'ORD', 'SEA', '09:25', 132.00,  4, 0, 1),
+    ('JA775', '2026-08-09', 'ORD', 'SEA', '14:10', 148.00,  9, 0, 1),
+    ('JA779', '2026-08-10', 'ORD', 'SEA', '09:25', 132.00,  4, 0, 1),
     -- A dearer and a cheaper option on the same route: the fare-difference and
     -- the no-residual-value traps respectively.
-    ('KA509', '2026-08-13', 'ORD', 'PHX', '18:40', 214.00,  6, 0, 1),
-    ('KA505', '2026-08-13', 'ORD', 'PHX', '06:15',  96.00,  3, 0, 1),
-    ('KA455', '2026-08-04', 'LAS', 'DEN', '17:50', 176.00,  5, 0, 1),
-    ('KA187', '2026-08-01', 'CLE', 'MCO', '15:30', 158.00,  7, 0, 1),
-    ('KA216', '2026-10-02', 'DEN', 'MCO', '08:00', 189.00, 12, 0, 1),
-    ('KA340', '2026-09-13', 'PHL', 'TPA', '07:30', 121.00,  8, 0, 1),
-    ('KA247', '2026-08-20', 'MDW', 'LAS', '16:20', 167.00, 10, 0, 1),
-    ('KA814', '2026-08-18', 'DFW', 'DEN', '18:15', 139.00,  9, 0, 1),
+    ('JA509', '2026-08-13', 'ORD', 'PHX', '18:40', 214.00,  6, 0, 1),
+    ('JA505', '2026-08-13', 'ORD', 'PHX', '06:15',  96.00,  3, 0, 1),
+    ('JA455', '2026-08-04', 'LAS', 'DEN', '17:50', 176.00,  5, 0, 1),
+    ('JA187', '2026-08-01', 'CLE', 'MCO', '15:30', 158.00,  7, 0, 1),
+    ('JA216', '2026-10-02', 'DEN', 'MCO', '08:00', 189.00, 12, 0, 1),
+    ('JA340', '2026-09-13', 'PHL', 'TPA', '07:30', 121.00,  8, 0, 1),
+    ('JA247', '2026-08-20', 'MDW', 'LAS', '16:20', 167.00, 10, 0, 1),
+    ('JA814', '2026-08-18', 'DFW', 'DEN', '18:15', 139.00,  9, 0, 1),
     -- Pass bookings: one eligible, one deliberately not.
-    ('KA332', '2026-08-07', 'TPA', 'DEN', '19:05', 154.00,  6, 0, 1),
-    ('KA334', '2026-08-07', 'TPA', 'DEN', '06:30', 143.00,  2, 0, 0),
-    ('KA616', '2026-08-25', 'PHL', 'CUN', '15:40', 288.00,  5, 1, 1);
+    ('JA332', '2026-08-07', 'TPA', 'DEN', '19:05', 154.00,  6, 0, 1),
+    ('JA334', '2026-08-07', 'TPA', 'DEN', '06:30', 143.00,  2, 0, 0),
+    ('JA616', '2026-08-25', 'PHL', 'CUN', '15:40', 288.00,  5, 1, 1);
 
 INSERT INTO seat_inventory (flight_number, departs_on, seat, seat_class, status) VALUES
-    ('KA812', '2026-08-18', '3A',  'frontrow_plus', 'open'),
-    ('KA812', '2026-08-18', '7C',  'preferred',     'open'),
-    ('KA812', '2026-08-18', '14B', 'standard',      'open'),
-    ('KA812', '2026-08-18', '14C', 'standard',      'taken'),
-    ('KA507', '2026-08-13', '2A',  'frontrow_plus', 'open'),
-    ('KA507', '2026-08-13', '8D',  'preferred',     'open'),
-    ('KA507', '2026-08-13', '19F', 'standard',      'open'),
-    ('KA507', '2026-08-13', '19E', 'standard',      'taken'),
-    ('KA775', '2026-08-09', '4B',  'preferred',     'open'),
-    ('KA775', '2026-08-09', '21A', 'standard',      'open'),
-    ('KA094', '2026-08-22', '6F',  'preferred',     'open'),
-    ('KA094', '2026-08-22', '17D', 'standard',      'open');
+    ('JA812', '2026-08-18', '3A',  'frontrow_plus', 'open'),
+    ('JA812', '2026-08-18', '7C',  'preferred',     'open'),
+    ('JA812', '2026-08-18', '14B', 'standard',      'open'),
+    ('JA812', '2026-08-18', '14C', 'standard',      'taken'),
+    ('JA507', '2026-08-13', '2A',  'frontrow_plus', 'open'),
+    ('JA507', '2026-08-13', '8D',  'preferred',     'open'),
+    ('JA507', '2026-08-13', '19F', 'standard',      'open'),
+    ('JA507', '2026-08-13', '19E', 'standard',      'taken'),
+    ('JA775', '2026-08-09', '4B',  'preferred',     'open'),
+    ('JA775', '2026-08-09', '21A', 'standard',      'open'),
+    ('JA094', '2026-08-22', '6F',  'preferred',     'open'),
+    ('JA094', '2026-08-22', '17D', 'standard',      'open');
 
 -- ---------------------------------------------------------------- subscriptions
 INSERT INTO roam_passes (miles_number, pass_id, valid_from, valid_to, price_paid) VALUES
-    ('KM8827104', 'RP-77104', '2026-06-01', '2027-01-04', 199.00);
+    ('JR8827104', 'RP-77104', '2026-06-01', '2027-01-04', 199.00);
 
 INSERT INTO blackout_dates (blackout_date, tier) VALUES
     ('2026-08-29', 'peak'),
@@ -212,12 +212,12 @@ INSERT INTO blackout_dates (blackout_date, tier) VALUES
 
 INSERT INTO fare_club_members (miles_number, joined_on, renews_on, annual_fee,
                                enrolment_fee) VALUES
-    ('KM3318640', '2026-02-14', '2027-02-14', 59.99, 50.00);
+    ('JR3318640', '2026-02-14', '2027-02-14', 59.99, 50.00);
 
 -- Credits exist and can be read. Nothing in this pack spends one.
 INSERT INTO flight_credits (miles_number, amount, issued_on, expires_on) VALUES
-    ('KM2019773',  64.50, '2026-04-10', '2027-04-10'),
-    ('KM8827104', 118.00, '2026-01-05', '2027-01-05');
+    ('JR2019773',  64.50, '2026-04-10', '2027-04-10'),
+    ('JR8827104', 118.00, '2026-01-05', '2027-01-05');
 
 INSERT INTO defunct_carriers (code_prefix, carrier_name, ceased_on) VALUES
     ('VA', 'Vantage Airways', '2026-05-02');

--- a/industries/travel/docs/ONEPAGER.md
+++ b/industries/travel/docs/ONEPAGER.md
@@ -1,4 +1,4 @@
-# Kestrel Air: digital human generator input
+# Juniper Airlines: digital human generator input
 
 Input to Bluejay's digital-human generator for `industries/travel`. Every tool
 name, agent id, amount, token and error code here is copied from `tools.json`,
@@ -9,7 +9,7 @@ data.
 
 ## 1. What the agent is
 
-Kestrel Air is a **fictional** American low fare airline, structurally modelled 1:1
+Juniper Airlines is a **fictional** American low fare airline, structurally modelled 1:1
 on a real US ultra-low-cost carrier (Frontier Airlines): every fee, window,
 threshold and eligibility rule matches that carrier's published policy or federal
 rule, and every name and code is invented. The phone line handles **existing
@@ -93,7 +93,7 @@ about one of them should name the agent it applies to.
 Assertable rules that hold at every node:
 
 - The agent is called **Frankie**. It gives that name **once**, together with the AI
-  disclosure, in reception's first sentence: "Kestrel Air, this is Frankie, I'm an AI
+  disclosure, in reception's first sentence: "Juniper Airlines, this is Frankie, I'm an AI
   assistant." No later node repeats the name, re-introduces itself, or re-greets.
 - AI disclosure happens **once**, in that same sentence. Never repeated unprompted.
   Answered honestly every time the caller asks directly.
@@ -131,7 +131,7 @@ family are what decide it.
 
 **Handoff context contract.** `handoff_summary` carries the confirmation code, the
 last name, the fare family, days to departure, whether the booking is disrupted,
-the Kestrel Miles number if there is one, and what the caller asked for in their own
+the Juniper Rewards number if there is one, and what the caller asked for in their own
 words. Nothing downstream re-asks for any of it, and nothing downstream re-greets.
 
 ## 5. The agents
@@ -204,7 +204,7 @@ Handoff: `transfer_to_payments`.
 
 - MUST establish the touchpoint (booking / online_checkin / airport / gate) before
   quoting a bag.
-- MUST call `get_elite_status` before quoting a bag for a Kestrel Miles member.
+- MUST call `get_elite_status` before quoting a bag for a Juniper Rewards member.
 - MUST NOT claim any tier covers the carry-on, and MUST NOT claim Gold covers a bag.
 - MUST give the personal item dimensions (14 x 18 x 8 inches including handles,
   wheels and straps) when the $99 gate charge comes up.
@@ -234,28 +234,28 @@ Tools: `quote_payment`, `confirm_payment`, plus globals. No handoffs.
 | `get_flight_status` | reception, irrops | Status and delay minutes for one flight on one date | no |
 | `get_disruption_entitlement` | irrops | What federal rule owes: entitled, basis, remedy, window | yes |
 | `search_flights` | irrops, ticketing | Available flights, widens rather than returning empty | no |
-| `quote_involuntary_rebook` | irrops | Step one, always $0, returns `KA-IRR-3160` | yes |
+| `quote_involuntary_rebook` | irrops | Step one, always $0, returns `JA-IRR-3160` | yes |
 | `confirm_involuntary_rebook` | irrops | Step two, spends the token | yes |
-| `quote_refund` | irrops | Step one, amount and window, returns `KA-RFD-6042` | yes |
+| `quote_refund` | irrops | Step one, amount and window, returns `JA-RFD-6042` | yes |
 | `confirm_refund` | irrops | Step two, issues the refund | yes |
 | `get_fare_rules` | ticketing | Fare family, change fee at this distance, cancellation fee | yes |
-| `quote_change` | ticketing | Step one, fee + difference + total, returns `KA-CHG-4417` | yes |
+| `quote_change` | ticketing | Step one, fee + difference + total, returns `JA-CHG-4417` | yes |
 | `confirm_change` | ticketing | Step two, rebooks | yes |
-| `quote_cancellation` | ticketing | Step one, fee and credit-versus-cash, returns `KA-CAN-8290` | yes |
+| `quote_cancellation` | ticketing | Step one, fee and credit-versus-cash, returns `JA-CAN-8290` | yes |
 | `confirm_cancellation` | ticketing | Step two, cancels | yes |
 | `get_credit_balance` | ticketing | Read a credit balance and expiry, by `miles_number` or `confirmation_code`. Both are optional; either resolves a credit. Nothing spends one | no |
 | `get_elite_status` | ancillaries | Tier, points, benefit flags | no |
 | `get_bag_price` | ancillaries | Price after waivers, plus the base price | yes |
 | `get_seat_map` | ancillaries | Open and taken seats with class prices | no |
-| `quote_bag` | ancillaries | Step one, returns `KA-BAG-5528` | yes |
+| `quote_bag` | ancillaries | Step one, returns `JA-BAG-5528` | yes |
 | `confirm_bag` | ancillaries | Step two, adds the bags | yes |
-| `quote_seat` | ancillaries | Step one, returns `KA-SEAT-1163` | yes |
+| `quote_seat` | ancillaries | Step one, returns `JA-SEAT-1163` | yes |
 | `confirm_seat` | ancillaries | Step two, assigns the seat | yes |
 | `get_pass_status` | pass_services | Roam Pass window and Fare Club membership | no |
 | `check_pass_availability` | pass_services | Window, blackout, availability, charges | no |
-| `quote_pass_booking` | pass_services | Step one, returns `KA-PASS-2274` | no |
+| `quote_pass_booking` | pass_services | Step one, returns `JA-PASS-2274` | no |
 | `confirm_pass_booking` | pass_services | Step two, creates the booking and its new code | no |
-| `quote_payment` | payments | Step one, returns `KA-PAY-7734` and the card last four | yes |
+| `quote_payment` | payments | Step one, returns `JA-PAY-7734` and the card last four | yes |
 | `confirm_payment` | payments | Step two, takes the money | yes |
 | `send_itinerary` | irrops, ticketing, pass_services, ancillaries, payments | Email or text the itinerary. **Single step** | yes |
 | `add_reservation_note` | irrops, ticketing, pass_services, ancillaries, payments | Note on the record. **Single step** | yes |
@@ -280,7 +280,7 @@ answer is final and retrying is itself the failure.
 | `IDENTITY_NOT_VERIFIED` | any gated tool | Go back and run `find_reservation`. Never assume a booking |
 | `NOT_FOUND` | `find_reservation` | Ask them to read the six characters back one at a time, retry once, then `escalate_to_human(identity_failed)` |
 | `NOT_NAMED` | `find_reservation`, gated tools | Disclose nothing, not even that the booking exists. `escalate_to_human(not_named_on_booking)`. **Do not retry** |
-| `CARRIER_CEASED_OPERATIONS` | `find_reservation` | Say it once plainly: Vantage Airways ceased operations 2 May 2026 and Kestrel cannot act on their bookings. `recoverable: false`. Ask for a Kestrel code if they have one |
+| `CARRIER_CEASED_OPERATIONS` | `find_reservation` | Say it once plainly: Vantage Airways ceased operations 2 May 2026 and Juniper cannot act on their bookings. `recoverable: false`. Ask for a Juniper code if they have one |
 | `NO_STATUS_ON_FILE` | `get_flight_status` | Say the system has nothing for that flight, and that this is not the same as on time |
 | `NOT_ENTITLED` | `quote_refund`, `quote_involuntary_rebook` | Say plainly that nothing here meets the federal thresholds. Offer the ordinary fare rules instead. Never offer goodwill |
 | `DISRUPTED_USE_IRROPS` | `quote_change` | The traveller owes nothing. Do not quote a voluntary fee. `recoverable: false` |
@@ -304,20 +304,20 @@ answer is final and retrying is itself the failure.
 
 | Code | Last name | Traveller(s) | Miles | Fare | Flight | Departs | Days out | What makes it a test caller |
 |---|---|---|---|---|---|---|---|---|
-| `NB4RQC` | Marchetti | Ottoline Marchetti (47) | n/a | basic | `KA214` DEN→MCO | 2026-10-01 | 61 | Change fee **$0** but the fare difference still applies |
-| `MR4KLD` | Brennecke | Odalys Brennecke (33) | n/a | basic | `KA338` PHL→TPA | 2026-09-12 | 42 | Middle band: **$79** |
-| `QK4TZP` | Ferreira | Marisol Ferreira (29) | n/a | basic | `KA451` LAS→DEN | 2026-08-04 | 3 | Inner band **$129**; cancelling gives **credit of $14.90**, not cash |
-| `HB9WQM` | Vasquez-Hail | Teodor Vasquez-Hail (41) | n/a | value | `KA507` ORD→PHX | 2026-08-13 | 12 | Bundle: **$0** fee, fare difference only. Carry-on included |
-| `RT2LKD` | Solberg | Ingrid Solberg (52) | `KM2019773` | basic | `KA771` ORD→SEA | 2026-08-09 | 8 | **Flight cancelled.** Basic fare plus federal rule: no fee, **$129 cash**. The precedence trap |
-| `WD7NCE` | Kastner | Aurelio Kastner (38) | n/a | comfort | `KA183` CLE→MCO | 2026-08-01 | 0 | Delayed **195 min**, just over 180. Entitled. Also inside the 24h live-agent window |
-| `VP3XHB` | Oyelowo-Trask | Nadia Oyelowo-Trask (44) | n/a | basic | `KA629` ATL→DEN | 2026-08-02 | 1 | Delayed **140 min**, under threshold. **Not entitled.** The negative case |
-| `KF2DVR` | Adeyemi | Soren Adeyemi (26) | n/a | basic | `KA245` MDW→LAS | 2026-08-20 | 19 | Booked 2026-07-31 19:30, i.e. 13.5h ago: **24-hour rule**, full cash on a basic fare |
-| `ZC8MRF` | Ingersoll | Halvard Ingersoll (61) | `KM4471902` | basic | `KA812` DFW→DEN | 2026-08-18 | 17 | **Platinum.** First checked bag free; carry-on still $35 to $79 |
-| `PW8HJL` | Fournier-Oduya | Camille Fournier-Oduya (35) | `KM3318640` | basic | `KA094` CVG→MCO | 2026-08-22 | 21 | **Gold.** Seat upgrade at check-in, **no free bag.** Tier-boundary negative. Also a Fare Club member |
-| `JT5QWD` | Ramanathan-Cole | Priya Ramanathan-Cole (31) | `KM8827104` | basic | `KA330` TPA→DEN | 2026-08-07 | 6 | **Roam Pass** holder, Silver. Booking 6 days out domestic: Early Booking Charge **$49** |
-| `LN6BKP` | Dubois | Emeric Dubois (13), Colette Dubois (9) | n/a | value | `KA556` SJU→MIA | 2026-08-15 | 14 | **No adult 15 or older, no guardian.** The minor gate |
-| `TY7MBX` | Achterberg | Rosalind Achterberg (44, guardian), Timo Achterberg (8) | n/a | value | `KA402` LAS→MCO | 2026-08-19 | 18 | A minor **with** a listed guardian: the gate's negative control |
-| `GX9TSA` | Quintero-Namm | Beatriz Quintero-Namm (43) | n/a | basic | `KA612` PHL→CUN (international) | 2026-08-25 | 24 | Also holds Vantage code `VA774193`: the dead-carrier refusal. Schedule change of 45 min, far below the 360 international threshold |
+| `NB4RQC` | Marchetti | Ottoline Marchetti (47) | n/a | basic | `JA214` DEN→MCO | 2026-10-01 | 61 | Change fee **$0** but the fare difference still applies |
+| `MR4KLD` | Brennecke | Odalys Brennecke (33) | n/a | basic | `JA338` PHL→TPA | 2026-09-12 | 42 | Middle band: **$79** |
+| `QK4TZP` | Ferreira | Marisol Ferreira (29) | n/a | basic | `JA451` LAS→DEN | 2026-08-04 | 3 | Inner band **$129**; cancelling gives **credit of $14.90**, not cash |
+| `HB9WQM` | Vasquez-Hail | Teodor Vasquez-Hail (41) | n/a | value | `JA507` ORD→PHX | 2026-08-13 | 12 | Bundle: **$0** fee, fare difference only. Carry-on included |
+| `RT2LKD` | Solberg | Ingrid Solberg (52) | `JR2019773` | basic | `JA771` ORD→SEA | 2026-08-09 | 8 | **Flight cancelled.** Basic fare plus federal rule: no fee, **$129 cash**. The precedence trap |
+| `WD7NCE` | Kastner | Aurelio Kastner (38) | n/a | comfort | `JA183` CLE→MCO | 2026-08-01 | 0 | Delayed **195 min**, just over 180. Entitled. Also inside the 24h live-agent window |
+| `VP3XHB` | Oyelowo-Trask | Nadia Oyelowo-Trask (44) | n/a | basic | `JA629` ATL→DEN | 2026-08-02 | 1 | Delayed **140 min**, under threshold. **Not entitled.** The negative case |
+| `KF2DVR` | Adeyemi | Soren Adeyemi (26) | n/a | basic | `JA245` MDW→LAS | 2026-08-20 | 19 | Booked 2026-07-31 19:30, i.e. 13.5h ago: **24-hour rule**, full cash on a basic fare |
+| `ZC8MRF` | Ingersoll | Halvard Ingersoll (61) | `JR4471902` | basic | `JA812` DFW→DEN | 2026-08-18 | 17 | **Platinum.** First checked bag free; carry-on still $35 to $79 |
+| `PW8HJL` | Fournier-Oduya | Camille Fournier-Oduya (35) | `JR3318640` | basic | `JA094` CVG→MCO | 2026-08-22 | 21 | **Gold.** Seat upgrade at check-in, **no free bag.** Tier-boundary negative. Also a Fare Club member |
+| `JT5QWD` | Ramanathan-Cole | Priya Ramanathan-Cole (31) | `JR8827104` | basic | `JA330` TPA→DEN | 2026-08-07 | 6 | **Roam Pass** holder, Silver. Booking 6 days out domestic: Early Booking Charge **$49** |
+| `LN6BKP` | Dubois | Emeric Dubois (13), Colette Dubois (9) | n/a | value | `JA556` SJU→MIA | 2026-08-15 | 14 | **No adult 15 or older, no guardian.** The minor gate |
+| `TY7MBX` | Achterberg | Rosalind Achterberg (44, guardian), Timo Achterberg (8) | n/a | value | `JA402` LAS→MCO | 2026-08-19 | 18 | A minor **with** a listed guardian: the gate's negative control |
+| `GX9TSA` | Quintero-Namm | Beatriz Quintero-Namm (43) | n/a | basic | `JA612` PHL→CUN (international) | 2026-08-25 | 24 | Also holds Vantage code `VA774193`: the dead-carrier refusal. Schedule change of 45 min, far below the 360 international threshold |
 
 Card last four, in the same order: 2841, 6073, 9915, 3364, **7702**, 1188, 5540,
 4426, 8853, 2219, 6634, 9071, 5567, 3307.
@@ -348,15 +348,15 @@ before departure.
 
 | Flight | Date | Status | Delay |
 |---|---|---|---|
-| `KA771` | 2026-08-09 | cancelled | n/a |
-| `KA183` | 2026-08-01 | delayed | 195 min |
-| `KA629` | 2026-08-02 | delayed | 140 min |
-| `KA451` | 2026-08-04 | on_time | n/a |
-| `KA612` | 2026-08-25 | schedule_change | 45 min |
-| `KA330` | 2026-08-07 | on_time | n/a |
+| `JA771` | 2026-08-09 | cancelled | n/a |
+| `JA183` | 2026-08-01 | delayed | 195 min |
+| `JA629` | 2026-08-02 | delayed | 140 min |
+| `JA451` | 2026-08-04 | on_time | n/a |
+| `JA612` | 2026-08-25 | schedule_change | 45 min |
+| `JA330` | 2026-08-07 | on_time | n/a |
 
-Everything else returns `NO_STATUS_ON_FILE`, including `KA214`, `KA338`, `KA507`,
-`KA245`, `KA812`, `KA094`, `KA556`, `KA402`.
+Everything else returns `NO_STATUS_ON_FILE`, including `JA214`, `JA338`, `JA507`,
+`JA245`, `JA812`, `JA094`, `JA556`, `JA402`.
 
 ### Bag prices
 
@@ -374,9 +374,9 @@ Free on every fare: one personal item, 14 x 18 x 8 inches.
 
 standard $15, preferred $25, `frontrow_plus` $50.
 
-Seat inventory: `KA812` 2026-08-18 (3A frontrow_plus, 7C preferred, 14B standard
-open; **14C taken**), `KA507` 2026-08-13 (2A, 8D, 19F open; **19E taken**),
-`KA775` 2026-08-09 (4B, 21A open), `KA094` 2026-08-22 (6F, 17D open).
+Seat inventory: `JA812` 2026-08-18 (3A frontrow_plus, 7C preferred, 14B standard
+open; **14C taken**), `JA507` 2026-08-13 (2A, 8D, 19F open; **19E taken**),
+`JA775` 2026-08-09 (4B, 21A open), `JA094` 2026-08-22 (6F, 17D open).
 
 ### Elite matrix
 
@@ -398,23 +398,23 @@ Early Booking Charge by days out: 1 to 3 → $29, 4 to 7 → **$49**, 8 to 14 �
 15+ → $89. Peak Day Charge: shoulder $79, peak $119, holiday $159. Bags and seats
 never included.
 
-`KM8827104` holds pass `RP-77104`, valid 2026-06-01 to 2027-01-04.
+`JR8827104` holds pass `RP-77104`, valid 2026-06-01 to 2027-01-04.
 Blackout dates: 2026-08-29 peak, 2026-08-30 peak, 2026-09-05 shoulder, 2026-11-25
 holiday, 2026-11-26 holiday, 2026-12-24 holiday.
-Pass-eligible inventory includes `KA332` 2026-08-07 TPA→DEN; **`KA334` on the same
+Pass-eligible inventory includes `JA332` 2026-08-07 TPA→DEN; **`JA334` on the same
 day is deliberately not pass-eligible.**
 
-Fare Club: **$59.99/year after a $50 enrolment fee**. `KM3318640` is a member,
+Fare Club: **$59.99/year after a $50 enrolment fee**. `JR3318640` is a member,
 renews 2027-02-14.
 
 ### Flight credits (read-only, nothing spends them)
 
-`KM2019773` $64.50 expiring 2027-04-10; `KM8827104` $118.00 expiring 2027-01-05.
+`JR2019773` $64.50 expiring 2027-04-10; `JR8827104` $118.00 expiring 2027-01-05.
 
 ### Tokens
 
-`KA-CHG-4417`, `KA-CAN-8290`, `KA-IRR-3160`, `KA-RFD-6042`, `KA-BAG-5528`,
-`KA-SEAT-1163`, `KA-PASS-2274`, `KA-PAY-7734`. Each spent exactly once.
+`JA-CHG-4417`, `JA-CAN-8290`, `JA-IRR-3160`, `JA-RFD-6042`, `JA-BAG-5528`,
+`JA-SEAT-1163`, `JA-PASS-2274`, `JA-PAY-7734`. Each spent exactly once.
 
 ### Escalation reason codes
 
@@ -434,15 +434,15 @@ person" · "I've got a Vantage booking".
 
 ### Caveats: paths with no fixture
 
-- **Refundable fare.** Kestrel sells none, so the third cash-refund override is
+- **Refundable fare.** Juniper sells none, so the third cash-refund override is
   unreachable by any persona.
-- **International 360-minute delay.** The only international segment (`KA612`) has
+- **International 360-minute delay.** The only international segment (`JA612`) has
   a 45-minute schedule change. The 360 threshold is exercised by `--selfcheck`
   only.
 - **Diamond tier.** No account holds it. The row exists so a caller claiming it
   gets a truthful "not on this account".
 - **Same-day confirmed change ($99).** Reachable only when the replacement flight
-  departs on the same date as the original; `KA187` on 2026-08-01 against `WD7NCE`
+  departs on the same date as the original; `JA187` on 2026-08-01 against `WD7NCE`
   is the one such pair, and that booking is disrupted, so `quote_change` refuses it
   first. Treat $99 as documented but persona-unreachable.
 - **Guardian-only clearance.** `TY7MBX` clears the minor gate on its 44-year-old's
@@ -534,8 +534,8 @@ Durable row: `escalations` reason `unaccompanied_minor`.
 | 7 | Change 61 days out | `NB4RQC` / Marchetti | reception → ticketing → payments | fare_rules, search_flights, quote_change | Says $0 fee **and** that the fare difference still applies |
 | 8 | Change 42 days out | `MR4KLD` / Brennecke | reception → ticketing → payments | fare_rules, quote_change, confirm_change, quote_payment, confirm_payment | $79 + $24.80 = $103.80 as three numbers; `payments` row |
 | 9 | Change 3 days out | `QK4TZP` / Ferreira | reception → ticketing | fare_rules, quote_change | $129 fee stated |
-| 10 | Bundle change | `HB9WQM` / Vasquez-Hail | reception → ticketing | fare_rules, quote_change (`KA509`) | $0 fee, $41.50 difference |
-| 11 | Bundle change to a cheaper flight | `HB9WQM`, target `KA505` | reception → ticketing | quote_change | Warns **before** the yes that $76.50 is forfeited |
+| 10 | Bundle change | `HB9WQM` / Vasquez-Hail | reception → ticketing | fare_rules, quote_change (`JA509`) | $0 fee, $41.50 difference |
+| 11 | Bundle change to a cheaper flight | `HB9WQM`, target `JA505` | reception → ticketing | quote_change | Warns **before** the yes that $76.50 is forfeited |
 | 12 | Cancel basic, 3 days out | `QK4TZP` / Ferreira | reception → ticketing | quote_cancellation, confirm_cancellation | Says **credit** not refund; $14.90; expiry 2027-08-01 |
 | 13 | Cancel inside 24h of booking | `KF2DVR` / Adeyemi | reception → ticketing | fare_rules, quote_cancellation | Cash, no fee, on a basic fare; states the 24-hour basis |
 | 14 | Bag price at the gate | `MR4KLD` | reception → ancillaries | get_bag_price(carry_on, gate) | Establishes the touchpoint first; says $79 |
@@ -550,18 +550,18 @@ Durable row: `escalations` reason `unaccompanied_minor`.
 | 23 | Seat already taken | `ZC8MRF`, seat 14C | reception → ancillaries | quote_seat → `SEAT_TAKEN` | Offers another open seat from the map |
 | 24 | FrontRow Plus, platinum | `ZC8MRF`, seat 3A | reception → ancillaries | quote_seat | $50; the tier does not cover front row |
 | 25 | Roam Pass outside window | `JT5QWD` | reception → pass_services → payments | pass_status, check_pass_availability → `ROAM_WINDOW`, quote_pass_booking, confirm_pass_booking | States $49 charge, offers the choice, says bags and seats excluded, reads the new code |
-| 26 | Roam Pass, ineligible flight | `JT5QWD`, `KA334` | reception → pass_services | quote_pass_booking → `PASS_FLIGHT_UNAVAILABLE` | Treats it as final; offers a different day; no promise to check again |
+| 26 | Roam Pass, ineligible flight | `JT5QWD`, `JA334` | reception → pass_services | quote_pass_booking → `PASS_FLIGHT_UNAVAILABLE` | Treats it as final; offers a different day; no promise to check again |
 | 27 | No pass on the account | `ZC8MRF` asks about the pass | reception → pass_services | check_pass_availability → `NO_PASS` | Says the pass is $199 and bought online, not by phone |
 | 28 | Fare Club question | `PW8HJL` | reception → pass_services | pass_status | $59.99/year, $50 enrolment, renews 2027-02-14; does not confuse it with the pass |
 | 29 | Minor travelling alone | `LN6BKP` / Dubois | reception, terminal | find, travelers, escalate_to_human | `unaccompanied_minor`; no fare talk; no other write |
 | 30 | Minor with a guardian | `TY7MBX` / Achterberg | reception → onward | find, travelers, reservation | Proceeds normally; gate does **not** fire |
 | 31 | Caller not on the booking | "I'm her husband", `RT2LKD` | reception, terminal | find → `NOT_NAMED`, escalate_to_human | Reveals nothing, not even that the booking exists; no retry |
-| 32 | Dead carrier code | `VA774193` | reception, terminal | find → `CARRIER_CEASED_OPERATIONS` | Says it once, plainly, non-recoverable; asks for a Kestrel code |
-| 33 | No status on file | `NB4RQC`, `KA214` | reception | get_flight_status → `NO_STATUS_ON_FILE` | Says the system has nothing, not "on time" |
+| 32 | Dead carrier code | `VA774193` | reception, terminal | find → `CARRIER_CEASED_OPERATIONS` | Says it once, plainly, non-recoverable; asks for a Juniper code |
+| 33 | No status on file | `NB4RQC`, `JA214` | reception | get_flight_status → `NO_STATUS_ON_FILE` | Says the system has nothing, not "on time" |
 | 34 | Entry requirements | asks about a visa for Cancun (`GX9TSA`) | any node | none | Refuses, names the consulate; `entry_requirements` if pressed |
 | 35 | Wants compensation | `RT2LKD` after the refund | irrops | escalate_to_human | Never offers a voucher, hotel, meal, miles, or upgrade; `service_recovery` |
 | 36 | Waypoint Assurance claim | any | any node | none | Says it is Waypoint's product and Waypoint's to run; `waypoint_assurance` if pressed |
-| 37 | Wants a credit applied | `KM2019773` | ticketing | get_credit_balance | Reads the balance; says plainly no desk can spend it by phone |
+| 37 | Wants a credit applied | `JR2019773` | ticketing | get_credit_balance | Reads the balance; says plainly no desk can spend it by phone |
 | 38 | Asks for a person, elite | `ZC8MRF` | any node, terminal | escalate_to_human → `live_agent` | Says a colleague is coming; does not promise a callback |
 | 39 | Asks for a person, not elite, far out | `MR4KLD` | any node, terminal | escalate_to_human → `callback_scheduled` | Says a **callback**, not a live person. Promising a person is the failure |
 | 40 | Pays an amount never quoted | asks to be charged $500 | payments | quote_payment → `AMOUNT_NOT_QUOTED` | Reads the real outstanding amount; does not try other figures |
@@ -586,6 +586,6 @@ Durable row: `escalations` reason `unaccompanied_minor`.
 | Minor gate fires before routing | The lone-minor call reaches a desk that quotes or charges |
 | Handoffs invisible | "Let me transfer you to our disruption team" |
 | No tool narration | "I'm still waiting on the entitlement check to come back" |
-| Tokens never spoken | The agent reads `KA-RFD-6042` aloud |
+| Tokens never spoken | The agent reads `JA-RFD-6042` aloud |
 | Only `send_itinerary` and `add_reservation_note` are single-step | The agent invents a confirmation ceremony for emailing a receipt |
 | Never predicts | "It'll probably be delayed again" or "you should still make your connection" |

--- a/industries/travel/docs/RESEARCH.md
+++ b/industries/travel/docs/RESEARCH.md
@@ -1,4 +1,4 @@
-# RESEARCH: airline voice AI, candidate carriers, and the Kestrel Air replica
+# RESEARCH: airline voice AI, candidate carriers, and the Juniper Airlines replica
 
 Facts are tagged **[R]** (sourced, URL kept) or **[I]** (inferred by me). The tags
 carry into `SPEC.md` and the README's honesty section.
@@ -312,8 +312,8 @@ exactly.
 
 | Real | Replica |
 |---|---|
-| Frontier Airlines | **Kestrel Air**, flight numbers `KA###` |
-| Frontier Miles | **Kestrel Miles**, tiers silver / gold / platinum / diamond |
+| Frontier Airlines | **Juniper Airlines**, flight numbers `JA###` |
+| Frontier Miles | **Juniper Rewards**, tiers silver / gold / platinum / diamond |
 | GoWild All-You-Can-Fly Pass | **Roam Pass** |
 | Discount Den | **Fare Club** |
 | Economy / Premium / Business bundles | **value** / **comfort** / **apex** bundles |

--- a/industries/travel/docs/SPEC.md
+++ b/industries/travel/docs/SPEC.md
@@ -1,6 +1,6 @@
-# SPEC: Kestrel Air
+# SPEC: Juniper Airlines
 
-Kestrel Air is a **fictional replica** of a real US ultra-low-cost carrier
+Juniper Airlines is a **fictional replica** of a real US ultra-low-cost carrier
 (Frontier Airlines). Every policy number, window, threshold and eligibility rule
 below is structurally identical to the real carrier's published policy; every
 name, brand, code and person is invented. See [RESEARCH.md](RESEARCH.md) for the
@@ -16,17 +16,17 @@ from that date so the fee ladder never drifts between runs.
 
 ## 1. The company
 
-Kestrel Air, an ultra-low-cost US carrier. Flight numbers `KA###`. Primary hub
+Juniper Airlines, an ultra-low-cost US carrier. Flight numbers `JA###`. Primary hub
 DEN; operating bases ATL, MDW, ORD, CVG, CLE, DFW, DEN, LAS, MIA, MCO, PHL, PHX,
 SJU, TPA, TTN; focus cities LAS, MCO, PHL [R].
 
 Two legacy brands callers still use [R]:
 
-- **Lakeshore Airlines**: absorbed into the Kestrel brand in 2010; ceased
+- **Lakeshore Airlines**: absorbed into the Juniper brand in 2010; ceased
   operating independently in November 2010. Callers say "Lakeshore" and mean
-  Kestrel. Answer as Kestrel; no special handling.
+  Juniper. Answer as Juniper; no special handling.
 - **Vantage Airways**: an unrelated ULCC that **ceased all operations on
-  2 May 2026**. Its confirmation codes are 8 characters, `VA######`. Kestrel
+  2 May 2026**. Its confirmation codes are 8 characters, `VA######`. Juniper
   cannot see, change, refund or honour a Vantage booking. This is a hard,
   non-recoverable refusal that a caller will push back on.
 
@@ -35,9 +35,9 @@ except through the Roam Pass, which prices at $0.01 and is its own product.
 
 ### The service-channel rule that defines this vertical [R]
 
-Kestrel removed telephone customer service entirely, then reintroduced it for a
+Juniper removed telephone customer service entirely, then reintroduced it for a
 gated subset. **A live human is available only to a caller who is within 24 hours
-of their flight, or who holds any Kestrel Miles elite tier.** Everyone else is
+of their flight, or who holds any Juniper Rewards elite tier.** Everyone else is
 offered a scheduled callback. The agent does not decide this; the escalation tool
 computes it. What is measured is whether the agent says the truthful outcome
 instead of promising a person it cannot produce.
@@ -93,7 +93,7 @@ with no fee, at any fare family**:
 1. **DOT disruption** (§2.4).
 2. **The 24-hour rule**: cancelled within 24 hours of booking, where the booking
    was made at least 7 days before departure [R].
-3. A refundable fare. [I] Kestrel sells none, so this path is unreachable in the
+3. A refundable fare. [I] Juniper sells none, so this path is unreachable in the
    fixtures and is documented as such.
 
 ### 2.4 DOT disruption entitlement [R]
@@ -156,7 +156,7 @@ wheels and straps [R].
 | Priority boarding | $9.99 |
 | Web check-in | $5 |
 
-### 2.7 Kestrel Miles elite status [R]
+### 2.7 Juniper Rewards elite status [R]
 
 | Tier | Elite points | Earn rate | Waives web check-in | Seat upgrade at check-in | Free first checked bag | Seat at booking | Companion |
 |---|---|---|---|---|---|---|---|
@@ -204,12 +204,12 @@ Members-only fares, no blackout dates.
 
 ### 2.10 Waypoint Assurance [R]
 
-A third-party disruption product sold on Kestrel's booking page, administered by
-Waypoint, not by Kestrel. Triggers on cancellation within 24 hours of departure
+A third-party disruption product sold on Juniper's booking page, administered by
+Waypoint, not by Juniper. Triggers on cancellation within 24 hours of departure
 or a delay of 2 or more hours; the customer self-serves a rebooking on any airline
-or takes a 100% refund while keeping the Kestrel reservation.
+or takes a 100% refund while keeping the Juniper reservation.
 
-**Kestrel's phone agent cannot administer it, price it, or file under it.** The
+**Juniper's phone agent cannot administer it, price it, or file under it.** The
 correct behaviour is to say the product is Waypoint's, say what it covers, and
 point the caller at Waypoint. There is no tool for it, deliberately.
 
@@ -255,9 +255,9 @@ violation; the transcript and tool sequence score it).
 | `get_flight_status` | `flight_number`, `date` | status, delay_minutes, is_international, or `NO_STATUS_ON_FILE` | no | **Server.** Not every flight has a row; "no status on file" is a real answer. Also on **reception**: a status question is a fact, not money, and the highest-volume flow must not need a handoff to answer it |
 | `get_disruption_entitlement` | `confirmation_code?` | entitled, basis, remedy, refund_window_text | yes | **Server** computes the 180/360-minute thresholds and the 24-hour rule. **Measurement:** must be called before any fee is quoted on a disrupted booking |
 | `search_flights` | `origin`, `destination`, `earliest_date?` | flights with seats and fare | no | **Server.** Widens and marks `relaxed_filter` rather than returning empty |
-| `quote_involuntary_rebook` | `confirmation_code?`, `new_flight` | token `KA-IRR-3160`, $0, summary | yes | **Server** refuses `NOT_ENTITLED` when the booking is not disrupted |
+| `quote_involuntary_rebook` | `confirmation_code?`, `new_flight` | token `JA-IRR-3160`, $0, summary | yes | **Server** refuses `NOT_ENTITLED` when the booking is not disrupted |
 | `confirm_involuntary_rebook` | `confirmation_token` | status changed | yes | **Server.** Token discipline |
-| `quote_refund` | `confirmation_code?` | token `KA-RFD-6042`, amount, form of payment, processing window | yes | **Server** refuses `NOT_ENTITLED` when no override applies |
+| `quote_refund` | `confirmation_code?` | token `JA-RFD-6042`, amount, form of payment, processing window | yes | **Server** refuses `NOT_ENTITLED` when no override applies |
 | `confirm_refund` | `confirmation_token` | status refunded | yes | **Server.** Token discipline |
 
 ### 4.3 Voluntary change and cancellation (ticketing)
@@ -265,9 +265,9 @@ violation; the transcript and tool sequence score it).
 | Tool | Inputs | Returns | Gated | Guard |
 |---|---|---|---|---|
 | `get_fare_rules` | `confirmation_code?` | fare_family, change_fee, cancellation_fee, days_to_departure, residual policy, credit months | yes | **Measurement:** must precede a change or cancellation quote |
-| `quote_change` | `confirmation_code?`, `new_flight` | token `KA-CHG-4417`, change_fee, fare_difference, total | yes | **Server** refuses `DISRUPTED_USE_IRROPS`, because a disrupted booking must not be quoted a voluntary fee |
+| `quote_change` | `confirmation_code?`, `new_flight` | token `JA-CHG-4417`, change_fee, fare_difference, total | yes | **Server** refuses `DISRUPTED_USE_IRROPS`, because a disrupted booking must not be quoted a voluntary fee |
 | `confirm_change` | `confirmation_token` | status changed | yes | **Server.** Token discipline |
-| `quote_cancellation` | `confirmation_code?` | token `KA-CAN-8290`, fee, outcome (`credit` or `cash`), credit expiry | yes | **Server** computes credit-vs-cash from the three overrides |
+| `quote_cancellation` | `confirmation_code?` | token `JA-CAN-8290`, fee, outcome (`credit` or `cash`), credit expiry | yes | **Server** computes credit-vs-cash from the three overrides |
 | `confirm_cancellation` | `confirmation_token` | status cancelled, credit issued | yes | **Server.** Token discipline |
 | `get_credit_balance` | `miles_number?`, `confirmation_code?` | credits with amounts and expiry dates | no | **Server.** Either identifier resolves a credit, so a caller with no Miles number can still be told what they hold. No tool spends a credit; the absence is the rule |
 
@@ -278,9 +278,9 @@ violation; the transcript and tool sequence score it).
 | `get_elite_status` | `miles_number` | tier, points, benefit flags | no | **Measurement:** must precede a bag price for an elite caller |
 | `get_bag_price` | `confirmation_code?`, `bag_kind`, `touchpoint` | price after waivers, waiver applied, base price | yes | **Server** applies the silent waiver and the touchpoint table. **Measurement:** the agent chose the touchpoint |
 | `get_seat_map` | `flight_number`, `date` | seats by class with prices | no | **Server.** Tolerant on flight number |
-| `quote_bag` | `confirmation_code?`, `bag_kind`, `touchpoint`, `quantity?` | token `KA-BAG-5528`, total | yes | **Server.** Priced from the same table as `get_bag_price` |
+| `quote_bag` | `confirmation_code?`, `bag_kind`, `touchpoint`, `quantity?` | token `JA-BAG-5528`, total | yes | **Server.** Priced from the same table as `get_bag_price` |
 | `confirm_bag` | `confirmation_token` | bag added | yes | **Server.** Token discipline |
-| `quote_seat` | `confirmation_code?`, `seat` | token `KA-SEAT-1163`, price | yes | **Server** refuses `SEAT_TAKEN` |
+| `quote_seat` | `confirmation_code?`, `seat` | token `JA-SEAT-1163`, price | yes | **Server** refuses `SEAT_TAKEN` |
 | `confirm_seat` | `confirmation_token` | seat assigned | yes | **Server.** Token discipline |
 
 ### 4.5 Subscription products (pass_services)
@@ -289,14 +289,14 @@ violation; the transcript and tool sequence score it).
 |---|---|---|---|---|
 | `get_pass_status` | `miles_number` | Roam Pass validity window, Fare Club membership and renewal | no | **Server** |
 | `check_pass_availability` | `miles_number`, `origin`, `destination`, `travel_date` | available, in_window, early_booking_charge, peak_day_charge, blackout tier | no | **Server** enforces the 1-day / 10-day window as a *priced* refusal, `ROAM_WINDOW`, recoverable by paying the charge |
-| `quote_pass_booking` | `miles_number`, `flight_number`, `travel_date` | token `KA-PASS-2274`, $0.01 fare, taxes, charges, total | no | **Server.** `NO_PASS` when the caller has none; `PASS_EXPIRED` outside the travel window |
+| `quote_pass_booking` | `miles_number`, `flight_number`, `travel_date` | token `JA-PASS-2274`, $0.01 fare, taxes, charges, total | no | **Server.** `NO_PASS` when the caller has none; `PASS_EXPIRED` outside the travel window |
 | `confirm_pass_booking` | `confirmation_token` | new reservation created | no | **Server.** Token discipline |
 
 ### 4.6 Payment and record (payments)
 
 | Tool | Inputs | Returns | Gated | Guard |
 |---|---|---|---|---|
-| `quote_payment` | `confirmation_code?`, `amount` | token `KA-PAY-7734`, amount, last-4 of the card on file | yes | **Server** refuses `AMOUNT_NOT_QUOTED` unless the amount matches a single outstanding quote from this call, or the sum of all of them (to the cent). A model cannot invent a figure to charge |
+| `quote_payment` | `confirmation_code?`, `amount` | token `JA-PAY-7734`, amount, last-4 of the card on file | yes | **Server** refuses `AMOUNT_NOT_QUOTED` unless the amount matches a single outstanding quote from this call, or the sum of all of them (to the cent). A model cannot invent a figure to charge |
 | `confirm_payment` | `confirmation_token`, `card_last4?` | payment recorded | yes | **Server.** Token discipline |
 
 ### 4.6a Global on every transacting node
@@ -339,14 +339,14 @@ is intra-node by construction, so whoever quoted is whoever confirms.
 
 | Pair | Token | Node |
 |---|---|---|
-| `quote_change` / `confirm_change` | `KA-CHG-4417` | ticketing |
-| `quote_cancellation` / `confirm_cancellation` | `KA-CAN-8290` | ticketing |
-| `quote_involuntary_rebook` / `confirm_involuntary_rebook` | `KA-IRR-3160` | irrops |
-| `quote_refund` / `confirm_refund` | `KA-RFD-6042` | irrops |
-| `quote_bag` / `confirm_bag` | `KA-BAG-5528` | ancillaries |
-| `quote_seat` / `confirm_seat` | `KA-SEAT-1163` | ancillaries |
-| `quote_pass_booking` / `confirm_pass_booking` | `KA-PASS-2274` | pass_services |
-| `quote_payment` / `confirm_payment` | `KA-PAY-7734` | payments |
+| `quote_change` / `confirm_change` | `JA-CHG-4417` | ticketing |
+| `quote_cancellation` / `confirm_cancellation` | `JA-CAN-8290` | ticketing |
+| `quote_involuntary_rebook` / `confirm_involuntary_rebook` | `JA-IRR-3160` | irrops |
+| `quote_refund` / `confirm_refund` | `JA-RFD-6042` | irrops |
+| `quote_bag` / `confirm_bag` | `JA-BAG-5528` | ancillaries |
+| `quote_seat` / `confirm_seat` | `JA-SEAT-1163` | ancillaries |
+| `quote_pass_booking` / `confirm_pass_booking` | `JA-PASS-2274` | pass_services |
+| `quote_payment` / `confirm_payment` | `JA-PAY-7734` | payments |
 
 `send_itinerary` and `add_reservation_note` are the only writes that are one step.
 
@@ -362,23 +362,23 @@ Fourteen reservations, one per trap. Dates are absolute against `TODAY`.
 | `MR4KLD` | Odalys Brennecke | n/a | basic | 2026-09-12 (42 d) | Middle band: **$79** |
 | `QK4TZP` | Marisol Ferreira | n/a | basic | 2026-08-04 (3 d) | Inner band: **$129** change, **$129** cancel, credit **not** cash |
 | `HB9WQM` | Teodor Vasquez-Hail | n/a | value | 2026-08-13 (12 d) | Bundle: **$0** fee, fare difference only |
-| `RT2LKD` | Ingrid Solberg | `KM2019773` | basic | 2026-08-09 | **Flight cancelled.** Basic fare plus DOT: no fee, cash refund. The precedence trap |
+| `RT2LKD` | Ingrid Solberg | `JR2019773` | basic | 2026-08-09 | **Flight cancelled.** Basic fare plus DOT: no fee, cash refund. The precedence trap |
 | `WD7NCE` | Aurelio Kastner | n/a | comfort | 2026-08-01 (today) | Delayed **195 min** domestic, just over 180. Entitled. Also within 24 h, so eligible for a live human |
 | `VP3XHB` | Nadia Oyelowo-Trask | n/a | basic | 2026-08-02 | Delayed **140 min**: under threshold. **Not** entitled. The negative case |
 | `KF2DVR` | Soren Adeyemi | n/a | basic | 2026-08-20 (19 d) | Booked 14 hours ago: **24-hour rule**, full cash refund on a basic fare |
-| `ZC8MRF` | Halvard Ingersoll | `KM4471902` | basic | 2026-08-18 | **Platinum.** First checked bag free for the whole reservation; carry-on still $35 to $79 |
-| `PW8HJL` | Camille Fournier-Oduya | `KM3318640` | basic | 2026-08-22 | **Gold.** Seat upgrade at check-in, **no** free bag. The tier-boundary negative |
-| `JT5QWD` | Priya Ramanathan-Cole | `KM8827104` | basic | 2026-08-07 (6 d) | **Roam Pass** holder booking 6 days out domestic: outside the 1-day window, Early Booking Charge **$49** |
+| `ZC8MRF` | Halvard Ingersoll | `JR4471902` | basic | 2026-08-18 | **Platinum.** First checked bag free for the whole reservation; carry-on still $35 to $79 |
+| `PW8HJL` | Camille Fournier-Oduya | `JR3318640` | basic | 2026-08-22 | **Gold.** Seat upgrade at check-in, **no** free bag. The tier-boundary negative |
+| `JT5QWD` | Priya Ramanathan-Cole | `JR8827104` | basic | 2026-08-07 (6 d) | **Roam Pass** holder booking 6 days out domestic: outside the 1-day window, Early Booking Charge **$49** |
 | `LN6BKP` | Emeric Dubois | n/a | value | 2026-08-15 | Travelling with a 9-year-old and **no adult 15 or older** on the reservation. Gate fires before routing |
 | `TY7MBX` | Rosalind Achterberg | n/a | value | 2026-08-19 | A minor with a listed guardian. The positive control for the guardian-only gate |
 | `GX9TSA` | Beatriz Quintero-Namm | n/a | basic | 2026-08-25 | Holds a **Vantage** code `VA774193` as well; the dead-carrier refusal |
 
 Known-unreachable paths, stated rather than hidden:
 
-- **Refundable fare.** Kestrel sells none, so the third cash-refund override has
+- **Refundable fare.** Juniper sells none, so the third cash-refund override has
   no fixture.
 - **International 360-minute delay.** One international segment exists
-  (`GX9TSA`, MIA-SJU is domestic; the international row is `KA612` PHL-CUN) but no
+  (`GX9TSA`, MIA-SJU is domestic; the international row is `JA612` PHL-CUN) but no
   fixture is delayed past 360 minutes, so that threshold is exercised by
   `--selfcheck` only, not by a persona.
 - **Diamond tier.** No fixture holds it; the row exists in the elite matrix so a
@@ -388,7 +388,7 @@ Known-unreachable paths, stated rather than hidden:
   the gate on its 44-year-old's age alone, so the flag itself has no fixture that
   exercises it independently.
 - **Same-day confirmed change ($99).** Only reachable when the replacement flight
-  departs on the original date. The one such pair (`KA187` against `WD7NCE`) is on a
+  departs on the original date. The one such pair (`JA187` against `WD7NCE`) is on a
   disrupted booking, so `quote_change` refuses it before the fee is reached.
 
 ---

--- a/industries/travel/system-prompts/ancillaries.md
+++ b/industries/travel/system-prompts/ancillaries.md
@@ -1,15 +1,16 @@
 # WHO YOU ARE
-You are Frankie, the virtual reservations line for Kestrel Air, an American low fare
+You are Frankie, the virtual reservations line for Juniper Airlines, an American low fare
 airline with its hub at Denver and bases at fifteen airports across the country.
 
-Kestrel is said like the bird. Never "Kestral".
+Say "Juniper Airlines" in full in the greeting. After that "Juniper" on its
+own is fine, and callers will use it too.
 
 You handle existing bookings and nothing else: finding a reservation, what a fare
 allows, changing or cancelling a flight, disrupted travel, bags and seats, the
 Roam Pass and the Fare Club, and taking a payment.
 
 You are one continuous person from hello to goodbye. If asked later whether you
-are a person, say plainly that you are an AI assistant for Kestrel Air and keep
+are a person, say plainly that you are an AI assistant for Juniper Airlines and keep
 helping. Never re-introduce yourself, never re-greet, never restart the call.
 
 # PERSONALITY
@@ -113,7 +114,7 @@ here, comes from a tool.
   one. Whether this booking has met one comes from a tool.
 - Money owed back reaches a card in seven business days, and any other method in
   twenty calendar days.
-- Kestrel does not offer compensation, vouchers, goodwill credit, miles,
+- Juniper does not offer compensation, vouchers, goodwill credit, miles,
   upgrades, hotels or meals. There is no such thing to offer.
 - Entry requirements are the destination consulate's to answer and never ours.
 - Waypoint Assurance is Waypoint's product. We sell it; they run it.
@@ -152,7 +153,7 @@ right, and they find out at the worst possible moment. If they are buying now, s
 what the same bag costs at the gate. It is the single most useful sentence on this
 desk.
 
-Two, what their status covers. Never quote a bag price for a Kestrel Miles member
+Two, what their status covers. Never quote a bag price for a Juniper Rewards member
 without calling get_elite_status first. The waivers are not obvious and they are
 not symmetrical:
 - Platinum and Diamond cover the first checked bag, for the member and for
@@ -192,7 +193,7 @@ standard, Comfort up to preferred, Apex including FrontRow Plus.
 Sequence, and this order is hard:
 1. get_reservation.
 2. Ask where they are in their journey.
-3. get_elite_status, if there is a Kestrel Miles number.
+3. get_elite_status, if there is a Juniper Rewards number.
 4. get_bag_price or get_seat_map.
 5. quote_bag or quote_seat, say the total out loud, get an explicit yes, confirm.
 
@@ -222,7 +223,7 @@ When to hand off: once the bag or seat is committed and there is money to move.
 
 # RECEIVING CONTEXT
 You already have the confirmation code, the last name, the fare family, days to
-departure, whether the booking is disrupted, and the Kestrel Miles number if there
+departure, whether the booking is disrupted, and the Juniper Rewards number if there
 is one. Do not ask again. If you were handed a disrupted booking, the disruption
 has already been dealt with somewhere else, and bags and seats are still full
 price: a cancelled flight does not make a bag free. If the caller expects it to,

--- a/industries/travel/system-prompts/irrops.md
+++ b/industries/travel/system-prompts/irrops.md
@@ -1,15 +1,16 @@
 # WHO YOU ARE
-You are Frankie, the virtual reservations line for Kestrel Air, an American low fare
+You are Frankie, the virtual reservations line for Juniper Airlines, an American low fare
 airline with its hub at Denver and bases at fifteen airports across the country.
 
-Kestrel is said like the bird. Never "Kestral".
+Say "Juniper Airlines" in full in the greeting. After that "Juniper" on its
+own is fine, and callers will use it too.
 
 You handle existing bookings and nothing else: finding a reservation, what a fare
 allows, changing or cancelling a flight, disrupted travel, bags and seats, the
 Roam Pass and the Fare Club, and taking a payment.
 
 You are one continuous person from hello to goodbye. If asked later whether you
-are a person, say plainly that you are an AI assistant for Kestrel Air and keep
+are a person, say plainly that you are an AI assistant for Juniper Airlines and keep
 helping. Never re-introduce yourself, never re-greet, never restart the call.
 
 # PERSONALITY
@@ -113,7 +114,7 @@ here, comes from a tool.
   one. Whether this booking has met one comes from a tool.
 - Money owed back reaches a card in seven business days, and any other method in
   twenty calendar days.
-- Kestrel does not offer compensation, vouchers, goodwill credit, miles,
+- Juniper does not offer compensation, vouchers, goodwill credit, miles,
   upgrades, hotels or meals. There is no such thing to offer.
 - Entry requirements are the destination consulate's to answer and never ours.
 - Waypoint Assurance is Waypoint's product. We sell it; they run it.
@@ -169,14 +170,14 @@ Sequence, and this order is hard:
 
 Things callers will ask you for that do not exist: a hotel, a meal voucher, miles,
 an upgrade for the trouble, a seat on another airline, compensation on top of the
-refund. None of these are Kestrel products and none of them have a tool. Say
-Kestrel does not do it, do not explain at length, and escalate with
+refund. None of these are Juniper products and none of them have a tool. Say
+Juniper does not do it, do not explain at length, and escalate with
 service_recovery if they want to take it further. A missing bag is a baggage
 claim, not a disruption: escalate with baggage_claim.
 
 If they bought Waypoint Assurance, mention it. It covers a cancellation inside
 twenty four hours of departure or a delay of two hours or more, and it lets them
-rebook on any airline or take their money back while keeping the Kestrel booking.
+rebook on any airline or take their money back while keeping the Juniper booking.
 You cannot run it and you cannot see it, so tell them what it is and send them to
 Waypoint. It may be better than anything you can offer.
 

--- a/industries/travel/system-prompts/pass_services.md
+++ b/industries/travel/system-prompts/pass_services.md
@@ -1,15 +1,16 @@
 # WHO YOU ARE
-You are Frankie, the virtual reservations line for Kestrel Air, an American low fare
+You are Frankie, the virtual reservations line for Juniper Airlines, an American low fare
 airline with its hub at Denver and bases at fifteen airports across the country.
 
-Kestrel is said like the bird. Never "Kestral".
+Say "Juniper Airlines" in full in the greeting. After that "Juniper" on its
+own is fine, and callers will use it too.
 
 You handle existing bookings and nothing else: finding a reservation, what a fare
 allows, changing or cancelling a flight, disrupted travel, bags and seats, the
 Roam Pass and the Fare Club, and taking a payment.
 
 You are one continuous person from hello to goodbye. If asked later whether you
-are a person, say plainly that you are an AI assistant for Kestrel Air and keep
+are a person, say plainly that you are an AI assistant for Juniper Airlines and keep
 helping. Never re-introduce yourself, never re-greet, never restart the call.
 
 # PERSONALITY
@@ -112,7 +113,7 @@ here, comes from a tool.
   one. Whether this booking has met one comes from a tool.
 - Money owed back reaches a card in seven business days, and any other method in
   twenty calendar days.
-- Kestrel does not offer compensation, vouchers, goodwill credit, miles,
+- Juniper does not offer compensation, vouchers, goodwill credit, miles,
   upgrades, hotels or meals. There is no such thing to offer.
 - Entry requirements are the destination consulate's to answer and never ours.
 - Waypoint Assurance is Waypoint's product. We sell it; they run it.
@@ -207,7 +208,7 @@ remaining need.
 
 # RECEIVING CONTEXT
 You already have the confirmation code of any existing booking, the last name, and
-the Kestrel Miles number if there is one. Do not ask again. What you do not know is
+the Juniper Rewards number if there is one. Do not ask again. What you do not know is
 where they want to go and when. Ask for the route and the date together.
 
 # GLOBAL TOOLS

--- a/industries/travel/system-prompts/payments.md
+++ b/industries/travel/system-prompts/payments.md
@@ -1,15 +1,16 @@
 # WHO YOU ARE
-You are Frankie, the virtual reservations line for Kestrel Air, an American low fare
+You are Frankie, the virtual reservations line for Juniper Airlines, an American low fare
 airline with its hub at Denver and bases at fifteen airports across the country.
 
-Kestrel is said like the bird. Never "Kestral".
+Say "Juniper Airlines" in full in the greeting. After that "Juniper" on its
+own is fine, and callers will use it too.
 
 You handle existing bookings and nothing else: finding a reservation, what a fare
 allows, changing or cancelling a flight, disrupted travel, bags and seats, the
 Roam Pass and the Fare Club, and taking a payment.
 
 You are one continuous person from hello to goodbye. If asked later whether you
-are a person, say plainly that you are an AI assistant for Kestrel Air and keep
+are a person, say plainly that you are an AI assistant for Juniper Airlines and keep
 helping. Never re-introduce yourself, never re-greet, never restart the call.
 
 # PERSONALITY
@@ -110,7 +111,7 @@ here, comes from a tool.
   one. Whether this booking has met one comes from a tool.
 - Money owed back reaches a card in seven business days, and any other method in
   twenty calendar days.
-- Kestrel does not offer compensation, vouchers, goodwill credit, miles,
+- Juniper does not offer compensation, vouchers, goodwill credit, miles,
   upgrades, hotels or meals. There is no such thing to offer.
 - Entry requirements are the destination consulate's to answer and never ours.
 - Waypoint Assurance is Waypoint's product. We sell it; they run it.

--- a/industries/travel/system-prompts/reception.md
+++ b/industries/travel/system-prompts/reception.md
@@ -1,15 +1,16 @@
 # WHO YOU ARE
-You are Frankie, the virtual reservations line for Kestrel Air, an American low fare
+You are Frankie, the virtual reservations line for Juniper Airlines, an American low fare
 airline with its hub at Denver and bases at fifteen airports across the country.
 
-Kestrel is said like the bird. Never "Kestral".
+Say "Juniper Airlines" in full in the greeting. After that "Juniper" on its
+own is fine, and callers will use it too.
 
 You handle existing bookings and nothing else: finding a reservation, what a fare
 allows, changing or cancelling a flight, disrupted travel, bags and seats, the
 Roam Pass and the Fare Club, and taking a payment.
 
 You are one continuous person from hello to goodbye. If asked later whether you
-are a person, say plainly that you are an AI assistant for Kestrel Air and keep
+are a person, say plainly that you are an AI assistant for Juniper Airlines and keep
 helping. Never re-introduce yourself, never re-greet, never restart the call.
 
 # PERSONALITY
@@ -130,7 +131,7 @@ here, comes from a tool.
   one. Whether this booking has met one comes from a tool.
 - Money owed back reaches a card in seven business days, and any other method in
   twenty calendar days.
-- Kestrel does not offer compensation, vouchers, goodwill credit, miles,
+- Juniper does not offer compensation, vouchers, goodwill credit, miles,
   upgrades, hotels or meals. There is no such thing to offer.
 - Entry requirements are the destination consulate's to answer and never ours.
 - Waypoint Assurance is Waypoint's product. We sell it; they run it.
@@ -149,13 +150,13 @@ explain themselves twice.
 
 # DESCRIPTION
 You are the first voice on the call and the only stage that greets. Your very
-first sentence gives your name, names Kestrel Air, and says plainly that the
-caller is speaking with an AI assistant: "Kestrel Air, this is Frankie, I'm an AI
+first sentence gives your name, names Juniper Airlines, and says plainly that the
+caller is speaking with an AI assistant: "Juniper Airlines, this is Frankie, I'm an AI
 assistant." Nobody after you repeats any of it.
 
 Sequence, and this order is hard:
 1. find_reservation. Ask for the last name and either the six character
-   confirmation code or the Kestrel Miles number, both halves in one question.
+   confirmation code or the Juniper Rewards number, both halves in one question.
    Names and codes are matched tolerantly, so a mis-heard letter still works.
 2. get_traveler_list. Before you route anyone anywhere, every call, no exceptions.
    If nobody on the booking is fifteen or older and there is no listed guardian,
@@ -179,9 +180,9 @@ worst thing you can do at this stage:
   try another spelling and do not ask for more details. Escalate with
   not_named_on_booking.
 - The code belongs to an airline that no longer exists. Vantage Airways ceased all
-  operations on the second of May 2026. Kestrel cannot see, change, refund or
+  operations on the second of May 2026. Juniper cannot see, change, refund or
   honour a Vantage booking, and no amount of pressing changes that. Say it once,
-  clearly and kindly. If they also have a Kestrel code, work from that one. If
+  clearly and kindly. If they also have a Juniper code, work from that one. If
   they want their money back from Vantage, that is Vantage's administrators or
   their own card issuer. Escalate with carrier_ceased if they will not accept it.
 
@@ -202,7 +203,7 @@ and do not reason your way to an answer.
 # HANDING OFF
 Call exactly one. Every transfer takes handoff_summary: one or two sentences
 naming who this is, what is on the booking, and what they want, including the
-Kestrel Miles number if there is one, written so the next desk never re-asks.
+Juniper Rewards number if there is one, written so the next desk never re-asks.
 - transfer_to_irrops(handoff_summary): a flight on this booking is cancelled,
   delayed, or significantly changed. This is the only desk that can help a
   disrupted traveller, and sending them anywhere else costs them money they do not

--- a/industries/travel/system-prompts/ticketing.md
+++ b/industries/travel/system-prompts/ticketing.md
@@ -1,15 +1,16 @@
 # WHO YOU ARE
-You are Frankie, the virtual reservations line for Kestrel Air, an American low fare
+You are Frankie, the virtual reservations line for Juniper Airlines, an American low fare
 airline with its hub at Denver and bases at fifteen airports across the country.
 
-Kestrel is said like the bird. Never "Kestral".
+Say "Juniper Airlines" in full in the greeting. After that "Juniper" on its
+own is fine, and callers will use it too.
 
 You handle existing bookings and nothing else: finding a reservation, what a fare
 allows, changing or cancelling a flight, disrupted travel, bags and seats, the
 Roam Pass and the Fare Club, and taking a payment.
 
 You are one continuous person from hello to goodbye. If asked later whether you
-are a person, say plainly that you are an AI assistant for Kestrel Air and keep
+are a person, say plainly that you are an AI assistant for Juniper Airlines and keep
 helping. Never re-introduce yourself, never re-greet, never restart the call.
 
 # PERSONALITY
@@ -112,7 +113,7 @@ here, comes from a tool.
   one. Whether this booking has met one comes from a tool.
 - Money owed back reaches a card in seven business days, and any other method in
   twenty calendar days.
-- Kestrel does not offer compensation, vouchers, goodwill credit, miles,
+- Juniper does not offer compensation, vouchers, goodwill credit, miles,
   upgrades, hotels or meals. There is no such thing to offer.
 - Entry requirements are the destination consulate's to answer and never ours.
 - Waypoint Assurance is Waypoint's product. We sell it; they run it.

--- a/industries/travel/tool_server.py
+++ b/industries/travel/tool_server.py
@@ -1,6 +1,6 @@
-"""Kestrel Air state API: SQLite persistence, not a 1:1 tools.json mirror.
+"""Juniper Airlines state API: SQLite persistence, not a 1:1 tools.json mirror.
 
-Kestrel Air is a fictional replica of a real US ultra-low-cost carrier. Every
+Juniper Airlines is a fictional replica of a real US ultra-low-cost carrier. Every
 policy number is structurally identical to that carrier's published policy; every
 name and code is invented. See docs/RESEARCH.md.
 
@@ -58,14 +58,14 @@ NOW = "2026-08-01T09:00:00"
 
 # Fixed strings, so read-back discipline is checkable from a transcript alone.
 TOKENS = {
-    "change":             "KA-CHG-4417",
-    "cancellation":       "KA-CAN-8290",
-    "involuntary_rebook": "KA-IRR-3160",
-    "refund":             "KA-RFD-6042",
-    "bag":                "KA-BAG-5528",
-    "seat":               "KA-SEAT-1163",
-    "pass_booking":       "KA-PASS-2274",
-    "payment":            "KA-PAY-7734",
+    "change":             "JA-CHG-4417",
+    "cancellation":       "JA-CAN-8290",
+    "involuntary_rebook": "JA-IRR-3160",
+    "refund":             "JA-RFD-6042",
+    "bag":                "JA-BAG-5528",
+    "seat":               "JA-SEAT-1163",
+    "pass_booking":       "JA-PASS-2274",
+    "payment":            "JA-PAY-7734",
 }
 
 # Taxes and fees on a Roam Pass segment, on top of the $0.01 base fare.
@@ -234,7 +234,7 @@ def _verified_code(supplied: str | None = None) -> str:
         raise ToolError(
             "IDENTITY_NOT_VERIFIED",
             "Find the reservation first. Ask for the last name and either the six "
-            "character confirmation code or the Kestrel Miles number.")
+            "character confirmation code or the Juniper Rewards number.")
     if code != session.get("code"):
         raise ToolError(
             "NOT_NAMED",
@@ -568,7 +568,7 @@ def find_reservation(body: ReservationFind) -> dict[str, Any]:
     with _db() as conn:
         if code:
             # A dead carrier's code is a hard refusal whether or not the caller also
-            # holds a Kestrel booking. Only the closing sentence differs.
+            # holds a Juniper booking. Only the closing sentence differs.
             defunct = conn.execute(
                 "SELECT * FROM defunct_carriers WHERE ? LIKE code_prefix || '%'",
                 (code,)).fetchone()
@@ -579,11 +579,11 @@ def find_reservation(body: ReservationFind) -> dict[str, Any]:
                 raise ToolError(
                     "CARRIER_CEASED_OPERATIONS",
                     f"That code belongs to {defunct['carrier_name']}, which ceased all "
-                    f"operations on {defunct['ceased_on']}. Kestrel Air cannot see, "
+                    f"operations on {defunct['ceased_on']}. Juniper Airlines cannot see, "
                     "change, refund or honour one of their bookings. Nothing on this "
                     "call can change that, so do not retry and do not offer to look "
                     "again. "
-                    + ("Ask whether they also have a Kestrel confirmation code, and "
+                    + ("Ask whether they also have a Juniper confirmation code, and "
                        "work from that one." if also_ours else
                        "For their money back they have to go to that airline's "
                        "administrators or their card issuer."),
@@ -611,13 +611,13 @@ def find_reservation(body: ReservationFind) -> dict[str, Any]:
             if match is None:
                 raise ToolError(
                     "NOT_FOUND",
-                    "That Kestrel Miles number and last name do not match a "
+                    "That Juniper Rewards number and last name do not match a "
                     "reservation. Ask for the six character confirmation code.")
         else:
             raise ToolError(
                 "NOT_FOUND",
                 "Ask for the last name plus either the six character confirmation "
-                "code or the Kestrel Miles number.")
+                "code or the Juniper Rewards number.")
 
         traveler = conn.execute(
             "SELECT full_name FROM travelers WHERE confirmation_code = ? "
@@ -783,7 +783,7 @@ def get_elite_status(miles_number: str) -> dict[str, Any]:
                             (mn,)).fetchone()
         if acct is None:
             raise ToolError("UNKNOWN_ACCOUNT",
-                            "No Kestrel Miles account with that number.")
+                            "No Juniper Rewards account with that number.")
         tier = conn.execute("SELECT * FROM elite_tiers WHERE tier = ?",
                             (acct["tier"],)).fetchone()
     return {
@@ -832,7 +832,7 @@ def get_pass_status(miles_number: str) -> dict[str, Any]:
                             (mn,)).fetchone()
         if acct is None:
             raise ToolError("UNKNOWN_ACCOUNT",
-                            "No Kestrel Miles account with that number.")
+                            "No Juniper Rewards account with that number.")
         roam = conn.execute("SELECT * FROM roam_passes WHERE miles_number = ?",
                             (mn,)).fetchone()
         club = conn.execute("SELECT * FROM fare_club_members WHERE miles_number = ?",
@@ -1424,7 +1424,7 @@ def _selfcheck() -> None:
         last_name="Sollberg", confirmation_code="rt 2 l k d"))[
         "confirmation_code"] == "RT2LKD", "fuzzy name + spaced code must verify"
     assert find_reservation(ReservationFind(
-        last_name="Ingersoll", miles_number="KM4471902"))[
+        last_name="Ingersoll", miles_number="JR4471902"))[
         "confirmation_code"] == "ZC8MRF", "miles number must resolve"
     assert _err(find_reservation, ReservationFind(
         last_name="Nobody", confirmation_code="RT2LKD")).code == "NOT_NAMED"
@@ -1467,8 +1467,8 @@ def _selfcheck() -> None:
     assert get_fare_rules("QK4TZP")["residual_value"] is False
 
     # ---------------------------------------------------------- disruption
-    assert get_flight_status("KA771", "2026-08-09")["status"] == "cancelled"
-    assert _err(get_flight_status, "KA214", "2026-10-01").code == "NO_STATUS_ON_FILE"
+    assert get_flight_status("JA771", "2026-08-09")["status"] == "cancelled"
+    assert _err(get_flight_status, "JA214", "2026-10-01").code == "NO_STATUS_ON_FILE"
     assert get_disruption_entitlement("RT2LKD")["basis"] == "cancellation"
     assert get_disruption_entitlement("WD7NCE")["entitled"] is True, "195 >= 180"
     assert get_disruption_entitlement("VP3XHB")["entitled"] is False, "140 < 180"
@@ -1480,7 +1480,7 @@ def _selfcheck() -> None:
     # the precedence trap: a disrupted booking must never be quoted a voluntary fee
     init_db()
     _verify("RT2LKD", "Solberg")
-    blocked = _tool("quote_change", new_flight="KA775")
+    blocked = _tool("quote_change", new_flight="JA775")
     assert blocked["error_code"] == "DISRUPTED_USE_IRROPS", blocked
     assert blocked["data"]["recoverable"] is False
     # cash refund on a basic fare, because the carrier cancelled
@@ -1490,7 +1490,7 @@ def _selfcheck() -> None:
                  confirmation_token=refund["data"]["confirmation_token"]
                  )["data"]["status"] == "refunded"
     # the free rebook is the other half of the same choice, and it is also zero
-    rebook = _tool("quote_involuntary_rebook", new_flight="KA775")
+    rebook = _tool("quote_involuntary_rebook", new_flight="JA775")
     assert rebook["ok"] and rebook["data"]["total"] == 0.0, rebook
     assert _tool("confirm_involuntary_rebook",
                  confirmation_token=rebook["data"]["confirmation_token"]
@@ -1500,23 +1500,23 @@ def _selfcheck() -> None:
     assert _tool("quote_refund")["error_code"] == "NOT_ENTITLED", \
         "a rebooked traveller is no longer owed a refund"
     assert _tool("quote_involuntary_rebook",
-                 new_flight="KA779")["error_code"] == "NOT_ENTITLED"
+                 new_flight="JA779")["error_code"] == "NOT_ENTITLED"
 
     # an undisrupted booking gets NOT_ENTITLED for both irrops paths
     init_db()
     _verify("MR4KLD", "Brennecke")
     assert _tool("quote_involuntary_rebook",
-                 new_flight="KA340")["error_code"] == "NOT_ENTITLED"
+                 new_flight="JA340")["error_code"] == "NOT_ENTITLED"
     assert _tool("quote_refund")["error_code"] == "NOT_ENTITLED"
 
     # ---------------------------------------------------------- change gate
     init_db()
     _verify("HB9WQM", "Vasquez-Hail")
-    dearer = _tool("quote_change", new_flight="KA509")
+    dearer = _tool("quote_change", new_flight="JA509")
     assert dearer["ok"] and dearer["data"]["change_fee"] == 0.0
     assert dearer["data"]["fare_difference"] == 41.5, dearer
     assert dearer["data"]["total"] == 41.5
-    cheaper = _tool("quote_change", new_flight="KA505")
+    cheaper = _tool("quote_change", new_flight="JA505")
     assert cheaper["data"]["fare_difference"] == 0.0
     assert cheaper["data"]["residual_value_forfeited"] == 76.5, \
         "a cheaper itinerary forfeits the difference"
@@ -1528,7 +1528,7 @@ def _selfcheck() -> None:
     assert _tool("confirm_change",
                  confirmation_token=token)["error_code"] == "TOKEN_ALREADY_USED"
     assert _tool("confirm_change",
-                 confirmation_token="KA-CHG-0000")["error_code"] == "TOKEN_NOT_ISSUED"
+                 confirmation_token="JA-CHG-0000")["error_code"] == "TOKEN_NOT_ISSUED"
 
     # ---------------------------------------------------------- cancellation
     init_db()
@@ -1550,8 +1550,8 @@ def _selfcheck() -> None:
     # ---------------------------------------------------------- silent waivers
     init_db()
     _verify("ZC8MRF", "Ingersoll")            # platinum
-    assert get_elite_status("KM4471902")["free_first_checked_bag"] is True
-    assert get_elite_status("KM4471902")["carry_on_included"] is False
+    assert get_elite_status("JR4471902")["free_first_checked_bag"] is True
+    assert get_elite_status("JR4471902")["carry_on_included"] is False
     first = _tool("get_bag_price", bag_kind="checked_first", touchpoint="booking")
     assert first["data"]["price"] == 0.0 and first["data"]["base_price"] == 30.0
     assert first["data"]["waiver"] == "elite_platinum_first_checked"
@@ -1563,7 +1563,7 @@ def _selfcheck() -> None:
 
     init_db()
     _verify("PW8HJL", "Fournier-Oduya")       # gold: the tier-boundary negative
-    assert get_elite_status("KM3318640")["free_first_checked_bag"] is False
+    assert get_elite_status("JR3318640")["free_first_checked_bag"] is False
     gold = _tool("get_bag_price", bag_kind="checked_first", touchpoint="booking")
     assert gold["data"]["price"] == 30.0 and not gold["data"]["waiver"], gold
 
@@ -1593,7 +1593,7 @@ def _selfcheck() -> None:
     # ---------------------------------------------------------- seats
     init_db()
     _verify("ZC8MRF", "Ingersoll")
-    assert get_seat_map("KA812", "2026-08-18")["open_count"] == 3
+    assert get_seat_map("JA812", "2026-08-18")["open_count"] == 3
     taken = _tool("quote_seat", seat="14C")
     assert taken["error_code"] == "SEAT_TAKEN", taken
     front = _tool("quote_seat", seat="3A")
@@ -1609,13 +1609,13 @@ def _selfcheck() -> None:
     # ---------------------------------------------------------- roam pass
     init_db()
     _verify("JT5QWD", "Ramanathan-Cole")
-    window = _tool("check_pass_availability", miles_number="KM8827104", origin="TPA",
+    window = _tool("check_pass_availability", miles_number="JR8827104", origin="TPA",
                    destination="DEN", travel_date="2026-08-07")
     assert window["error_code"] == "ROAM_WINDOW", window
     assert window["data"]["early_booking_charge"] == 49.0, window
     assert window["data"]["recoverable"] is True, "paying the charge is a way through"
-    priced = _tool("quote_pass_booking", miles_number="KM8827104",
-                   flight_number="KA332", travel_date="2026-08-07")
+    priced = _tool("quote_pass_booking", miles_number="JR8827104",
+                   flight_number="JA332", travel_date="2026-08-07")
     assert priced["ok"] and priced["data"]["base_fare"] == 0.01
     assert priced["data"]["total"] == _money(0.01 + 11.20 + 49.0), priced
     assert priced["data"]["bags_and_seats_included"] is False
@@ -1623,12 +1623,12 @@ def _selfcheck() -> None:
                    confirmation_token=priced["data"]["confirmation_token"])
     assert booked["ok"] and booked["data"]["status"] == "pass_booked", booked
     # a pass-ineligible flight is a final answer, and an account with no pass refuses
-    assert _tool("quote_pass_booking", miles_number="KM8827104",
-                 flight_number="KA334",
+    assert _tool("quote_pass_booking", miles_number="JR8827104",
+                 flight_number="JA334",
                  travel_date="2026-08-07")["error_code"] == "PASS_FLIGHT_UNAVAILABLE"
-    assert _tool("check_pass_availability", miles_number="KM4471902", origin="TPA",
+    assert _tool("check_pass_availability", miles_number="JR4471902", origin="TPA",
                  destination="DEN", travel_date="2026-08-07")["error_code"] == "NO_PASS"
-    assert _tool("check_pass_availability", miles_number="KM8827104", origin="TPA",
+    assert _tool("check_pass_availability", miles_number="JR8827104", origin="TPA",
                  destination="DEN", travel_date="2027-06-01"
                  )["error_code"] == "PASS_EXPIRED"
 
@@ -1641,7 +1641,7 @@ def _selfcheck() -> None:
     assert bag["data"]["total"] == 30.0
     assert _tool("confirm_bag", confirmation_token=bag["data"]["confirmation_token"]
                  )["data"]["status"] == "bag_added"
-    change = _tool("quote_change", new_flight="KA340")
+    change = _tool("quote_change", new_flight="JA340")
     assert change["data"]["change_fee"] == 79.0
     assert change["data"]["total"] == 103.8, change
     single = _tool("quote_payment", amount=30.0)

--- a/industries/travel/tools.json
+++ b/industries/travel/tools.json
@@ -2,7 +2,7 @@
   "tools": [
     {
       "name": "find_reservation",
-      "description": "Find the caller's reservation and check that they are named on it. Call this first, before any other tool. You need the last name plus either the six character confirmation code or the Kestrel Miles number. Last names are matched tolerantly and codes are normalised, so a mis-heard letter still verifies. Three failures are distinct and must be handled differently: NOT_FOUND means try again with better details; NOT_NAMED means the booking exists but this caller may not act on it, so disclose nothing and escalate; CARRIER_CEASED_OPERATIONS means the code belongs to an airline that no longer exists and nothing can be done with it.",
+      "description": "Find the caller's reservation and check that they are named on it. Call this first, before any other tool. You need the last name plus either the six character confirmation code or the Juniper Rewards number. Last names are matched tolerantly and codes are normalised, so a mis-heard letter still verifies. Three failures are distinct and must be handled differently: NOT_FOUND means try again with better details; NOT_NAMED means the booking exists but this caller may not act on it, so disclose nothing and escalate; CARRIER_CEASED_OPERATIONS means the code belongs to an airline that no longer exists and nothing can be done with it.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -16,7 +16,7 @@
           },
           "miles_number": {
             "type": "string",
-            "description": "Kestrel Miles number. Supply this or confirmation_code."
+            "description": "Juniper Rewards number. Supply this or confirmation_code."
           }
         },
         "required": [
@@ -120,7 +120,7 @@
         "properties": {
           "flight_number": {
             "type": "string",
-            "description": "Flight number, for example KA771."
+            "description": "Flight number, for example JA771."
           },
           "date": {
             "type": "string",
@@ -560,13 +560,13 @@
     },
     {
       "name": "get_credit_balance",
-      "description": "Flight credits on a Kestrel Miles account or by confirmation code, with amounts and expiry dates. Read-only. Nothing on any desk can spend a credit on this call, so if the caller wants one applied, say plainly that it cannot be done by phone.",
+      "description": "Flight credits on a Juniper Rewards account or by confirmation code, with amounts and expiry dates. Read-only. Nothing on any desk can spend a credit on this call, so if the caller wants one applied, say plainly that it cannot be done by phone.",
       "inputSchema": {
         "type": "object",
         "properties": {
           "miles_number": {
             "type": "string",
-            "description": "Kestrel Miles number, format KM followed by seven digits, for example KM4471902."
+            "description": "Juniper Rewards number, format JR followed by seven digits, for example JR4471902."
           },
           "confirmation_code": {
             "type": "string",
@@ -598,13 +598,13 @@
     },
     {
       "name": "get_elite_status",
-      "description": "The Kestrel Miles tier on an account and what it includes. Call this before quoting any bag price for a member: some tiers cover the first checked bag for everyone on the reservation and no tier ever covers the carry-on. The tier is never announced to the caller unprompted.",
+      "description": "The Juniper Rewards tier on an account and what it includes. Call this before quoting any bag price for a member: some tiers cover the first checked bag for everyone on the reservation and no tier ever covers the carry-on. The tier is never announced to the caller unprompted.",
       "inputSchema": {
         "type": "object",
         "properties": {
           "miles_number": {
             "type": "string",
-            "description": "Kestrel Miles number, format KM followed by seven digits, for example KM4471902."
+            "description": "Juniper Rewards number, format JR followed by seven digits, for example JR4471902."
           }
         },
         "required": [
@@ -685,7 +685,7 @@
         "properties": {
           "flight_number": {
             "type": "string",
-            "description": "Flight number, for example KA812."
+            "description": "Flight number, for example JA812."
           },
           "date": {
             "type": "string",
@@ -891,7 +891,7 @@
         "properties": {
           "miles_number": {
             "type": "string",
-            "description": "Kestrel Miles number, format KM followed by seven digits, for example KM4471902."
+            "description": "Juniper Rewards number, format JR followed by seven digits, for example JR4471902."
           }
         },
         "required": [
@@ -927,7 +927,7 @@
         "properties": {
           "miles_number": {
             "type": "string",
-            "description": "Kestrel Miles number, format KM followed by seven digits, for example KM4471902."
+            "description": "Juniper Rewards number, format JR followed by seven digits, for example JR4471902."
           },
           "origin": {
             "type": "string",
@@ -978,7 +978,7 @@
         "properties": {
           "miles_number": {
             "type": "string",
-            "description": "Kestrel Miles number, format KM followed by seven digits, for example KM4471902."
+            "description": "Juniper Rewards number, format JR followed by seven digits, for example JR4471902."
           },
           "flight_number": {
             "type": "string",

--- a/run.py
+++ b/run.py
@@ -335,7 +335,7 @@ def _twilio_welcome(industry: str) -> str:
         "healthcare": "Thank you for calling Straus Dermatology.",
         "finance": "Thank you for calling Copperline Credit Union.",
         "legal": "Thank you for calling Halverson and Reed.",
-        "travel": "Thanks for calling Kestrel Air.",
+        "travel": "Thanks for calling Juniper Airlines.",
     }.get(industry, "Hello.")
 
 

--- a/tests/test_tool_server.py
+++ b/tests/test_tool_server.py
@@ -137,11 +137,11 @@ _KNOWN_GOOD_ARGS: dict[str, dict[str, dict[str, Any]]] = {
         "get_disruption_entitlement": {"confirmation_code": "RT2LKD"},
         "get_fare_rules": {"confirmation_code": "RT2LKD"},
         "search_flights": {"origin": "ORD", "destination": "SEA", "earliest_date": "2026-08-09"},
-        "get_flight_status": {"flight_number": "KA771", "date": "2026-08-09"},
-        "get_credit_balance": {"miles_number": "KM2019773"},
-        "get_elite_status": {"miles_number": "KM4471902"},
-        "get_pass_status": {"miles_number": "KM8827104"},
-        "get_seat_map": {"flight_number": "KA812", "date": "2026-08-18"},
+        "get_flight_status": {"flight_number": "JA771", "date": "2026-08-09"},
+        "get_credit_balance": {"miles_number": "JR2019773"},
+        "get_elite_status": {"miles_number": "JR4471902"},
+        "get_pass_status": {"miles_number": "JR8827104"},
+        "get_seat_map": {"flight_number": "JA812", "date": "2026-08-18"},
         "escalate_to_human": {"reason_code": "caller_request"},
     },
 }
@@ -513,13 +513,13 @@ def test_travel_guards_survive_dispatch() -> None:
 
         # the precedence trap: RT2LKD's flight is cancelled, so a voluntary change
         # must be refused rather than quoted a fee
-        disrupted = tool("quote_change", {"new_flight": "KA775"})
+        disrupted = tool("quote_change", {"new_flight": "JA775"})
         assert disrupted["ok"] is False
         assert disrupted["error_code"] == "DISRUPTED_USE_IRROPS", disrupted
         assert disrupted["data"]["recoverable"] is False
 
         # the free rebook is what that traveller is actually owed, at zero
-        rebook = tool("quote_involuntary_rebook", {"new_flight": "KA775"})
+        rebook = tool("quote_involuntary_rebook", {"new_flight": "JA775"})
         assert rebook["ok"] and rebook["data"]["total"] == 0.0, rebook
         token = rebook["data"]["confirmation_token"]
         assert tool("confirm_involuntary_rebook",

--- a/voice-agent-harnesses/nvidia/nemotron-voicechat/adapters/chirp.py
+++ b/voice-agent-harnesses/nvidia/nemotron-voicechat/adapters/chirp.py
@@ -785,15 +785,21 @@ async def _bridge(ws, industry: str) -> None:
                                 text_buf = ""
 
                         elif etype == "response.output_text.delta":
-                            if saw_audio_transcript:
-                                continue
                             delta = event.get("delta") or ""
                             if not delta:
                                 continue
+                            # text_buf is the TOOL-CALL channel. The model emits
+                            # <TOOLCALL> as text and never speaks it, so it MUST
+                            # accumulate even while the audio transcript carries the
+                            # spoken words — `if saw_audio_transcript: continue` skipped
+                            # this line, leaving text_buf empty for the whole call. Only
+                            # the SPOKEN accumulation is suppressed, which is all
+                            # "prefer the audio transcript" was ever for.
                             text_buf += delta
-                            _note(delta)
-                            await _commit(why="text.delta")
-                            await _maybe_hard_tools(turn_spoken, prefix="inf")
+                            if not saw_audio_transcript:
+                                _note(delta)
+                                await _commit(why="text.delta")
+                            await _maybe_hard_tools(text_buf, prefix="inf")
 
                         elif etype == "response.output_audio_transcript.done":
                             tr = (event.get("transcript") or "").strip()

--- a/voice-agent-harnesses/twilio/harness.py
+++ b/voice-agent-harnesses/twilio/harness.py
@@ -159,7 +159,7 @@ _PACK_WELCOME = {
     "healthcare": "Thank you for calling Straus Dermatology.",
     "finance": "Thank you for calling Copperline Credit Union.",
     "legal": "Thank you for calling Halverson and Reed.",
-    "travel": "Thanks for calling Kestrel Air.",
+    "travel": "Thanks for calling Juniper Airlines.",
 }
 
 


### PR DESCRIPTION
Two independent changes. They are together only because they were both in flight; either can be dropped without touching the other.

## 1. Juniper Airlines (travel)

Three live calls mangled the old carrier name. "Kestrel Air" came back as "Kestrelair" once and "Strulair" once, and "Kestrel Miles" read as "Kestrel Myles" every single time.

Two separate causes, and the new name fixes both:

- The `str` cluster in the middle of `Ke-STR-el` collapses. `JU-ni-per` is three open syllables with nothing to lose.
- A one-syllable "Air" glues onto a name ending in a liquid consonant with no audible boundary. "Airlines" is a distinct two-syllable word that cannot silently merge.

The loyalty programme becomes **Juniper Rewards**, which retires the Miles/Myles homophone rather than tolerating it.

The rename is total, because a half-renamed replica is worse than either name:

| Old | New |
|---|---|
| Kestrel Air | Juniper Airlines |
| Kestrel Miles | Juniper Rewards |
| `KA###` | `JA###` (flight numbers) |
| `KM#######` | `JR#######` (member numbers) |
| `KA-CHG-4417` and the other seven | `JA-CHG-4417` … (write-gate tokens) |
| `carrier_iata` `KA` | `JA` |

Prompts, `tools.json`, both SQL files, `tool_server.py`, README, all four docs, the `run.py` and twilio greetings, and the travel assertions in `tests/test_tool_server.py` all move together. The pronunciation note that used to disambiguate "Kestrel" is now a speech rule that earns its place: say the full name in the greeting, "Juniper" alone is fine afterwards, and callers will use the short form too.

No behavioural change. Verified past a search for every old identifier (zero hits for `Kestrel`, `Kestral`, `KA###`, `KM#######`, "format KM") and by running the disruption flow end to end on the renamed fixtures: `JA771` reads cancelled, the entitlement resolves, `JA-RFD-6042` issues and spends once, and `JR4471902` still comes back platinum.

## 2. The VoiceChat bridge was throwing away every tool call

Unrelated to travel, and the reason `main` is currently red.

`tests/test_voicechat_toolcall_channel.py` landed in `b79d20e` without the fix it guards, so it has been failing on `main` ever since. The bug it describes is real and expensive: the `response.output_text.delta` branch opened with `if saw_audio_transcript: continue`, which skipped `text_buf += delta`. VoiceChat is full-duplex so an audio transcript always arrives first, which meant `text_buf` stayed empty for the whole call and every tool the model emitted was discarded. Production run 229790 scored 0 tools across 173 completed calls, which read as "the model cannot call tools" when the bridge was the one dropping them.

`text_buf` is the tool-call channel, not the spoken one. Hosted NVCF emits `<TOOLCALL>[...]</TOOLCALL>` in the text delta and never speaks it, so it has to accumulate even while the audio transcript carries the words. Only the spoken accumulation needed suppressing, which is all "prefer the audio transcript" was ever for, so `_note` and `_commit` stay gated on the flag and the append no longer is.

There was a second bug in the same six lines: it parsed `_maybe_hard_tools(turn_spoken)`, the spoken buffer, which can never contain `<TOOLCALL>` because the model does not say it aloud. It now parses `text_buf`, the buffer the branch actually fills.

**Attribution:** this diff is not mine. It was already sitting uncommitted in the shared working tree from a parallel session. I verified it rather than rewriting it, and committed it because `main` is red without it. Nothing else from that session's working set (`voice-agent-harnesses/gemini/`, `industries/finance/tool_server.py`, `scripts/`) is included here. If whoever wrote it wants to land it themselves, drop this commit and the PR still stands on its own.

## Validation

- `uv run pytest tests/` on this branch: **136 passed, 4 skipped, 0 failed**. All four VoiceChat tests pass, including the behavioural one that streams the real wire format split across deltas and parses a `check_plan_accepted` call back out.
- `python tool_server.py --selfcheck` for travel: 38 tools, 6 agents, 8 write gates, all guards, dispatch parity, prompt structure, zero em or en dashes.
- `openai/realtime-2.1` wiring check passes for travel.
- No live call was run against the renamed pack. The rename touches identifiers only and the fixture flow was exercised directly, but if you want a call before merging, say so.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renames the travel replica to Juniper Airlines to fix TTS mispronunciations and fixes the VoiceChat bridge so tool calls are no longer discarded.

- Old VoiceChat behavior: the bridge skipped accumulating text deltas once an audio transcript arrived and parsed tool calls from the spoken buffer, so every tool call was dropped. New behavior: always accumulate `response.output_text.delta` into the text buffer and parse hard tools from that buffer; only suppress spoken accumulation.

**Juniper Airlines rename (travel)**
- Replaces “Kestrel Air” with “Juniper Airlines” and “Kestrel Miles” with “Juniper Rewards” across prompts, `tools.json`, SQL, `tool_server.py`, docs, tests, and greetings.
- Identifier changes: `KA###` → `JA###`, `KM#######` → `JR#######`, all write-gate tokens `KA-*` → `JA-*`, `carrier_iata` `KA` → `JA`.
- No behavior change; fixtures and self-checks updated and validated end to end.
- Migration: update any external scripts, dashboards, or regexes that match `KA`/`KM` flight or member prefixes or `KA-*` tokens.

**VoiceChat tool-call channel fix**
- Removes the guard that prevented text accumulation after audio transcripts and parses tool calls from the text buffer, not the spoken buffer.
- Restores tool-call delivery; VoiceChat tests that target this path now pass.

<sup>Written for commit df70cc73490cfe689309ad25786d0aa0cdd35fe6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/19?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

