### PR TITLE
Fix Cartesia Line healthcare naming and cyclic handoffs

### DIFF
--- a/tests/test_cartesia_industry.py
+++ b/tests/test_cartesia_industry.py
@@ -37,6 +37,17 @@ def test_line_agent_reads_pack_greeting() -> None:
     assert "BLUEPRINT.get(\"greeting\")" in text
     assert "_introduction" in text
     assert "next_stack" in text
+    assert "_continue_as_handoff" in text
+    assert "is_background=False" in text
+    assert "agent_as_handoff(" not in text
+
+
+def test_chirp_gates_pcm_on_bluejay_speech_events() -> None:
+    text = (FAMILY / "adapters" / "chirp.py").read_text()
+    assert "listening = False" in text
+    assert "if not listening:" in text
+    assert "speech.completed" in text
+    assert 'audio["held"]' in text
 
 
 def test_healthcare_handoff_graph_is_cyclic_but_walkable() -> None:

--- a/tests/test_cartesia_industry.py
+++ b/tests/test_cartesia_industry.py
@@ -1,0 +1,65 @@
+"""Cartesia Line must deploy a per-pack agent, not the /app/industry folder name."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FAMILY = ROOT / "voice-agent-harnesses" / "cartesia"
+if str(FAMILY) not in sys.path:
+    sys.path.insert(0, str(FAMILY))
+
+from harness import industry_name, load_blueprint  # noqa: E402
+
+
+def test_industry_name_uses_INDUSTRY_when_mount_is_app_industry(tmp_path, monkeypatch) -> None:
+    d = tmp_path / "industry"
+    d.mkdir()
+    monkeypatch.setenv("INDUSTRY", "healthcare")
+    monkeypatch.setenv("INDUSTRY_DIR", str(d))
+    assert industry_name(d) == "healthcare"
+
+
+def test_industry_name_from_pack_path(monkeypatch) -> None:
+    monkeypatch.delenv("INDUSTRY", raising=False)
+    assert industry_name(ROOT / "industries" / "healthcare") == "healthcare"
+
+
+def test_healthcare_blueprint_greeting() -> None:
+    bp = load_blueprint(ROOT / "industries" / "healthcare")
+    assert bp["start"] == "reception"
+    assert "Straus Dermatology" in (bp.get("greeting") or "")
+
+
+def test_line_agent_reads_pack_greeting() -> None:
+    text = (FAMILY / "line_agent" / "main.py").read_text()
+    assert "BLUEPRINT.get(\"greeting\")" in text
+    assert "_introduction" in text
+    assert "next_stack" in text
+
+
+def test_healthcare_handoff_graph_is_cyclic_but_walkable() -> None:
+    """reception↔identity↔scheduling loops; Line get_agent must skip back-edges."""
+    bp = load_blueprint(ROOT / "industries" / "healthcare")
+    seen: set[str] = set()
+
+    def walk(name: str, stack: frozenset[str]) -> None:
+        seen.add(name)
+        nxt = stack | {name}
+        for t in bp["agents"][name]["tools"]:
+            if not t.get("handoff"):
+                continue
+            target = t["handoff_to"]
+            if target in nxt:
+                continue
+            walk(target, nxt)
+
+    walk(bp["start"], frozenset())
+    assert "reception" in seen
+    assert "identity" in seen
+    assert "scheduling" in seen
+    assert "billing" in seen
+    assert "cosmetic" in seen
+    assert "coverage" in seen
+    assert "clinical" in seen

--- a/voice-agent-harnesses/cartesia/adapters/chirp.py
+++ b/voice-agent-harnesses/cartesia/adapters/chirp.py
@@ -127,8 +127,12 @@ async def _bridge(ws: WebSocket) -> None:
     agent_span = None
     customer_span = None
     utt: str | None = None
-    audio = {"in": 0, "out": 0}
+    audio = {"in": 0, "out": 0, "held": 0}
     seen_tools: set[str] = set()
+    # Cartesia Ink ends a user turn when media_input stops. Bluejay keeps
+    # sending PCM after speech.completed (hold noise), so Ink never commits
+    # and the Line agent sits silent until the DH asks "are you still there?".
+    listening = False
 
     try:
         async with traced_run(workflow, simulation_result_id=sim_id, model=model):
@@ -147,13 +151,16 @@ async def _bridge(ws: WebSocket) -> None:
 
                 async def inbound() -> None:
                     """Bluejay pcm → media_input; Bluejay speech.* → customer.speech."""
-                    nonlocal customer_span
+                    nonlocal customer_span, listening
                     try:
                         while not end.is_set():
                             msg = await ws.receive()
                             if msg["type"] == "websocket.disconnect":
                                 break
                             if (pcm := msg.get("bytes")):
+                                if not listening:
+                                    audio["held"] += len(pcm)
+                                    continue
                                 audio["in"] += len(pcm)
                                 await agent_ws.send(
                                     json.dumps(
@@ -171,13 +178,26 @@ async def _bridge(ws: WebSocket) -> None:
                             except json.JSONDecodeError:
                                 continue
                             if event.get("type") == "speech.started":
+                                listening = True
                                 end_speech_span(customer_span)
                                 uid = (event.get("data") or {}).get("utterance_id") or f"c_{uuid.uuid4().hex[:12]}"
                                 customer_span = start_speech_span(uid, speaker="customer")
                                 print(f"chirp customer speech.started {uid}", flush=True)
                             elif event.get("type") == "speech.completed":
+                                listening = False
+                                # 200ms of zeros so Ink sees a clean end of speech.
+                                silence = b"\x00" * (16000 * 2 // 5)
+                                await agent_ws.send(
+                                    json.dumps(
+                                        {
+                                            "event": "media_input",
+                                            "media": {"payload": base64.b64encode(silence).decode()},
+                                        }
+                                    )
+                                )
                                 end_speech_span(customer_span)
                                 customer_span = None
+                                print("chirp customer speech.completed", flush=True)
                     finally:
                         end_speech_span(customer_span)
                         customer_span = None
@@ -250,7 +270,10 @@ async def _bridge(ws: WebSocket) -> None:
                 for t in pending:
                     t.cancel()
                 await asyncio.gather(*pending, return_exceptions=True)
-                print(f"chirp audio bytes in={audio['in']} out={audio['out']}", flush=True)
+                print(
+                    f"chirp audio bytes in={audio['in']} out={audio['out']} held={audio['held']}",
+                    flush=True,
+                )
                 for t in done:
                     exc = None if t.cancelled() else t.exception()
                     if exc is not None and not type(exc).__name__.startswith(

--- a/voice-agent-harnesses/cartesia/adapters/chirp.py
+++ b/voice-agent-harnesses/cartesia/adapters/chirp.py
@@ -39,7 +39,7 @@ from harness import (  # noqa: E402
     end_session,
     ensure_agent,
     for_provider,
-    industry_path,
+    industry_name,
     load_blueprint,
     provider_id_from_request,
     run_tool,
@@ -114,7 +114,7 @@ async def chirp(ws: WebSocket) -> None:
 
 async def _bridge(ws: WebSocket) -> None:
     industry, model = STATE["industry"], STATE["model"]
-    workflow = f"mivas-{Path(industry_path(industry)).name}-{model}"
+    workflow = f"mivas-{industry_name(industry)}-{model}"
     sim_id = ws.headers.get("x-simulation-result-id")
     if sim_id:
         print(f"chirp sim_result_id={sim_id}", flush=True)

--- a/voice-agent-harnesses/cartesia/harness.py
+++ b/voice-agent-harnesses/cartesia/harness.py
@@ -66,6 +66,23 @@ def industry_path(name: str | Path) -> Path:
     return (REPO_ROOT / "industries" / name).resolve()
 
 
+def industry_name(industry_dir: str | Path | None = None) -> str:
+    """k8s mounts the pack at /app/industry, so Path.name is not the pack id."""
+    named = os.environ.get("INDUSTRY", "").strip()
+    if named and named != "industry":
+        return named
+    if industry_dir is None:
+        return named or "control-industry"
+    path = Path(industry_dir)
+    if path.is_dir():
+        name = path.resolve().name
+    else:
+        name = path.name
+    if name == "industry":
+        return named or "control-industry"
+    return name or named or "control-industry"
+
+
 def load_blueprint(industry_dir: str | Path) -> dict[str, Any]:
     industry_dir = industry_path(industry_dir)
     blueprint = json.loads((industry_dir / "agent_blueprint.json").read_text())
@@ -82,6 +99,8 @@ def load_blueprint(industry_dir: str | Path) -> dict[str, Any]:
         "start": blueprint["agents"][0]["name"],
         "agents": agents,
         "catalog": catalog,
+        # answering-node opener; without it Line defaults to the repair-shop line
+        "greeting": blueprint.get("greeting"),
     }
 
 
@@ -116,10 +135,10 @@ def _agent_id_for_name(desired: str) -> str | None:
 def export_blueprint(industry_dir: str | Path) -> str:
     """Bake the industry prompts + tool schemas into the deployable directory."""
     bp = load_blueprint(industry_dir)
-    name = Path(bp["industry_dir"]).name
-    (AGENT_DIR / "blueprint.json").write_text(
-        json.dumps({k: v for k, v in bp.items() if k != "industry_dir"}, indent=2) + "\n"
-    )
+    name = industry_name(bp["industry_dir"])
+    payload = {k: v for k, v in bp.items() if k != "industry_dir"}
+    payload["industry"] = name
+    (AGENT_DIR / "blueprint.json").write_text(json.dumps(payload, indent=2) + "\n")
     return name
 
 
@@ -160,6 +179,7 @@ def ensure_agent(industry_dir: str | Path, *, public_url: str | None = None) -> 
     agent_changed = bool(cached_agent_id and agent_id != cached_agent_id)
     created_new = False
     desired = f"mivas-{name}"
+    print(f"cartesia pack={name} desired={desired}", flush=True)
 
     if not agent_id:
         agent_id = _agent_id_for_name(desired)
@@ -173,9 +193,15 @@ def ensure_agent(industry_dir: str | Path, *, public_url: str | None = None) -> 
             created_new = True
 
     env = {"TOOL_BASE_URL": public_url or os.environ.get("PUBLIC_URL", "")}
-    for key in ("OPENAI_API_KEY", "MIVAS_MODEL", "MIVAS_GREETING"):
+    for key in ("OPENAI_API_KEY", "MIVAS_MODEL"):
         if os.environ.get(key):
             env[key] = os.environ[key]
+    greeting = os.environ.get("MIVAS_GREETING", "").strip()
+    if not greeting:
+        baked = json.loads((AGENT_DIR / "blueprint.json").read_text())
+        greeting = (baked.get("greeting") or "").strip()
+    if greeting:
+        env["MIVAS_GREETING"] = greeting
     env = {k: v for k, v in env.items() if v}
     # `env set` rolls a new deployment version (~2 min), so only push on change —
     # by digest, so the cache file never holds the API key it carries.

--- a/voice-agent-harnesses/cartesia/line_agent/main.py
+++ b/voice-agent-harnesses/cartesia/line_agent/main.py
@@ -4,9 +4,10 @@ Line is code-first: this file *is* the agent config, so the industry blueprint
 has to travel with it. `harness.export_blueprint()` writes `blueprint.json` into
 this directory right before every deploy; the deployed runtime has no repo.
 
-Multi-agent is native: the receptionist's `handoff_to_scheduler` is a Line
-handoff tool (`agent_as_handoff`), so the scheduler takes over inside Line with
-no bridge-side routing. `end_call` is Line's built-in.
+Multi-agent is native: the receptionist's transfer tool is a Line
+handoff that replays AgentHandedOff onto the specialist so it generates
+immediately (agent_as_handoff would send CallStarted and wait). `end_call`
+is Line's built-in.
 
 `schedule_appointment` is an `http_server_tool` pointed at the harness webhook
 (`$TOOL_BASE_URL/tool/schedule_appointment?call_id=<ac_*>`) rather than a local function: that
@@ -22,13 +23,15 @@ import os
 from pathlib import Path
 from urllib.parse import quote
 
+from line.agent import call_agent
+from line.events import AgentHandedOff
 from line.llm_agent import (
     LlmAgent,
     LlmConfig,
-    agent_as_handoff,
     end_call,
     http_server_tool,
 )
+from line.llm_agent.tools.utils import ToolType, construct_function_tool
 from line.voice_agent_app import AgentEnv, CallRequest, VoiceAgentApp
 
 BLUEPRINT = json.loads((Path(__file__).parent / "blueprint.json").read_text())
@@ -66,13 +69,40 @@ def _http_tool(name: str, call_id: str | None) -> object:
             "X-Call-Id": str(call_id),
             "X-Cartesia-Call-Id": str(call_id),
         }
+    # Foreground + a short timeout: background http_server_tool (the SDK default)
+    # returns to the LLM only after the webhook finishes, so a slow POST is
+    # dead air until the caller pokes the agent again.
     return http_server_tool(
         name=name,
         description=spec.get("description", name),
         url=_tool_url(name, call_id),
         method="POST",
         request_body_schema=schema,
+        timeout=8.0,
+        is_background=False,
         **extra,
+    )
+
+
+def _continue_as_handoff(agent: LlmAgent, *, name: str, description: str):
+    """handoff that makes the specialist generate immediately.
+
+    Line's agent_as_handoff sends CallStarted to the target. An empty
+    introduction then waits for the next user turn — healthcare sounds like a
+    hang until the DH asks "are you still there?". AgentHandedOff is not
+    CallStarted, so LlmAgent generates from the existing history instead.
+    """
+
+    async def _handoff_fn(ctx, event):
+        kick = event if isinstance(event, AgentHandedOff) else event
+        async for output in call_agent(agent, ctx.turn_env, kick):
+            yield output
+
+    return construct_function_tool(
+        _handoff_fn,
+        name=name,
+        description=description,
+        tool_type=ToolType.HANDOFF,
     )
 
 
@@ -96,7 +126,7 @@ def _build(
                 continue
             target = _build(target_name, call_id, next_stack, cache)
             tools.append(
-                agent_as_handoff(
+                _continue_as_handoff(
                     target,
                     name=t["name"],
                     description=BLUEPRINT["catalog"][t["name"]]["description"],

--- a/voice-agent-harnesses/cartesia/line_agent/main.py
+++ b/voice-agent-harnesses/cartesia/line_agent/main.py
@@ -33,10 +33,9 @@ from line.voice_agent_app import AgentEnv, CallRequest, VoiceAgentApp
 
 BLUEPRINT = json.loads((Path(__file__).parent / "blueprint.json").read_text())
 MODEL = os.getenv("MIVAS_MODEL", "gpt-4.1")
-GREETING = os.getenv("MIVAS_GREETING", "Welcome to Bluejay's Repair Services!")
-# A handoff target is started with CallStarted, so it only speaks if it has an
-# introduction — this is the scheduler prompt's own step 1, verbatim.
-HANDOFF_INTRO = "Hey, when do you want to schedule your repair appointment?"
+_REPAIR_GREETING = "Welcome to Bluejay's Repair Services!"
+_REPAIR_HANDOFF = "Hey, when do you want to schedule your repair appointment?"
+GREETING = os.getenv("MIVAS_GREETING") or BLUEPRINT.get("greeting") or _REPAIR_GREETING
 
 
 def _call_id(call_request: CallRequest | None) -> str | None:
@@ -77,12 +76,25 @@ def _http_tool(name: str, call_id: str | None) -> object:
     )
 
 
-def _build(agent_name: str, call_id: str | None) -> LlmAgent:
+def _build(
+    agent_name: str,
+    call_id: str | None,
+    stack: frozenset[str] = frozenset(),
+    cache: dict[str, LlmAgent] | None = None,
+) -> LlmAgent:
+    """build one Line agent; skip handoff edges that would recurse (healthcare is cyclic)."""
+    cache = cache if cache is not None else {}
+    if agent_name in cache:
+        return cache[agent_name]
     entry = BLUEPRINT["agents"][agent_name]
     tools = []
+    next_stack = stack | {agent_name}
     for t in entry["tools"]:
         if t.get("handoff"):
-            target = _build(t["handoff_to"], call_id)
+            target_name = t["handoff_to"]
+            if target_name in next_stack:
+                continue
+            target = _build(target_name, call_id, next_stack, cache)
             tools.append(
                 agent_as_handoff(
                     target,
@@ -94,15 +106,36 @@ def _build(agent_name: str, call_id: str | None) -> LlmAgent:
             tools.append(end_call)
         else:
             tools.append(_http_tool(t["name"], call_id))
-    return LlmAgent(
+    intro = _introduction(agent_name)
+    config = (
+        LlmConfig(system_prompt=entry["instructions"], introduction=intro)
+        if intro
+        else LlmConfig(system_prompt=entry["instructions"])
+    )
+    agent = LlmAgent(
         model=MODEL,
         api_key=os.environ["OPENAI_API_KEY"],
         tools=tools,
-        config=LlmConfig(
-            system_prompt=entry["instructions"],
-            introduction=GREETING if agent_name == BLUEPRINT["start"] else HANDOFF_INTRO,
-        ),
+        config=config,
     )
+    cache[agent_name] = agent
+    return agent
+
+
+def _introduction(agent_name: str) -> str | None:
+    """start node speaks the pack greeting; handoff targets must not re-greet.
+
+    control-industry has no pack greeting and the scheduler only talks on
+    CallStarted if it has an introduction. Other packs continue mid-stride.
+    """
+    if agent_name == BLUEPRINT["start"]:
+        return GREETING
+    override = os.getenv("MIVAS_HANDOFF_INTRO")
+    if override is not None:
+        return override or None
+    if BLUEPRINT.get("greeting"):
+        return None
+    return _REPAIR_HANDOFF
 
 
 async def get_agent(env: AgentEnv, call_request: CallRequest) -> LlmAgent:


### PR DESCRIPTION
## Summary
- Name the Cartesia Line agent from `$INDUSTRY` so a k8s mount at `/app/industry` deploys `mivas-healthcare` instead of the repair-shop `mivas-industry`.
- Use the pack greeting (Straus) and skip cyclic handoff back-edges so `get_agent` can build the healthcare graph.

Smoke on `cartesia/line × healthcare` is 5/5 on the k8s rubric (utterances + actual tools + traces): https://app.getbluejay.ai/simulations/30468/runs/231221

## Test plan
- [x] `tests/test_cartesia_industry.py` covers mount naming, Straus greeting, and a cyclic walk of the healthcare graph
- [x] Cluster smoke: 5 sequential DHs on sim 30468 / run 231221 all passed utterances, non-empty `actual` tools, and `trace_ids`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cartesia Line agent naming, greetings, cyclic handoffs, and post-speech silence so healthcare speaks and routes correctly. Previously k8s deployed `mivas-industry` with the repair greeting, handoffs waited after transfer, cyclic graphs recursed, and Ink never ended user turns; now we deploy `mivas-<pack>`, greet from the pack, continue handoffs from history, skip back-edges, and gate PCM to close turns.

- Resolve the pack id with `industry_name` from `INDUSTRY` or the pack path; use it in workflow IDs (`mivas-<pack>-<model>`) and bake `industry` into `blueprint.json`.
- Bake `greeting` into `blueprint.json`; `ensure_agent` sources `MIVAS_GREETING` from the pack when unset.
- Introductions: the start node uses the pack greeting; handoff targets do not re-greet unless `MIVAS_HANDOFF_INTRO` forces it; control packs fall back to repair defaults.
- Build agents with per-node caching and skip handoff edges that revisit a node to avoid recursion.
- Replace `agent_as_handoff` with a handoff that emits `AgentHandedOff` so the target generates immediately; run `http_server_tool` in the foreground with `timeout=8.0`.
- In `chirp`, send PCM only between `speech.started` and `speech.completed`; on completion, send 200ms of silence to finalize the turn and track `held` PCM bytes.

**Rollout**
- Set `INDUSTRY` in k8s deployments that mount the pack at `/app/industry` to ensure `mivas-<pack>` names and workflow IDs.
- Remove any hardcoded `MIVAS_GREETING` to use the pack greeting; optionally set `MIVAS_HANDOFF_INTRO` to force handoff introductions.

<sup>Written for commit cc49d1ecddab383e4dba8266faa27b1dcd7fc299. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

