### PR TITLE
Fix AssemblyAI greeting, CHIRP dropouts, and post-handoff silence

### DIFF
--- a/tests/test_assemblyai_greeting.py
+++ b/tests/test_assemblyai_greeting.py
@@ -1,0 +1,66 @@
+"""AssemblyAI must speak the pack greeting and not feed Bluejay hold noise into VAD."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+FAMILY = ROOT / "voice-agent-harnesses" / "assemblyai"
+if str(FAMILY) not in sys.path:
+    sys.path.insert(0, str(FAMILY))
+
+from harness import load_blueprint, session_config  # noqa: E402
+
+
+def test_healthcare_blueprint_greeting() -> None:
+    bp = load_blueprint(ROOT / "industries" / "healthcare")
+    assert bp["start"] == "reception"
+    assert "Straus Dermatology" in (bp.get("greeting") or "")
+
+
+def test_session_config_uses_pack_greeting_when_env_is_empty(monkeypatch) -> None:
+    monkeypatch.setenv("ASSEMBLYAI_GREETING", "")
+    bp = load_blueprint(ROOT / "industries" / "healthcare")
+    cfg = session_config(bp)
+    assert "Straus Dermatology" in cfg["greeting"]
+
+
+def test_session_config_env_override_wins(monkeypatch) -> None:
+    monkeypatch.setenv("ASSEMBLYAI_GREETING", "Hello from env.")
+    bp = load_blueprint(ROOT / "industries" / "healthcare")
+    cfg = session_config(bp)
+    assert cfg["greeting"] == "Hello from env."
+
+
+def test_chirp_gates_pcm_on_bluejay_speech_events() -> None:
+    text = (FAMILY / "adapters" / "chirp.py").read_text()
+    assert "listening = False" in text
+    assert "if not listening:" in text
+    assert "speech.completed" in text
+    assert "session_config(bp)" in text
+
+
+def test_chirp_paces_outbound_pcm() -> None:
+    text = (FAMILY / "adapters" / "chirp.py").read_text()
+    assert "PcmPacer" in text
+    assert "pacer.push" in text
+    assert "wait_until_idle" in text
+    assert "reset_clock" in text
+    pcm = (FAMILY / "pcm.py").read_text()
+    assert "CATCHUP_S = 1.0" in pcm
+
+
+def test_session_config_handoff_update_skips_greeting(monkeypatch) -> None:
+    monkeypatch.setenv("ASSEMBLYAI_GREETING", "")
+    bp = load_blueprint(ROOT / "industries" / "healthcare")
+    cfg = session_config(bp, agent="scheduling", greeting="")
+    assert cfg["greeting"] == ""
+    assert "scheduling" in cfg["system_prompt"].lower() or "schedul" in cfg["system_prompt"].lower()
+
+
+def test_chirp_handoff_rewires_and_ends_human_transfer() -> None:
+    text = (FAMILY / "adapters" / "chirp.py").read_text()
+    assert 'session_config(bp, agent=role, greeting="")' in text
+    assert '"transfer_to_human"' in text
+    assert '{"type": "session.end"}' in text

--- a/voice-agent-harnesses/assemblyai/adapters/chirp.py
+++ b/voice-agent-harnesses/assemblyai/adapters/chirp.py
@@ -19,6 +19,7 @@ from websockets.asyncio.server import serve
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 from harness import call_session, WS_URL, industry_path, load_blueprint, run_tool, session_config, set_call_id  # noqa: E402
+from pcm import PcmPacer  # noqa: E402
 from report import end_speech_span, start_speech_span, traced_run  # noqa: E402
 
 W, R_OUT, R_CHIRP = 2, 24_000, 16_000
@@ -67,6 +68,10 @@ async def _bridge(ws, model: str, industry: str) -> None:
     should_end = False
     ready = asyncio.Event()
     end = asyncio.Event()
+    # Bluejay keeps sending PCM after speech.completed (hold noise). If that
+    # reaches AssemblyAI, VAD never sees a quiet open and the pack greeting
+    # does not play — DH waits ~60s and nudges.
+    listening = False
 
     def _close_utt() -> None:
         nonlocal utt, speech_otel
@@ -85,18 +90,22 @@ async def _bridge(ws, model: str, industry: str) -> None:
         workflow, simulation_result_id=sim_id, model=model
     ), call_session(sim_id):
         async with websockets.connect(f"{WS_URL}?token={key}") as agent_ws:
-            await agent_ws.send(
-                json.dumps({"type": "session.update", "session": session_config(bp)})
-            )
+            cfg = session_config(bp)
+            print(f"chirp greeting={cfg['greeting']!r}", flush=True)
+            await agent_ws.send(json.dumps({"type": "session.update", "session": cfg}))
+            pacer = PcmPacer(ws.send)
+            pacer_task = asyncio.create_task(pacer.run())
 
             async def inbound() -> None:
                 """chirp 16 khz pcm → assemblyai 24 khz base64 input.audio (only once ready)."""
-                nonlocal up, customer_otel
+                nonlocal up, customer_otel, listening
                 try:
                     async for msg in ws:
                         if end.is_set():
                             break
                         if isinstance(msg, bytes) and msg and ready.is_set():
+                            if not listening:
+                                continue
                             pcm, up = audioop.ratecv(msg, W, 1, R_CHIRP, R_OUT, up)
                             if pcm:
                                 await agent_ws.send(
@@ -117,10 +126,23 @@ async def _bridge(ws, model: str, industry: str) -> None:
                         etype = event.get("type")
                         data = event.get("data") or {}
                         if etype == "speech.started":
+                            listening = True
                             _close_customer()
                             uid = data.get("utterance_id") or f"c_{uuid.uuid4().hex[:12]}"
                             customer_otel = start_speech_span(uid, speaker="customer")
                         elif etype == "speech.completed":
+                            listening = False
+                            if ready.is_set():
+                                # 200ms of zeros so AssemblyAI VAD commits the turn.
+                                silence = b"\x00" * (R_OUT * W // 5)
+                                await agent_ws.send(
+                                    json.dumps(
+                                        {
+                                            "type": "input.audio",
+                                            "audio": base64.b64encode(silence).decode(),
+                                        }
+                                    )
+                                )
                             _close_customer()
                 finally:
                     _close_customer()
@@ -138,6 +160,7 @@ async def _bridge(ws, model: str, industry: str) -> None:
                         event = json.loads(raw)
                         etype = event.get("type")
                         if etype == "session.ready":
+                            print("chirp session.ready", flush=True)
                             ready.set()
                         elif etype == "reply.audio":
                             if utt is None:
@@ -148,11 +171,13 @@ async def _bridge(ws, model: str, industry: str) -> None:
                                 base64.b64decode(event["data"]), W, 1, R_OUT, R_CHIRP, down
                             )
                             if pcm:
-                                await ws.send(pcm)
+                                pacer.push(pcm)
                         elif etype == "tool.call":
                             pending.append(event)
                         elif etype == "reply.done":
                             if utt:
+                                await pacer.wait_until_idle()
+                                pacer.reset_clock()
                                 await ws.send(_event("speech.completed", {"utterance_id": utt}))
                                 _close_utt()
                             if pending:
@@ -165,7 +190,17 @@ async def _bridge(ws, model: str, industry: str) -> None:
                                         state,
                                         call_id=call.get("call_id"),
                                     )
-                                    should_end = should_end or stop
+                                    should_end = should_end or stop or call["name"] in (
+                                        "transfer_to_human",
+                                        "end_call",
+                                    )
+                                    role = result.get("role")
+                                    if role:
+                                        print(f"chirp handoff → {role}", flush=True)
+                                        cfg = session_config(bp, agent=role, greeting="")
+                                        await agent_ws.send(
+                                            json.dumps({"type": "session.update", "session": cfg})
+                                        )
                                     await agent_ws.send(
                                         json.dumps(
                                             {
@@ -175,8 +210,7 @@ async def _bridge(ws, model: str, industry: str) -> None:
                                             }
                                         )
                                     )
-                                # let the farewell reply (if any) play before ending
-                            elif should_end:
+                            if should_end:
                                 with contextlib.suppress(Exception):
                                     await agent_ws.send(json.dumps({"type": "session.end"}))
                         elif etype == "session.ended":
@@ -185,6 +219,10 @@ async def _bridge(ws, model: str, industry: str) -> None:
                         elif etype == "session.error":
                             print(f"chirp assemblyai error: {event}", flush=True)
                 finally:
+                    await pacer.wait_until_idle()
+                    pacer.close()
+                    with contextlib.suppress(Exception):
+                        await asyncio.wait_for(pacer_task, timeout=15)
                     if utt:
                         _close_utt()
                     end.set()

--- a/voice-agent-harnesses/assemblyai/harness.py
+++ b/voice-agent-harnesses/assemblyai/harness.py
@@ -58,6 +58,7 @@ def load_blueprint(industry_dir: str | Path) -> dict[str, Any]:
         "start": blueprint["agents"][0]["name"],
         "agents": agents,
         "catalog": catalog,
+        "greeting": (blueprint.get("greeting") or "").strip(),
     }
 
 
@@ -90,25 +91,41 @@ def _tool_decl(spec: dict) -> dict[str, Any]:
 
 
 def session_config(
-    bp: dict[str, Any], *, voice: str | None = None, greeting: str | None = None
+    bp: dict[str, Any],
+    *,
+    voice: str | None = None,
+    greeting: str | None = None,
+    agent: str | None = None,
 ) -> dict[str, Any]:
-    """All blueprint tools are declared up front (config is fixed at connect)."""
+    """All blueprint tools are declared up front (config is fixed at connect).
+
+    Pass greeting="" on a mid-call handoff update so the specialist does not
+    re-play the opening line. Omit greeting to use env / pack / default.
+    """
     tools = []
     seen: set[str] = set()
-    for agent in bp["agents"].values():
-        for t in agent["tools"]:
+    for entry in bp["agents"].values():
+        for t in entry["tools"]:
             name = t["name"]
             if name in seen or name not in bp["catalog"]:
                 continue
             seen.add(name)
             tools.append(_tool_decl(bp["catalog"][name]))
 
-    start = bp["agents"][bp["start"]]
-    # note soft-handoff: other agents' tools are visible; prompt still starts as bp["start"]
-    instruction = start["instructions"] + _multiagent_note(bp)
+    role_name = agent if agent in bp["agents"] else bp["start"]
+    role = bp["agents"][role_name]
+    instruction = role["instructions"] + _multiagent_note(bp)
+    if greeting is not None:
+        spoken = greeting.strip()
+    else:
+        spoken = (
+            os.environ.get("ASSEMBLYAI_GREETING", "").strip()
+            or (bp.get("greeting") or "").strip()
+            or DEFAULT_GREETING
+        )
     return {
         "system_prompt": instruction,
-        "greeting": greeting or os.environ.get("ASSEMBLYAI_GREETING", DEFAULT_GREETING),
+        "greeting": spoken,
         "input": {"format": {"encoding": "audio/pcm"}},
         "output": {
             "voice": voice or os.environ.get("ASSEMBLYAI_VOICE") or "alba",

--- a/voice-agent-harnesses/assemblyai/pcm.py
+++ b/voice-agent-harnesses/assemblyai/pcm.py
@@ -1,0 +1,126 @@
+"""16 kHz s16le pacer for the AssemblyAI ↔ CHIRP bridge.
+
+AssemblyAI `reply.audio` often arrives in bursts. Bluejay timestamps CHIRP
+frames by arrival, so forwarding those bursts compresses the recording and
+scores `agent_audio_dropouts > 0`. Pace outbound at realtime 20 ms.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections.abc import Awaitable, Callable
+
+RATE = 16_000
+WIDTH = 2
+FRAME_MS = 20
+FRAME_BYTES = RATE * WIDTH * FRAME_MS // 1000  # 640
+BYTES_PER_SEC = RATE * WIDTH  # 32_000
+# AssemblyAI TTS chunks can pause >100 ms inside a turn; a short catchup
+# window restarts the clock and dumps the rest as a burst (dropouts).
+CATCHUP_S = 1.0
+
+
+class PcmPacer:
+    """emit 16-bit PCM at realtime, 20 ms frames, from a bursty source."""
+
+    def __init__(
+        self,
+        send: Callable[[bytes], Awaitable[None]],
+        *,
+        frame_bytes: int = FRAME_BYTES,
+        bytes_per_sec: int = BYTES_PER_SEC,
+        catchup_s: float = CATCHUP_S,
+    ) -> None:
+        self._send = send
+        self._frame = frame_bytes
+        self._bps = bytes_per_sec
+        self._catchup_s = catchup_s
+        self._buf = bytearray()
+        self._more = asyncio.Event()
+        self._idle = asyncio.Event()
+        self._idle.set()
+        self._closed = False
+        self._sent = 0
+        self._t0: float | None = None
+
+    def push(self, pcm: bytes) -> None:
+        if not pcm or self._closed:
+            return
+        self._buf.extend(pcm)
+        self._idle.clear()
+        self._more.set()
+
+    def clear(self) -> None:
+        """drop queued frames (barge-in). the next push starts a new clock."""
+        self._buf.clear()
+        self._t0 = None
+        self._sent = 0
+        self._idle.set()
+        self._more.set()
+
+    def close(self) -> None:
+        self._closed = True
+        self._more.set()
+
+    def reset_clock(self) -> None:
+        """start a new realtime clock on the next push (end of an utterance)."""
+        self._t0 = None
+        self._sent = 0
+
+    async def wait_until_idle(self, timeout: float = 30.0) -> None:
+        """block until every full frame pushed so far has been sent."""
+        try:
+            await asyncio.wait_for(self._idle.wait(), timeout)
+        except asyncio.TimeoutError:
+            return
+
+    async def run(self) -> None:
+        try:
+            while True:
+                if len(self._buf) < self._frame:
+                    if self._closed:
+                        await self._flush_tail()
+                        return
+                    self._idle.set()
+                    self._more.clear()
+                    if len(self._buf) >= self._frame:
+                        continue
+                    await self._more.wait()
+                    continue
+                await self._emit_frame()
+        finally:
+            self._idle.set()
+
+    async def _emit_frame(self) -> None:
+        now = time.monotonic()
+        if self._t0 is None:
+            self._t0 = now
+            self._sent = 0
+        due = self._t0 + self._sent / self._bps
+        delay = due - now
+        if delay < -self._catchup_s:
+            self._t0 = now
+            self._sent = 0
+            delay = 0.0
+        if delay > 0:
+            await asyncio.sleep(delay)
+        if not self._buf:
+            return
+        frame = bytes(self._buf[: self._frame])
+        del self._buf[: self._frame]
+        await self._send(frame)
+        self._sent += len(frame)
+        if len(self._buf) < self._frame:
+            self._idle.set()
+
+    async def _flush_tail(self) -> None:
+        if not self._buf:
+            return
+        if len(self._buf) % WIDTH:
+            self._buf.extend(b"\x00" * (WIDTH - len(self._buf) % WIDTH))
+        if len(self._buf) < self._frame:
+            self._buf.extend(b"\x00" * (self._frame - len(self._buf)))
+        await self._send(bytes(self._buf[: self._frame]))
+        self._buf.clear()
+        self._idle.set()


### PR DESCRIPTION
## Summary
- Play the industry pack greeting (empty `ASSEMBLYAI_GREETING` no longer wipes it) and gate inbound PCM on Bluejay speech events so hold noise does not block VAD.
- Pace outbound CHIRP PCM at realtime 20 ms so bursty TTS does not score `agent_audio_dropouts`.
- On handoff, `session.update` to the specialist prompt; hang up after `transfer_to_human` / `end_call` instead of sitting silent until the DH nudges.

Healthcare k8s smoke passed 5/5: https://app.getbluejay.ai/simulations/30473/runs/231397

## Test plan
- [x] `uv run pytest tests/test_assemblyai_greeting.py`
- [x] assemblyai/voice-agent × healthcare k8s smoke 5/5


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the industry pack greeting, prevents CHIRP dropouts from bursty AssemblyAI TTS, and ends calls promptly after handoff. Previously an empty `ASSEMBLYAI_GREETING` erased the pack greeting, Bluejay hold noise kept VAD open (blocking the intro), and we idled post-transfer.

- Greeting resolution: `session_config` now falls back to the pack greeting when `ASSEMBLYAI_GREETING` is empty; set a non-empty env value to override. On handoff, we update with `session_config(bp, agent=role, greeting="")` so the specialist does not replay the opening line.
- Inbound PCM gating: ignore Bluejay audio unless between `speech.started` and `speech.completed`; on completion send 200 ms of silence so AssemblyAI VAD closes the turn and plays the greeting.
- Outbound pacing: use `PcmPacer` to emit 16 kHz, 20 ms frames; wait for idle and reset the clock on `reply.done` to avoid `agent_audio_dropouts`.
- Handoff shutdown: after `transfer_to_human` or `end_call`, send `session.end` immediately instead of waiting.
- Tests cover greeting fallback, PCM gating, pacing, and handoff behavior.

<sup>Written for commit 7ce0316e47fe9f1b7da133025584104a1e0f3bd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/27?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

