### PR TITLE
Post OpenAI trace IDs at hangup so the goal judge can see tools

### DIFF
--- a/voice-agent-harnesses/openai/report.py
+++ b/voice-agent-harnesses/openai/report.py
@@ -20,7 +20,6 @@ import asyncio
 import json
 import logging
 import os
-import time
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Optional
 
@@ -39,15 +38,6 @@ logger = logging.getLogger("mivas.otel")
 
 DEFAULT_OTLP_ENDPOINT = "https://otlp.getbluejay.ai/v1/traces"
 DEFAULT_API_URL = "https://api.getbluejay.ai/v1"
-FINAL_STATUSES = {
-    "COMPLETED",
-    "FAILED",
-    "SYSTEM_ERROR",
-    "NO_ANSWER",
-    "CANCELLED",
-    "NO_CONNECTION",
-}
-EARLY_UPSERT_STATUSES = {"EVALUATING", "EVALUATED", "CONVERSATION_ENDED"}
 _RETRYABLE_UPSERT_STATUS = {429, 500, 502, 503, 504}
 _MAX_ATTR = 4000
 
@@ -172,51 +162,6 @@ def flush() -> None:
             logger.error("otel flush failed: %s", e)
 
 
-def _upsert_stop_statuses() -> set[str]:
-    """Statuses that release the pre-POST wait.
-
-    Default waits for a final status so the link is not wiped mid-eval. With
-    MIVAS_UPSERT_BEFORE_EVAL set, the POST goes out as soon as the conversation ends, so
-    the goal evaluator can see the call's tool calls — at the cost of a possible
-    double-count of execute_tool spans if eval then wipes the link and the relink fires.
-    """
-    if os.environ.get("MIVAS_UPSERT_BEFORE_EVAL", "").strip().lower() in ("1", "true", "yes"):
-        return FINAL_STATUSES | {"CONVERSATION_ENDED"}
-    return FINAL_STATUSES
-
-
-async def _await_terminal_upsert(
-    client: httpx.AsyncClient, simulation_result_id: str, timeout: float = 300.0
-) -> str | None:
-    """Wait for a *final* status, then POST once.
-
-    Not TERMINAL_STATUSES (it counts EVALUATING) and not 18 s: posting mid-eval gets
-    trace_ids wiped, and the relink then re-extracts every execute_tool span on top of
-    the first POST's, so each tool lands twice. Eval needs ~175 s; CHIRP has no session
-    cap, so the wait is free.
-    """
-    deadline = time.monotonic() + timeout
-    key = _api_key()
-    if not key:
-        return None
-    while time.monotonic() < deadline:
-        try:
-            r = await client.get(
-                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
-                headers={"X-API-Key": key},
-            )
-            if r.status_code == 200:
-                st = str(
-                    ((r.json() or {}).get("simulation_result") or {}).get("status")
-                )
-                if st in _upsert_stop_statuses():
-                    return st
-        except Exception:
-            pass
-        await asyncio.sleep(1.0)
-    return None
-
-
 async def _post_update_simulation_result(
     client: httpx.AsyncClient,
     body: dict[str, Any],
@@ -259,86 +204,14 @@ async def _post_update_simulation_result(
     return last
 
 
-async def _relink_after_final(
-    client: httpx.AsyncClient,
-    simulation_result_id: str,
-    body: dict[str, Any],
-    key: str,
-    trace_id: str,
-    early_status: str | None,
-) -> None:
-    """Re-POST trace_ids once the sim leaves EVALUATING (eval can wipe the link).
-
-    Only if it actually got wiped: each POST re-extracts the execute_tool spans and
-    appends them, so a redundant relink double-counts every tool on the timeline.
-    """
-    final: str | None = None
-    linked = False
-    deadline = time.monotonic() + 120.0
-    while time.monotonic() < deadline:
-        try:
-            r = await client.get(
-                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
-                headers={"X-API-Key": key},
-            )
-            if r.status_code == 200:
-                result = (r.json() or {}).get("simulation_result") or {}
-                st = str(result.get("status"))
-                if st in FINAL_STATUSES:
-                    final = st
-                    linked = trace_id in (result.get("trace_ids") or [])
-                    break
-        except Exception:
-            pass
-        await asyncio.sleep(2.0)
-    if final is not None and linked:
-        await asyncio.sleep(float(os.environ.get("MIVAS_RELINK_SETTLE_SECONDS", "15")))
-        try:
-            r = await client.get(
-                f"{_api_url()}/retrieve-simulation-result/{simulation_result_id}",
-                headers={"X-API-Key": key},
-            )
-            if r.status_code == 200:
-                result = (r.json() or {}).get("simulation_result") or {}
-                linked = trace_id in (result.get("trace_ids") or [])
-        except Exception:
-            pass
-        if linked:
-            logger.info(
-                "relink not needed after %s — trace=%s still linked sim=%s final=%s",
-                early_status,
-                trace_id,
-                simulation_result_id,
-                final,
-            )
-            return
-    if final is None:
-        logger.warning(
-            "relink skipped — still not final after early upsert terminal=%s sim=%s",
-            early_status,
-            simulation_result_id,
-        )
-        return
-    r = await _post_update_simulation_result(client, body, key)
-    if r.status_code >= 400:
-        logger.error(
-            "relink after %s FAILED sim=%s %s %s",
-            early_status,
-            simulation_result_id,
-            r.status_code,
-            r.text[:300],
-        )
-    else:
-        logger.info(
-            "relink after %s ok trace=%s sim=%s final=%s",
-            early_status,
-            trace_id,
-            simulation_result_id,
-            final,
-        )
-
-
 async def post_trace_ids(simulation_result_id: str, trace_id: str) -> None:
+    """Link this call's OTel trace after hangup. One POST, no wait for COMPLETED.
+
+    traced_run already force_flush()'d; that only proves the collector accepted the
+    spans. Middleware extracts execute_tool spans with a single ClickHouse read at
+    POST time, so settle first. A second POST re-extracts every span and doubles
+    the tool timeline — do not relink.
+    """
     key = _api_key()
     if not key or not simulation_result_id or not trace_id:
         logger.warning(
@@ -352,33 +225,21 @@ async def post_trace_ids(simulation_result_id: str, trace_id: str) -> None:
         "simulation_result_id": str(simulation_result_id),
         "trace_ids": [trace_id],
     }
+    await asyncio.sleep(float(os.environ.get("MIVAS_UPSERT_SETTLE_SECONDS", "10")))
     async with httpx.AsyncClient(timeout=20) as client:
-        st = await _await_terminal_upsert(client, simulation_result_id)
-        if st in EARLY_UPSERT_STATUSES:
-            # Bluejay extracts execute_tool spans at POST time, so posting the instant the
-            # call ends can beat the OTLP spans into the store and link a trace with no
-            # tools. force_flush() only proves the exporter accepted them. Settle first —
-            # still well inside the window before evaluation reads the tool list.
-            await asyncio.sleep(float(os.environ.get("MIVAS_UPSERT_SETTLE_SECONDS", "10")))
         r = await _post_update_simulation_result(client, body, key)
         if r.status_code >= 400:
             logger.error(
-                "update-simulation-result FAILED %s %s (status=%s)",
+                "update-simulation-result FAILED %s %s",
                 r.status_code,
                 r.text[:300],
-                st,
             )
         else:
             logger.info(
-                "update-simulation-result ok trace=%s sim=%s terminal=%s",
+                "update-simulation-result ok trace=%s sim=%s",
                 trace_id,
                 simulation_result_id,
-                st,
             )
-            if st is None or st in EARLY_UPSERT_STATUSES:
-                await _relink_after_final(
-                    client, simulation_result_id, body, key, trace_id, st
-                )
 
 
 class RealtimeEventTracer:

--- a/voice-agent-harnesses/openai/test_post_trace_ids.py
+++ b/voice-agent-harnesses/openai/test_post_trace_ids.py
@@ -6,9 +6,11 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import report  # noqa: E402
@@ -47,12 +49,14 @@ async def _case_posts_once_after_settle() -> None:
     async def _sleep(seconds: float) -> None:
         sleeps.append(seconds)
 
-    report._api_key = lambda: "test-key"  # type: ignore[method-assign]
-    report._api_url = lambda: "https://api.example.test/v1"  # type: ignore[method-assign]
-    report.httpx.AsyncClient = lambda timeout=20: client  # type: ignore[method-assign]
-    report.asyncio.sleep = _sleep  # type: ignore[method-assign]
-
-    await report.post_trace_ids("737917", "abc123")
+    with (
+        patch.object(report, "_api_key", return_value="test-key"),
+        patch.object(report, "_api_url", return_value="https://api.example.test/v1"),
+        patch.object(report.httpx, "AsyncClient", return_value=client),
+        patch.object(report.asyncio, "sleep", _sleep),
+        patch.dict(os.environ, {"MIVAS_UPSERT_SETTLE_SECONDS": "10"}),
+    ):
+        await report.post_trace_ids("737917", "abc123")
 
     assert sleeps == [10.0], sleeps
     assert client.gets == [], f"must not poll status before POST: {client.gets}"
@@ -66,9 +70,11 @@ async def _case_posts_once_after_settle() -> None:
 
 async def _case_skips_without_key() -> None:
     client = _FakeClient()
-    report._api_key = lambda: None  # type: ignore[method-assign]
-    report.httpx.AsyncClient = lambda timeout=20: client  # type: ignore[method-assign]
-    await report.post_trace_ids("737917", "abc123")
+    with (
+        patch.object(report, "_api_key", return_value=None),
+        patch.object(report.httpx, "AsyncClient", return_value=client),
+    ):
+        await report.post_trace_ids("737917", "abc123")
     assert client.posts == []
 
 

--- a/voice-agent-harnesses/openai/test_post_trace_ids.py
+++ b/voice-agent-harnesses/openai/test_post_trace_ids.py
@@ -1,0 +1,82 @@
+"""post_trace_ids must settle, POST once, and never wait for COMPLETED or relink.
+
+    uv run python voice-agent-harnesses/openai/test_post_trace_ids.py
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import report  # noqa: E402
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int = 200, text: str = "{}") -> None:
+        self.status_code = status_code
+        self.text = text
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.posts: list[dict[str, Any]] = []
+        self.gets: list[str] = []
+
+    async def post(self, url: str, json: dict[str, Any], headers: dict[str, str]) -> _FakeResponse:
+        self.posts.append({"url": url, "json": json, "headers": headers})
+        return _FakeResponse()
+
+    async def get(self, url: str, headers: dict[str, str]) -> _FakeResponse:
+        self.gets.append(url)
+        return _FakeResponse()
+
+    async def __aenter__(self) -> _FakeClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+
+async def _case_posts_once_after_settle() -> None:
+    sleeps: list[float] = []
+    client = _FakeClient()
+
+    async def _sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+
+    report._api_key = lambda: "test-key"  # type: ignore[method-assign]
+    report._api_url = lambda: "https://api.example.test/v1"  # type: ignore[method-assign]
+    report.httpx.AsyncClient = lambda timeout=20: client  # type: ignore[method-assign]
+    report.asyncio.sleep = _sleep  # type: ignore[method-assign]
+
+    await report.post_trace_ids("737917", "abc123")
+
+    assert sleeps == [10.0], sleeps
+    assert client.gets == [], f"must not poll status before POST: {client.gets}"
+    assert len(client.posts) == 1, client.posts
+    assert client.posts[0]["url"].endswith("/update-simulation-result")
+    assert client.posts[0]["json"] == {
+        "simulation_result_id": "737917",
+        "trace_ids": ["abc123"],
+    }
+
+
+async def _case_skips_without_key() -> None:
+    client = _FakeClient()
+    report._api_key = lambda: None  # type: ignore[method-assign]
+    report.httpx.AsyncClient = lambda timeout=20: client  # type: ignore[method-assign]
+    await report.post_trace_ids("737917", "abc123")
+    assert client.posts == []
+
+
+def main() -> None:
+    asyncio.run(_case_posts_once_after_settle())
+    asyncio.run(_case_skips_without_key())
+    print("ok")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- The OpenAI harness waited for `COMPLETED` before POSTing `trace_ids` to `update-simulation-result`, so the goal judge graded an empty tool record and then the tools appeared on a later retrieve.
- After hangup it now flushes OTLP (already), waits 10s for ClickHouse ingest (`MIVAS_UPSERT_SETTLE_SECONDS`), and POSTs `trace_ids` once. No status poll, no relink (a second POST double-counts `execute_tool` spans).
- Pair with the evals PR that stops `test_results` from overwriting mid-eval `trace_ids`. Live check: a few known D1 cases (e.g. T1-E1) after deploy — judge reasoning should mention the tools, and `trace_ids` should still be present after `COMPLETED`.

## Test plan
- [x] `uv run python voice-agent-harnesses/openai/test_post_trace_ids.py`
- [ ] Merge + deploy `openai/realtime-2.1:customer-support` (do not roll out while a run is in flight)
- [ ] Queue 3–5 known empty-tool failures (T1-E1 / clones), not a full 66
- [ ] Confirm `goal_reasoning` no longer says “no tool calls” on cases that have `get_fee` / `get_policy` on the result
- [ ] Confirm `trace_ids` still present on retrieve after `COMPLETED` (needs the evals companion PR)
- [ ] If that holds, follow-up PR for the other harnesses


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Posts OpenAI trace IDs immediately after hangup so the goal judge sees tool calls. Previously we waited for COMPLETED and sometimes relinked, which produced empty tool lists and double-counted tools.

- Remove terminal-status polling and relink; `report.py` now sleeps `MIVAS_UPSERT_SETTLE_SECONDS` (default 10s) and POSTs `trace_ids` once to `update-simulation-result`.
- Rely on existing OTLP flush; the settle wait lets ClickHouse ingest so tool spans exist at POST.
- Add `voice-agent-harnesses/openai/test_post_trace_ids.py` to assert one POST, no status GETs, and key guard; tests patch `asyncio`, `httpx`, and `MIVAS_UPSERT_SETTLE_SECONDS` via `unittest.mock` to avoid leaks between cases.

**Rollout**
- Do not deploy while a run is in flight.
- Spot-check known empty-tool cases; judge reasoning should mention tools and `trace_ids` should persist after COMPLETED.
- Ensure the companion evals change preserves `trace_ids` during evaluation.

<sup>Written for commit d40ff9b5ce4cac2fa0d245e24be17704a1b6c36a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/30?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

