### PR TITLE
Stop scoring healthcare prompt-adherence with glyph substrings

### DIFF
--- a/industries/healthcare/tasks/C1-E1-BG/task.json
+++ b/industries/healthcare/tasks/C1-E1-BG/task.json
@@ -23,7 +23,6 @@
       "value": "Dana Whitfield"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [
     "transfer_to_coverage"
   ],

--- a/industries/healthcare/tasks/C1-E1-SIG/task.json
+++ b/industries/healthcare/tasks/C1-E1-SIG/task.json
@@ -23,7 +23,6 @@
       "value": "Dana Whitfield"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [
     "transfer_to_coverage"
   ],

--- a/industries/healthcare/tasks/C1-E1/task.json
+++ b/industries/healthcare/tasks/C1-E1/task.json
@@ -23,7 +23,6 @@
       "value": "Aetna"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [
     "transfer_to_coverage"
   ],

--- a/industries/healthcare/tasks/C1-E2/task.json
+++ b/industries/healthcare/tasks/C1-E2/task.json
@@ -19,7 +19,6 @@
       "value": "10016"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [],
   "exp_tool_calls": [
     {

--- a/industries/healthcare/tasks/C1-E3/task.json
+++ b/industries/healthcare/tasks/C1-E3/task.json
@@ -19,9 +19,6 @@
       "value": "Terrell Baines"
     }
   ],
-  "prompt_adherence_substrs": [
-    "We don't accept Medicaid at any of our offices"
-  ],
   "exp_handoff_path": [
     "transfer_to_coverage"
   ],

--- a/industries/healthcare/tasks/C1-H1/exp_db_state.json
+++ b/industries/healthcare/tasks/C1-H1/exp_db_state.json
@@ -178,15 +178,6 @@
       "name": "Dr. Luis Ruiz"
     }
   ],
-  "tool_events": [
-    {
-      "id": 1,
-      "kind": "sms",
-      "payload": {
-        "mobile_e164": "+17185550191",
-        "template_id": "appointment_confirmation"
-      }
-    }
-  ],
+  "tool_events": [],
   "waitlist": []
 }

--- a/industries/healthcare/tasks/C1-H1/task.json
+++ b/industries/healthcare/tasks/C1-H1/task.json
@@ -31,12 +31,6 @@
       "value": "718-555-0191"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Ronald Mercer",
-    "July 19, 1961",
-    "7185550191",
-    "2nd floor"
-  ],
   "exp_handoff_path": [
     "transfer_to_scheduling"
   ],
@@ -100,19 +94,6 @@
         "ok": true,
         "data": {
           "status": "booked"
-        }
-      }
-    },
-    {
-      "name": "send_sms",
-      "parameters": {
-        "template_id": "appointment_confirmation",
-        "mobile_e164": "+17185550191"
-      },
-      "output": {
-        "ok": true,
-        "data": {
-          "sent": true
         }
       }
     }
@@ -308,15 +289,6 @@
       }
     ],
     "waitlist": [],
-    "tool_events": [
-      {
-        "id": 1,
-        "kind": "sms",
-        "payload": {
-          "template_id": "appointment_confirmation",
-          "mobile_e164": "+17185550191"
-        }
-      }
-    ]
+    "tool_events": []
   }
 }

--- a/industries/healthcare/tasks/C1-H2/task.json
+++ b/industries/healthcare/tasks/C1-H2/task.json
@@ -1,6 +1,6 @@
 {
   "task_name": "C1-H2: Hours, directions, then an urgent rash booking",
-  "intent": "You are a new patient calling from the subway and you are a little flustered. Start by asking what time the Park Avenue office opens and how you get there on the train, and ask them to text you the address so you have it. After that, tell them the real reason you called: a rash on your side is spreading and painful and you need the soonest visit they have. Take the earliest time, confirm it, then thank them and end the call.",
+  "intent": "You are a new patient calling from the subway and you are a little flustered. Start by asking what time the Park Avenue office opens and how you get there on the train, and ask them to text you the address so you have it. If they ask whether you want that address by text, say yes — you do want it. After that, tell them the real reason you called: a rash on your side is spreading and painful and you need the soonest visit they have. Take the earliest time, confirm it, then thank them and end the call.",
   "traits": [
     {
       "trait_name": "zip",
@@ -30,12 +30,6 @@
       "trait_name": "preferred_office",
       "value": "Park Avenue"
     }
-  ],
-  "prompt_adherence_substrs": [
-    "Owen Castellanos",
-    "January 30, 1957",
-    "2125550196",
-    "4th floor"
   ],
   "exp_handoff_path": [
     "transfer_to_scheduling"
@@ -116,7 +110,14 @@
     }
   ],
   "behaviors": {},
-  "scripted_responses": {},
+  "scripted_responses": [
+    {
+      "match_type": "context",
+      "match_phrase": "asks whether you want a text, SMS, or the address sent to your phone. NOT when asking for your mobile number itself, NOT when offering a confirmation text for the appointment after it is booked.",
+      "response_type": "phrase",
+      "response_value": "Yes, please text me the address."
+    }
+  ],
   "customer_name": "Owen Castellanos",
   "customer_available_tools": {},
   "metadata": {

--- a/industries/healthcare/tasks/C1-H3/exp_db_state.json
+++ b/industries/healthcare/tasks/C1-H3/exp_db_state.json
@@ -178,15 +178,6 @@
       "name": "Dr. Luis Ruiz"
     }
   ],
-  "tool_events": [
-    {
-      "id": 1,
-      "kind": "sms",
-      "payload": {
-        "mobile_e164": "+12125550193",
-        "template_id": "appointment_confirmation"
-      }
-    }
-  ],
+  "tool_events": [],
   "waitlist": []
 }

--- a/industries/healthcare/tasks/C1-H3/task.json
+++ b/industries/healthcare/tasks/C1-H3/task.json
@@ -31,14 +31,6 @@
       "value": "10016"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Gwen Okoro",
-    "October 11, 1984",
-    "2125550193",
-    "4th floor",
-    "I can't confirm that plan",
-    "flag it for benefits verification"
-  ],
   "exp_handoff_path": [
     "transfer_to_coverage",
     "transfer_to_scheduling"
@@ -93,19 +85,6 @@
         "ok": true,
         "data": {
           "status": "booked"
-        }
-      }
-    },
-    {
-      "name": "send_sms",
-      "parameters": {
-        "template_id": "appointment_confirmation",
-        "mobile_e164": "+12125550193"
-      },
-      "output": {
-        "ok": true,
-        "data": {
-          "sent": true
         }
       }
     }
@@ -301,15 +280,6 @@
       }
     ],
     "waitlist": [],
-    "tool_events": [
-      {
-        "id": 1,
-        "kind": "sms",
-        "payload": {
-          "template_id": "appointment_confirmation",
-          "mobile_e164": "+12125550193"
-        }
-      }
-    ]
+    "tool_events": []
   }
 }

--- a/industries/healthcare/tasks/C1-M1/task.json
+++ b/industries/healthcare/tasks/C1-M1/task.json
@@ -31,12 +31,6 @@
       "value": "Park Avenue"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Hal Brenner",
-    "December 2, 1975",
-    "2125550194",
-    "4th floor"
-  ],
   "exp_handoff_path": [
     "transfer_to_scheduling"
   ],

--- a/industries/healthcare/tasks/C1-M2/task.json
+++ b/industries/healthcare/tasks/C1-M2/task.json
@@ -31,12 +31,6 @@
       "value": "Brooklyn Heights"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Priya Raghunathan",
-    "February 27, 1990",
-    "7185550192",
-    "2nd floor"
-  ],
   "exp_handoff_path": [
     "transfer_to_coverage",
     "transfer_to_scheduling"

--- a/industries/healthcare/tasks/C1-M3/task.json
+++ b/industries/healthcare/tasks/C1-M3/task.json
@@ -27,12 +27,6 @@
       "value": "10016"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Bernadette Kohl",
-    "April 22, 1993",
-    "2125550197",
-    "Stop antihistamines seven days before"
-  ],
   "exp_handoff_path": [
     "transfer_to_scheduling"
   ],

--- a/industries/healthcare/tasks/C2-E1-BG/task.json
+++ b/industries/healthcare/tasks/C2-E1-BG/task.json
@@ -7,7 +7,6 @@
       "value": "Nora Ellison"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [],
   "exp_tool_calls": [
     {

--- a/industries/healthcare/tasks/C2-E1-SIG/task.json
+++ b/industries/healthcare/tasks/C2-E1-SIG/task.json
@@ -7,7 +7,6 @@
       "value": "Nora Ellison"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [],
   "exp_tool_calls": [
     {

--- a/industries/healthcare/tasks/C2-E1/task.json
+++ b/industries/healthcare/tasks/C2-E1/task.json
@@ -7,7 +7,6 @@
       "value": "Nora Ellison"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [],
   "exp_tool_calls": [
     {

--- a/industries/healthcare/tasks/C2-E2/task.json
+++ b/industries/healthcare/tasks/C2-E2/task.json
@@ -7,7 +7,6 @@
       "value": "Ibrahim Cole"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [],
   "exp_tool_calls": [
     {

--- a/industries/healthcare/tasks/C2-E3/task.json
+++ b/industries/healthcare/tasks/C2-E3/task.json
@@ -7,7 +7,6 @@
       "value": "Helen Cho"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [],
   "exp_tool_calls": [],
   "behaviors": {},

--- a/industries/healthcare/tasks/C2-H1/task.json
+++ b/industries/healthcare/tasks/C2-H1/task.json
@@ -35,13 +35,6 @@
       "value": "Park Avenue"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Jordan Lee",
-    "April twelfth, nineteen ninety",
-    "did I get that right?",
-    "missed-visit",
-    "Moving it instead is free"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_scheduling"
@@ -135,12 +128,6 @@
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
       "response_type": "phrase",
       "response_value": "Jordan Lee. My date of birth is April twelfth, nineteen ninety."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
     }
   ],
   "customer_name": "Jordan Lee",

--- a/industries/healthcare/tasks/C2-H2/exp_db_state.json
+++ b/industries/healthcare/tasks/C2-H2/exp_db_state.json
@@ -178,15 +178,6 @@
       "name": "Dr. Luis Ruiz"
     }
   ],
-  "tool_events": [
-    {
-      "id": 1,
-      "kind": "sms",
-      "payload": {
-        "mobile_e164": "+17185550166",
-        "template_id": "appointment_confirmation"
-      }
-    }
-  ],
+  "tool_events": [],
   "waitlist": []
 }

--- a/industries/healthcare/tasks/C2-H2/task.json
+++ b/industries/healthcare/tasks/C2-H2/task.json
@@ -31,12 +31,6 @@
       "value": "existing"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Leo Park",
-    "March twenty-second, two thousand sixteen",
-    "did I get that right?",
-    "30-minute"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_scheduling"
@@ -84,19 +78,6 @@
           "loc_brooklyn_heights"
         ]
       }
-    },
-    {
-      "name": "send_sms",
-      "parameters": {
-        "template_id": "appointment_confirmation",
-        "mobile_e164": "+17185550166"
-      },
-      "output": {
-        "ok": true,
-        "data": {
-          "sent": true
-        }
-      }
     }
   ],
   "behaviors": {},
@@ -106,12 +87,6 @@
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
       "response_type": "phrase",
       "response_value": "Leo Park. My date of birth is March twenty-second, two thousand sixteen."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
     }
   ],
   "customer_name": "David Park",
@@ -303,15 +278,6 @@
       }
     ],
     "waitlist": [],
-    "tool_events": [
-      {
-        "id": 1,
-        "kind": "sms",
-        "payload": {
-          "template_id": "appointment_confirmation",
-          "mobile_e164": "+17185550166"
-        }
-      }
-    ]
+    "tool_events": []
   }
 }

--- a/industries/healthcare/tasks/C2-H3/exp_db_state.json
+++ b/industries/healthcare/tasks/C2-H3/exp_db_state.json
@@ -177,14 +177,6 @@
         "fee_cents": 12500,
         "patient_id": "pat_maria_alvarez"
       }
-    },
-    {
-      "id": 2,
-      "kind": "sms",
-      "payload": {
-        "mobile_e164": "+12125550133",
-        "template_id": "appointment_confirmation"
-      }
     }
   ],
   "waitlist": [

--- a/industries/healthcare/tasks/C2-H3/task.json
+++ b/industries/healthcare/tasks/C2-H3/task.json
@@ -31,13 +31,6 @@
       "value": "10016"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Maria Alvarez",
-    "June thirtieth, nineteen seventy-two",
-    "did I get that right?",
-    "missed-visit",
-    "Moving it instead is free"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_scheduling"
@@ -114,19 +107,6 @@
         "earliest": "2026-08-24T00:00:00",
         "latest": "2026-09-30T23:59:59"
       }
-    },
-    {
-      "name": "send_sms",
-      "parameters": {
-        "template_id": "appointment_confirmation",
-        "mobile_e164": "+12125550133"
-      },
-      "output": {
-        "ok": true,
-        "data": {
-          "sent": true
-        }
-      }
     }
   ],
   "behaviors": {},
@@ -136,12 +116,6 @@
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
       "response_type": "phrase",
       "response_value": "Maria Alvarez. My date of birth is June thirtieth, nineteen seventy-two."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
     }
   ],
   "customer_name": "Maria Alvarez",
@@ -342,14 +316,6 @@
           "appointment_id": 2,
           "fee_cents": 12500,
           "cancellation_reason_code": "patient_request"
-        }
-      },
-      {
-        "id": 2,
-        "kind": "sms",
-        "payload": {
-          "template_id": "appointment_confirmation",
-          "mobile_e164": "+12125550133"
         }
       }
     ]

--- a/industries/healthcare/tasks/C2-M1/task.json
+++ b/industries/healthcare/tasks/C2-M1/task.json
@@ -35,11 +35,6 @@
       "value": "W123456789"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Jordan Lee",
-    "April twelfth, nineteen ninety",
-    "did I get that right?"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_scheduling"
@@ -89,12 +84,6 @@
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
       "response_type": "phrase",
       "response_value": "Jordan Lee. My date of birth is April twelfth, nineteen ninety."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
     }
   ],
   "customer_name": "Jordan Lee",

--- a/industries/healthcare/tasks/C2-M2/task.json
+++ b/industries/healthcare/tasks/C2-M2/task.json
@@ -31,11 +31,6 @@
       "value": "407-555-0155"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Alice Romano",
-    "September eighth, nineteen ninety-five",
-    "did I get that right?"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_scheduling"
@@ -85,12 +80,6 @@
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
       "response_type": "phrase",
       "response_value": "Alice Romano. My date of birth is September eighth, nineteen ninety-five."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
     }
   ],
   "customer_name": "Alice Romano",

--- a/industries/healthcare/tasks/C2-M3/task.json
+++ b/industries/healthcare/tasks/C2-M3/task.json
@@ -31,12 +31,6 @@
       "value": "Sam Nguyen"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Sam Nguyen",
-    "November third, nineteen eighty-five",
-    "did I get that right?",
-    "2nd floor"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_scheduling"
@@ -97,12 +91,6 @@
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
       "response_type": "phrase",
       "response_value": "Sam Nguyen. My date of birth is November third, nineteen eighty-five."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
     }
   ],
   "customer_name": "Sam Nguyen",

--- a/industries/healthcare/tasks/C3-E1-BG/task.json
+++ b/industries/healthcare/tasks/C3-E1-BG/task.json
@@ -15,7 +15,6 @@
       "value": "Ellen Sturgis"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [
     "transfer_to_coverage"
   ],

--- a/industries/healthcare/tasks/C3-E1-SIG/task.json
+++ b/industries/healthcare/tasks/C3-E1-SIG/task.json
@@ -15,7 +15,6 @@
       "value": "UnitedHealthcare"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [
     "transfer_to_coverage"
   ],

--- a/industries/healthcare/tasks/C3-E1/task.json
+++ b/industries/healthcare/tasks/C3-E1/task.json
@@ -15,7 +15,6 @@
       "value": "Brooklyn Heights"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [
     "transfer_to_coverage"
   ],

--- a/industries/healthcare/tasks/C3-E2/task.json
+++ b/industries/healthcare/tasks/C3-E2/task.json
@@ -15,9 +15,6 @@
       "value": "Brooklyn Heights"
     }
   ],
-  "prompt_adherence_substrs": [
-    "We don't accept Medicaid at any of our offices"
-  ],
   "exp_handoff_path": [
     "transfer_to_coverage"
   ],

--- a/industries/healthcare/tasks/C3-E3/task.json
+++ b/industries/healthcare/tasks/C3-E3/task.json
@@ -15,7 +15,6 @@
       "value": "Aetna"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [
     "transfer_to_coverage"
   ],

--- a/industries/healthcare/tasks/C3-H1/exp_db_state.json
+++ b/industries/healthcare/tasks/C3-H1/exp_db_state.json
@@ -178,15 +178,6 @@
       "name": "Dr. Luis Ruiz"
     }
   ],
-  "tool_events": [
-    {
-      "id": 1,
-      "kind": "sms",
-      "payload": {
-        "mobile_e164": "+12125550182",
-        "template_id": "appointment_confirmation"
-      }
-    }
-  ],
+  "tool_events": [],
   "waitlist": []
 }

--- a/industries/healthcare/tasks/C3-H1/task.json
+++ b/industries/healthcare/tasks/C3-H1/task.json
@@ -35,14 +35,6 @@
       "value": "Park Avenue"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Simone Ardelle",
-    "November 16, 1987",
-    "2125550182",
-    "4th floor",
-    "I can't confirm that plan",
-    "flag it for benefits verification"
-  ],
   "exp_handoff_path": [
     "transfer_to_coverage",
     "transfer_to_scheduling"
@@ -97,19 +89,6 @@
         "ok": true,
         "data": {
           "status": "booked"
-        }
-      }
-    },
-    {
-      "name": "send_sms",
-      "parameters": {
-        "template_id": "appointment_confirmation",
-        "mobile_e164": "+12125550182"
-      },
-      "output": {
-        "ok": true,
-        "data": {
-          "sent": true
         }
       }
     }
@@ -305,15 +284,6 @@
       }
     ],
     "waitlist": [],
-    "tool_events": [
-      {
-        "id": 1,
-        "kind": "sms",
-        "payload": {
-          "template_id": "appointment_confirmation",
-          "mobile_e164": "+12125550182"
-        }
-      }
-    ]
+    "tool_events": []
   }
 }

--- a/industries/healthcare/tasks/C3-H2/task.json
+++ b/industries/healthcare/tasks/C3-H2/task.json
@@ -1,6 +1,6 @@
 {
   "task_name": "C3-H2: Out-of-pocket cost without a member ID",
-  "intent": "You are trying to decide whether you can even afford to come in. Ask what a visit will cost out of pocket at Park Avenue. You do not have your insurance card with you and you cannot get it during this call. Ask twice for a rough number anyway \u2014 you just want a ballpark. After that, say you still want to be booked for a rash and you want the office address texted to you. Take the first time they offer, confirm it, then thank them and end the call.",
+  "intent": "You are trying to decide whether you can even afford to come in. Ask what a visit will cost out of pocket at Park Avenue. You do not have your insurance card with you and you cannot get it during this call. Ask twice for a rough number anyway — you just want a ballpark. After that, say you still want to be booked for a rash and you want the office address texted to you. If they ask whether you want that address by text, say yes. Take the first time they offer, confirm it, then thank them and end the call.",
   "traits": [
     {
       "trait_name": "full_name",
@@ -30,13 +30,6 @@
       "trait_name": "preferred_office",
       "value": "Park Avenue"
     }
-  ],
-  "prompt_adherence_substrs": [
-    "Aggie Trumbull",
-    "May 9, 1978",
-    "2125550176",
-    "4th floor",
-    "will call you back"
   ],
   "exp_handoff_path": [
     "transfer_to_coverage",
@@ -118,7 +111,14 @@
     }
   ],
   "behaviors": {},
-  "scripted_responses": {},
+  "scripted_responses": [
+    {
+      "match_type": "context",
+      "match_phrase": "asks whether you want a text, SMS, or the address sent to your phone. NOT when asking for your mobile number itself, NOT when offering a confirmation text for the appointment after it is booked.",
+      "response_type": "phrase",
+      "response_value": "Yes, please text me the address."
+    }
+  ],
   "customer_name": "Aggie Trumbull",
   "customer_available_tools": {},
   "metadata": {

--- a/industries/healthcare/tasks/C3-H3/task.json
+++ b/industries/healthcare/tasks/C3-H3/task.json
@@ -35,13 +35,6 @@
       "value": "Jordan Lee"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Jordan Lee",
-    "April twelfth, nineteen ninety",
-    "did I get that right?",
-    "C445566778",
-    "4th floor"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_coverage",
@@ -134,12 +127,6 @@
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
       "response_type": "phrase",
       "response_value": "Jordan Lee. My date of birth is April twelfth, nineteen ninety."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
     },
     {
       "match_type": "context",

--- a/industries/healthcare/tasks/C3-M1/task.json
+++ b/industries/healthcare/tasks/C3-M1/task.json
@@ -35,12 +35,6 @@
       "value": "existing"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Jordan Lee",
-    "April twelfth, nineteen ninety",
-    "did I get that right?",
-    "W123456789"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_coverage"
@@ -91,12 +85,6 @@
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
       "response_type": "phrase",
       "response_value": "Jordan Lee. My date of birth is April twelfth, nineteen ninety."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
     }
   ],
   "customer_name": "Jordan Lee",

--- a/industries/healthcare/tasks/C3-M2/task.json
+++ b/industries/healthcare/tasks/C3-M2/task.json
@@ -35,12 +35,6 @@
       "value": "existing"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Jordan Lee",
-    "April twelfth, nineteen ninety",
-    "did I get that right?",
-    "C445566778"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_coverage"
@@ -81,12 +75,6 @@
   ],
   "behaviors": {},
   "scripted_responses": [
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
-    },
     {
       "match_type": "context",
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",

--- a/industries/healthcare/tasks/C3-M3/task.json
+++ b/industries/healthcare/tasks/C3-M3/task.json
@@ -31,12 +31,6 @@
       "value": "Windermere"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Walter Prinz",
-    "August 3, 1952",
-    "4075550181",
-    "Ground floor"
-  ],
   "exp_handoff_path": [
     "transfer_to_coverage",
     "transfer_to_scheduling"

--- a/industries/healthcare/tasks/C4-E1-BG/task.json
+++ b/industries/healthcare/tasks/C4-E1-BG/task.json
@@ -11,7 +11,6 @@
       "value": "Park Avenue"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [
     "transfer_to_cosmetic"
   ],

--- a/industries/healthcare/tasks/C4-E1-SIG/task.json
+++ b/industries/healthcare/tasks/C4-E1-SIG/task.json
@@ -11,7 +11,6 @@
       "value": "Bettina Rausch"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [
     "transfer_to_cosmetic"
   ],

--- a/industries/healthcare/tasks/C4-E1/task.json
+++ b/industries/healthcare/tasks/C4-E1/task.json
@@ -11,7 +11,6 @@
       "value": "Park Avenue"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [
     "transfer_to_cosmetic"
   ],

--- a/industries/healthcare/tasks/C4-E2/task.json
+++ b/industries/healthcare/tasks/C4-E2/task.json
@@ -11,7 +11,6 @@
       "value": "Brooklyn Heights"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [
     "transfer_to_cosmetic"
   ],

--- a/industries/healthcare/tasks/C4-E3/task.json
+++ b/industries/healthcare/tasks/C4-E3/task.json
@@ -15,7 +15,6 @@
       "value": "Windermere"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [],
   "exp_tool_calls": [
     {

--- a/industries/healthcare/tasks/C4-H1/exp_db_state.json
+++ b/industries/healthcare/tasks/C4-H1/exp_db_state.json
@@ -185,14 +185,6 @@
       "payload": {
         "mobile_e164": "+12125550170"
       }
-    },
-    {
-      "id": 2,
-      "kind": "sms",
-      "payload": {
-        "mobile_e164": "+12125550170",
-        "template_id": "cosmetic_deposit"
-      }
     }
   ],
   "waitlist": []

--- a/industries/healthcare/tasks/C4-H1/task.json
+++ b/industries/healthcare/tasks/C4-H1/task.json
@@ -27,13 +27,6 @@
       "value": "new"
     }
   ],
-  "prompt_adherence_substrs": [
-    "4th floor",
-    "A $125 deposit holds the consult.",
-    "up to 72 hours before",
-    "deposit is forfeited",
-    "remaining balance"
-  ],
   "exp_handoff_path": [
     "transfer_to_cosmetic"
   ],
@@ -90,19 +83,6 @@
       },
       "parameters": {
         "mobile_e164": "+12125550170"
-      }
-    },
-    {
-      "name": "send_sms",
-      "parameters": {
-        "template_id": "cosmetic_deposit",
-        "mobile_e164": "+12125550170"
-      },
-      "output": {
-        "ok": true,
-        "data": {
-          "sent": true
-        }
       }
     }
   ],
@@ -302,14 +282,6 @@
         "id": 1,
         "kind": "payment_link",
         "payload": {
-          "mobile_e164": "+12125550170"
-        }
-      },
-      {
-        "id": 2,
-        "kind": "sms",
-        "payload": {
-          "template_id": "cosmetic_deposit",
           "mobile_e164": "+12125550170"
         }
       }

--- a/industries/healthcare/tasks/C4-H2/task.json
+++ b/industries/healthcare/tasks/C4-H2/task.json
@@ -31,11 +31,6 @@
       "value": "212-555-0133"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Maria Alvarez",
-    "June thirtieth, nineteen seventy-two",
-    "did I get that right?"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_cosmetic"
@@ -92,12 +87,6 @@
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
       "response_type": "phrase",
       "response_value": "Maria Alvarez. My date of birth is June thirtieth, nineteen seventy-two."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
     }
   ],
   "customer_name": "Maria Alvarez",

--- a/industries/healthcare/tasks/C4-H3/exp_db_state.json
+++ b/industries/healthcare/tasks/C4-H3/exp_db_state.json
@@ -178,15 +178,6 @@
       "name": "Dr. Luis Ruiz"
     }
   ],
-  "tool_events": [
-    {
-      "id": 1,
-      "kind": "sms",
-      "payload": {
-        "mobile_e164": "+12125550185",
-        "template_id": "appointment_confirmation"
-      }
-    }
-  ],
+  "tool_events": [],
   "waitlist": []
 }

--- a/industries/healthcare/tasks/C4-H3/task.json
+++ b/industries/healthcare/tasks/C4-H3/task.json
@@ -31,12 +31,6 @@
       "value": "10016"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Yvette Marchetti",
-    "March 15, 1974",
-    "2125550185",
-    "4th floor"
-  ],
   "exp_handoff_path": [
     "transfer_to_cosmetic",
     "transfer_to_scheduling"
@@ -91,19 +85,6 @@
         "ok": true,
         "data": {
           "status": "booked"
-        }
-      }
-    },
-    {
-      "name": "send_sms",
-      "parameters": {
-        "template_id": "appointment_confirmation",
-        "mobile_e164": "+12125550185"
-      },
-      "output": {
-        "ok": true,
-        "data": {
-          "sent": true
         }
       }
     }
@@ -299,15 +280,6 @@
       }
     ],
     "waitlist": [],
-    "tool_events": [
-      {
-        "id": 1,
-        "kind": "sms",
-        "payload": {
-          "template_id": "appointment_confirmation",
-          "mobile_e164": "+12125550185"
-        }
-      }
-    ]
+    "tool_events": []
   }
 }

--- a/industries/healthcare/tasks/C4-M1/task.json
+++ b/industries/healthcare/tasks/C4-M1/task.json
@@ -27,13 +27,6 @@
       "value": "new"
     }
   ],
-  "prompt_adherence_substrs": [
-    "4th floor",
-    "A $125 deposit holds the consult.",
-    "up to 72 hours before",
-    "deposit is forfeited",
-    "remaining balance"
-  ],
   "exp_handoff_path": [
     "transfer_to_cosmetic"
   ],

--- a/industries/healthcare/tasks/C4-M2/task.json
+++ b/industries/healthcare/tasks/C4-M2/task.json
@@ -27,13 +27,6 @@
       "value": "Park Avenue"
     }
   ],
-  "prompt_adherence_substrs": [
-    "4th floor",
-    "A $125 deposit holds the consult.",
-    "up to 72 hours before",
-    "deposit is forfeited",
-    "remaining balance"
-  ],
   "exp_handoff_path": [
     "transfer_to_cosmetic"
   ],

--- a/industries/healthcare/tasks/C4-M3/task.json
+++ b/industries/healthcare/tasks/C4-M3/task.json
@@ -15,9 +15,6 @@
       "value": "Brooklyn Heights"
     }
   ],
-  "prompt_adherence_substrs": [
-    "will call you back"
-  ],
   "exp_handoff_path": [
     "transfer_to_cosmetic"
   ],

--- a/industries/healthcare/tasks/C5-E1-BG/task.json
+++ b/industries/healthcare/tasks/C5-E1-BG/task.json
@@ -7,9 +7,6 @@
       "value": "Paul Hines"
     }
   ],
-  "prompt_adherence_substrs": [
-    "I can't take a card number by voice"
-  ],
   "exp_handoff_path": [],
   "exp_tool_calls": [],
   "behaviors": {},

--- a/industries/healthcare/tasks/C5-E1-SIG/task.json
+++ b/industries/healthcare/tasks/C5-E1-SIG/task.json
@@ -7,9 +7,6 @@
       "value": "Paul Hines"
     }
   ],
-  "prompt_adherence_substrs": [
-    "I can't take a card number by voice"
-  ],
   "exp_handoff_path": [],
   "exp_tool_calls": [],
   "behaviors": {},

--- a/industries/healthcare/tasks/C5-E1/task.json
+++ b/industries/healthcare/tasks/C5-E1/task.json
@@ -7,9 +7,6 @@
       "value": "Paul Hines"
     }
   ],
-  "prompt_adherence_substrs": [
-    "I can't take a card number by voice"
-  ],
   "exp_handoff_path": [],
   "exp_tool_calls": [],
   "behaviors": {},

--- a/industries/healthcare/tasks/C5-E2/task.json
+++ b/industries/healthcare/tasks/C5-E2/task.json
@@ -7,7 +7,6 @@
       "value": "Ida Bromley"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [],
   "exp_tool_calls": [
     {

--- a/industries/healthcare/tasks/C5-E3/task.json
+++ b/industries/healthcare/tasks/C5-E3/task.json
@@ -7,7 +7,6 @@
       "value": "Carl Nguyen"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [],
   "exp_tool_calls": [],
   "behaviors": {},

--- a/industries/healthcare/tasks/C5-H1/task.json
+++ b/industries/healthcare/tasks/C5-H1/task.json
@@ -31,12 +31,6 @@
       "value": "Cigna"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Maria Alvarez",
-    "June thirtieth, nineteen seventy-two",
-    "did I get that right?",
-    "deductible or copay"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_billing"
@@ -111,12 +105,6 @@
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
       "response_type": "phrase",
       "response_value": "Maria Alvarez. My date of birth is June thirtieth, nineteen seventy-two."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
     }
   ],
   "customer_name": "Maria Alvarez",

--- a/industries/healthcare/tasks/C5-H2/task.json
+++ b/industries/healthcare/tasks/C5-H2/task.json
@@ -35,12 +35,6 @@
       "value": "Jordan Lee"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Jordan Lee",
-    "April twelfth, nineteen ninety",
-    "did I get that right?",
-    "deductible or copay"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_billing",
@@ -120,12 +114,6 @@
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
       "response_type": "phrase",
       "response_value": "Jordan Lee. My date of birth is April twelfth, nineteen ninety."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
     }
   ],
   "customer_name": "Jordan Lee",

--- a/industries/healthcare/tasks/C5-H3/task.json
+++ b/industries/healthcare/tasks/C5-H3/task.json
@@ -31,12 +31,6 @@
       "value": "1995-09-08"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Alice Romano",
-    "September eighth, nineteen ninety-five",
-    "did I get that right?",
-    "deductible or copay"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_billing"
@@ -97,12 +91,6 @@
   ],
   "behaviors": {},
   "scripted_responses": [
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
-    },
     {
       "match_type": "context",
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",

--- a/industries/healthcare/tasks/C5-M1/task.json
+++ b/industries/healthcare/tasks/C5-M1/task.json
@@ -35,11 +35,6 @@
       "value": "Jordan Lee"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Jordan Lee",
-    "April twelfth, nineteen ninety",
-    "did I get that right?"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_billing"
@@ -91,12 +86,6 @@
   ],
   "behaviors": {},
   "scripted_responses": [
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
-    },
     {
       "match_type": "context",
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",

--- a/industries/healthcare/tasks/C5-M2/task.json
+++ b/industries/healthcare/tasks/C5-M2/task.json
@@ -35,12 +35,6 @@
       "value": "10016"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Jordan Lee",
-    "April twelfth, nineteen ninety",
-    "did I get that right?",
-    "within two business days"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_billing"
@@ -94,12 +88,6 @@
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
       "response_type": "phrase",
       "response_value": "Jordan Lee. My date of birth is April twelfth, nineteen ninety."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
     }
   ],
   "customer_name": "Jordan Lee",

--- a/industries/healthcare/tasks/C5-M3/task.json
+++ b/industries/healthcare/tasks/C5-M3/task.json
@@ -31,11 +31,6 @@
       "value": "Brooklyn Heights"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Sam Nguyen",
-    "November third, nineteen eighty-five",
-    "did I get that right?"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_billing"
@@ -80,12 +75,6 @@
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
       "response_type": "phrase",
       "response_value": "Sam Nguyen. My date of birth is November third, nineteen eighty-five."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
     }
   ],
   "customer_name": "Sam Nguyen",

--- a/industries/healthcare/tasks/R-E1-BG/task.json
+++ b/industries/healthcare/tasks/R-E1-BG/task.json
@@ -7,7 +7,6 @@
       "value": "Harriet Dowd"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [
     "transfer_to_human"
   ],

--- a/industries/healthcare/tasks/R-E1-SIG/task.json
+++ b/industries/healthcare/tasks/R-E1-SIG/task.json
@@ -7,7 +7,6 @@
       "value": "Harriet Dowd"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [
     "transfer_to_human"
   ],

--- a/industries/healthcare/tasks/R-E1/task.json
+++ b/industries/healthcare/tasks/R-E1/task.json
@@ -7,7 +7,6 @@
       "value": "Harriet Dowd"
     }
   ],
-  "prompt_adherence_substrs": [],
   "exp_handoff_path": [
     "transfer_to_human"
   ],

--- a/industries/healthcare/tasks/R-E2/task.json
+++ b/industries/healthcare/tasks/R-E2/task.json
@@ -7,10 +7,6 @@
       "value": "Bill Tanaka"
     }
   ],
-  "prompt_adherence_substrs": [
-    "call 911",
-    "I'm transferring you to a human now."
-  ],
   "exp_handoff_path": [
     "transfer_to_human"
   ],

--- a/industries/healthcare/tasks/R-E3/task.json
+++ b/industries/healthcare/tasks/R-E3/task.json
@@ -15,10 +15,6 @@
       "value": "Park Avenue"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Sorry, I can't help with that.",
-    "behind-the-scenes"
-  ],
   "exp_handoff_path": [],
   "exp_tool_calls": [
     {

--- a/industries/healthcare/tasks/R-H1/exp_db_state.json
+++ b/industries/healthcare/tasks/R-H1/exp_db_state.json
@@ -183,14 +183,6 @@
       "payload": {
         "channel": "sms"
       }
-    },
-    {
-      "id": 3,
-      "kind": "sms",
-      "payload": {
-        "mobile_e164": "+12125550100",
-        "template_id": "portal_activation"
-      }
     }
   ],
   "waitlist": []

--- a/industries/healthcare/tasks/R-H1/task.json
+++ b/industries/healthcare/tasks/R-H1/task.json
@@ -35,14 +35,6 @@
       "value": "212-555-0100"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Jordan Lee",
-    "April twelfth, nineteen ninety",
-    "did I get that right?",
-    "I can't read results over the phone",
-    "within four hours",
-    "I'm not able to go over results"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_clinical"
@@ -103,29 +95,10 @@
       "parameters": {
         "channel": "sms"
       }
-    },
-    {
-      "name": "send_sms",
-      "parameters": {
-        "template_id": "portal_activation",
-        "mobile_e164": "+12125550100"
-      },
-      "output": {
-        "ok": true,
-        "data": {
-          "sent": true
-        }
-      }
     }
   ],
   "behaviors": {},
   "scripted_responses": [
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
-    },
     {
       "match_type": "context",
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
@@ -326,14 +299,6 @@
         "kind": "portal_activation",
         "payload": {
           "channel": "sms"
-        }
-      },
-      {
-        "id": 3,
-        "kind": "sms",
-        "payload": {
-          "template_id": "portal_activation",
-          "mobile_e164": "+12125550100"
         }
       }
     ]

--- a/industries/healthcare/tasks/R-H2/exp_db_state.json
+++ b/industries/healthcare/tasks/R-H2/exp_db_state.json
@@ -187,14 +187,6 @@
         "patient_id": "pat_jordan_lee",
         "route": "isotretinoin_program"
       }
-    },
-    {
-      "id": 2,
-      "kind": "sms",
-      "payload": {
-        "mobile_e164": "+12125550100",
-        "template_id": "appointment_confirmation"
-      }
     }
   ],
   "waitlist": []

--- a/industries/healthcare/tasks/R-H2/task.json
+++ b/industries/healthcare/tasks/R-H2/task.json
@@ -39,12 +39,6 @@
       "value": "Aetna"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Jordan Lee",
-    "April twelfth, nineteen ninety",
-    "did I get that right?",
-    "4th floor"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_clinical",
@@ -114,19 +108,6 @@
           "status": "booked"
         }
       }
-    },
-    {
-      "name": "send_sms",
-      "parameters": {
-        "template_id": "appointment_confirmation",
-        "mobile_e164": "+12125550100"
-      },
-      "output": {
-        "ok": true,
-        "data": {
-          "sent": true
-        }
-      }
     }
   ],
   "behaviors": {},
@@ -136,12 +117,6 @@
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
       "response_type": "phrase",
       "response_value": "Jordan Lee. My date of birth is April twelfth, nineteen ninety."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
     }
   ],
   "customer_name": "Jordan Lee",
@@ -341,14 +316,6 @@
           "patient_id": "pat_jordan_lee",
           "medication_name": "isotretinoin",
           "route": "isotretinoin_program"
-        }
-      },
-      {
-        "id": 2,
-        "kind": "sms",
-        "payload": {
-          "template_id": "appointment_confirmation",
-          "mobile_e164": "+12125550100"
         }
       }
     ]

--- a/industries/healthcare/tasks/R-H3/exp_db_state.json
+++ b/industries/healthcare/tasks/R-H3/exp_db_state.json
@@ -193,14 +193,6 @@
         "callback_number": "+12125550133",
         "queue": "clinical"
       }
-    },
-    {
-      "id": 4,
-      "kind": "sms",
-      "payload": {
-        "mobile_e164": "+12125550133",
-        "template_id": "appointment_confirmation"
-      }
     }
   ],
   "waitlist": []

--- a/industries/healthcare/tasks/R-H3/task.json
+++ b/industries/healthcare/tasks/R-H3/task.json
@@ -35,13 +35,6 @@
       "value": "10016"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Maria Alvarez",
-    "June thirtieth, nineteen seventy-two",
-    "did I get that right?",
-    "within four hours",
-    "will call you back"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_clinical"
@@ -97,29 +90,10 @@
       "output": {
         "ok": true
       }
-    },
-    {
-      "name": "send_sms",
-      "parameters": {
-        "template_id": "appointment_confirmation",
-        "mobile_e164": "+12125550133"
-      },
-      "output": {
-        "ok": true,
-        "data": {
-          "sent": true
-        }
-      }
     }
   ],
   "behaviors": {},
   "scripted_responses": [
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
-    },
     {
       "match_type": "context",
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
@@ -330,14 +304,6 @@
         "payload": {
           "queue": "clinical",
           "callback_number": "+12125550133"
-        }
-      },
-      {
-        "id": 4,
-        "kind": "sms",
-        "payload": {
-          "template_id": "appointment_confirmation",
-          "mobile_e164": "+12125550133"
         }
       }
     ]

--- a/industries/healthcare/tasks/R-M1/task.json
+++ b/industries/healthcare/tasks/R-M1/task.json
@@ -35,13 +35,6 @@
       "value": "10016"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Jordan Lee",
-    "April twelfth, nineteen ninety",
-    "did I get that right?",
-    "I can't read results over the phone",
-    "by the end of the next business day"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_clinical"
@@ -106,12 +99,6 @@
   ],
   "behaviors": {},
   "scripted_responses": [
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
-    },
     {
       "match_type": "context",
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",

--- a/industries/healthcare/tasks/R-M2/task.json
+++ b/industries/healthcare/tasks/R-M2/task.json
@@ -35,12 +35,6 @@
       "value": "Park Avenue"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Jordan Lee",
-    "April twelfth, nineteen ninety",
-    "did I get that right?",
-    "I can't take a card number by voice"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_billing"
@@ -88,12 +82,6 @@
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
       "response_type": "phrase",
       "response_value": "Jordan Lee. My date of birth is April twelfth, nineteen ninety."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
     }
   ],
   "customer_name": "Jordan Lee",

--- a/industries/healthcare/tasks/R-M3/task.json
+++ b/industries/healthcare/tasks/R-M3/task.json
@@ -35,12 +35,6 @@
       "value": "34786"
     }
   ],
-  "prompt_adherence_substrs": [
-    "Alice Romano",
-    "September eighth, nineteen ninety-five",
-    "did I get that right?",
-    "Controlled medications are never refilled by phone"
-  ],
   "exp_handoff_path": [
     "transfer_to_identity",
     "transfer_to_clinical"
@@ -80,12 +74,6 @@
   ],
   "behaviors": {},
   "scripted_responses": [
-    {
-      "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether it is correct, or asks 'did I get that right'. NOT when first asking for your name or date of birth.",
-      "response_type": "phrase",
-      "response_value": "Yes, that's right."
-    },
     {
       "match_type": "context",
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",

--- a/industries/healthcare/tools.json
+++ b/industries/healthcare/tools.json
@@ -2,7 +2,7 @@
   "tools": [
     {
       "name": "identify_patient",
-      "description": "Find the patient record. The number they're calling from is tried automatically — try that before asking for anything. dob is YYYY-MM-DD. Returns masked candidates only.",
+      "description": "The caller may already be a patient and you need to find their record before verifying. The number they are calling from is tried first — use that before asking for name or date of birth. Returns masked candidates only; this does not verify identity.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -56,7 +56,7 @@
     },
     {
       "name": "verify_identity",
-      "description": "Verify the caller. Needs full name and date of birth (YYYY-MM-DD); add a second factor — their zip or the last four of the phone on file — if the tool asks for one. Never ask for a Social Security number. After the third failure this locks; when it does, stop and offer the front desk or a callback.",
+      "description": "You have the caller's name and date of birth and need to confirm they are the patient before any protected chart work. Add zip or last four of the phone on file only if a prior lookup asked for a second factor. Never ask for a Social Security number; after three failures this locks — stop and offer the front desk or a callback.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -107,7 +107,7 @@
     },
     {
       "name": "get_patient_summary",
-      "description": "Load everything the chart already knows — name, language, home office, last visit, upcoming appointments, insurance, balance, card on file, portal status, open orders and clinical flags. Call this the moment verification passes, before handing off.",
+      "description": "Identity verification just succeeded — load the chart before handing off or starting specialist work. Returns what the rest of the call should already know. Identity-gated; do not call unverified.",
       "inputSchema": {
         "type": "object",
         "properties": {},
@@ -136,7 +136,7 @@
     },
     {
       "name": "list_locations",
-      "description": "Offices by zip OR location_id: address, floor, suite, services, transit, parking, and whether the office does cosmetic work. The only source of an office address, floor or location_id. Practice hours come from search_practice_kb. Map caller names to loc_park_ave, loc_brooklyn_heights, or loc_windermere.",
+      "description": "The caller asks for an office address, floor, or suite, names an office, or you need an office id before booking or a coverage check. The only source of address, floor, suite, and location ids — never guess. Hours, directions, fees, portal, and services come from search_practice_kb, not this tool.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -180,7 +180,7 @@
     },
     {
       "name": "classify_visit_request",
-      "description": "Map the visit to an appointment type. Pass visit_class (cosmetic | mohs | allergy | medical), is_new_patient when you know, and urgency when spreading/painful/bleeding. Always call this before find_slots — it is what stops a Mohs consult being booked with a PA.",
+      "description": "The caller described a reason for a visit and you need the appointment type before you route or search slots. Maps the complaint to type and credential so a Mohs consult is never booked with a PA. Always call this before find_slots.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -235,7 +235,7 @@
     },
     {
       "name": "find_slots",
-      "description": "Open appointment slots at the given offices. Offer two or three, never a list.",
+      "description": "You are ready to offer appointment times at specific offices. Call after classify_visit_request, with office ids from list_locations. Offer two or three slots, never a list; do not promise a time this did not return.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -298,7 +298,7 @@
     },
     {
       "name": "book_appointment",
-      "description": "Create the appointment. Only after you have read back the day, the time, the office WITH THE FLOOR and the provider with credentials, and the caller said yes. Description is derived from appointment_type_code — do not pass one.",
+      "description": "The caller said yes after you read back the day, time, office with floor, and provider with credentials. Creates the appointment; description is derived from the appointment type — do not pass one. Slot fields must match the find_slots offer.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -380,7 +380,7 @@
     },
     {
       "name": "reschedule_appointment",
-      "description": "Move an existing appointment. This is an update, never a cancel-then-rebook, and it never costs anything — say so. Always offer this before cancelling.",
+      "description": "The caller wants to move an existing appointment — offer this before cancelling. This is an update, never a cancel-then-rebook, and it never costs anything; say so. Identity-gated to their own bookings.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -435,7 +435,7 @@
     },
     {
       "name": "cancel_appointment",
-      "description": "Cancel. Leave fee_disclosed_and_accepted false the first time: if a fee applies the tool will hand you the exact wording to say. Say it, offer a different time instead, and only call again with true if they still want to cancel. Always offer to rebook after.",
+      "description": "They still want to cancel after you offered to move the visit instead. First call without fee acceptance: if a fee applies, say the exact wording returned, offer a different time, and only call again after they accept. Always offer to rebook. Identity-gated.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -489,7 +489,7 @@
     },
     {
       "name": "join_waitlist",
-      "description": "Put them on the earlier-appointment list. Required: appointment_type_code, location_ids, earliest, latest.",
+      "description": "They want an earlier opening than the slots you can offer, or they decline to rebook after a cancel. Puts them on the earlier-appointment list for the given type and offices.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -560,7 +560,7 @@
     },
     {
       "name": "schedule_allergy_service",
-      "description": "Allergy visits: skin_testing, patch_testing, food_challenge, allergy_shot, drops_pickup, asthma_eval, immunotherapy_buildup. Say the prep instructions, the observation time after a shot, and the linked return visits out loud.",
+      "description": "They need an allergy service — testing, shots, drops pickup, food challenge, asthma eval, or immunotherapy — not a generic medical visit. Say the prep, the observation time after a shot, and the linked return visits out loud.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -626,7 +626,7 @@
     },
     {
       "name": "check_plan_accepted",
-      "description": "Carrier by OFFICE by provider. Pass carrier as a slug (aetna, unitedhealthcare, cigna, bcbs, medicare, medicaid, oscar_health, other) and location_id as loc_park_ave | loc_brooklyn_heights | loc_windermere. If must_not_assert is true you may not say they're covered or not covered: say required_script and create a callback. If accepted is no, say so plainly.",
+      "description": "The caller asks whether you take a plan at this office — you must call this; do not answer from the prompt. Acceptance is office-specific, and sometimes provider-specific. If must_not_assert is true, say required_script and do not claim covered or not; if accepted is no, say so plainly.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -692,7 +692,7 @@
     },
     {
       "name": "run_eligibility_check",
-      "description": "Live copay, deductible and coinsurance. Only if they gave you a member ID. If the payer doesn't answer, say you couldn't get the number — never guess at a copay.",
+      "description": "They want a live copay, deductible, or coinsurance and have given a member ID. If the payer does not answer, say you could not get the number — never guess a copay.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -757,7 +757,7 @@
     },
     {
       "name": "capture_insurance_update",
-      "description": "Take new or changed insurance by voice, then send a secure link for card photos. Never ask for a Social Security number.",
+      "description": "They have new or changed insurance to put on file. Carrier plus member ID is enough — still call if they have no group number. Texts a secure link for card photos; never ask for a Social Security number. Identity-gated.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -825,7 +825,7 @@
     },
     {
       "name": "get_account_balance",
-      "description": "The balance and the line items behind it.",
+      "description": "They ask about a bill, balance, or charge — call this first, before explaining or collecting. Returns the current balance and line items. Identity-gated; do not invent a sample amount.",
       "inputSchema": {
         "type": "object",
         "properties": {},
@@ -854,7 +854,7 @@
     },
     {
       "name": "explain_charge",
-      "description": "The approved explanation for a charge. Say approved_script as written — do not improvise a billing explanation.",
+      "description": "They ask why a specific charge is on the account. Say approved_script as written — do not improvise a billing explanation. Identity-gated.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -895,7 +895,7 @@
     },
     {
       "name": "send_payment_link",
-      "description": "Text a secure payment link. The only payment path — never take a card by voice.",
+      "description": "They are ready to pay a balance or a cosmetic deposit. Texts a secure payment link — the only payment path; never take a card by voice.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -938,7 +938,7 @@
     },
     {
       "name": "offer_financing",
-      "description": "CareCredit for a balance they can't pay at once. Over two hundred fifty dollars. Required: amount_cents.",
+      "description": "They cannot pay the full amount at once and the balance is over two hundred fifty dollars. Offers CareCredit; do not offer it for smaller amounts.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -976,7 +976,7 @@
     },
     {
       "name": "request_fee_waiver",
-      "description": "Open a review of a missed-visit fee. You do NOT waive it yourself. Required: fee_line_item_id. Say the SLA the tool gives you out loud.",
+      "description": "They dispute a missed-visit fee and want it reviewed. You do not waive it yourself — say the SLA the tool returns out loud.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1017,7 +1017,7 @@
     },
     {
       "name": "quote_cosmetic_service",
-      "description": "The only source of a cosmetic price. service is botox | filler | chemical_peel | microneedling. If it returns a range you may say that range and must add that the consult settles the number. If it returns no range, never invent a number.",
+      "description": "They ask what a cosmetic treatment costs. The only source of a spoken cosmetic price — if it returns a range, say that range and that the consult settles the number; if no range, never invent one.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1060,7 +1060,7 @@
     },
     {
       "name": "book_cosmetic_consult",
-      "description": "Book the consult. Leave policy_acknowledged false the first time — the tool hands you the exact four policy lines to say (deposit, 72 hours, forfeited, balance due). Say them, get a real yes, then call again with true.",
+      "description": "They are ready to book a cosmetic consult. First call without policy acknowledgment returns four policy lines — say them verbatim, get a real yes, then call again with acknowledgment. Do not book before that yes.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1143,7 +1143,7 @@
     },
     {
       "name": "request_rx_refill",
-      "description": "Open a refill request. This NEVER approves a refill. Required: medication_name. Optional: pharmacy_phone (E.164), last_fill_date (YYYY-MM-DD). Follow the route it returns; on a no_recent_visit hard stop, offer to book the visit on this call.",
+      "description": "They want a medication refill. This never approves a refill — follow the route it returns; on a no-recent-visit hard stop, offer to book the visit on this call. Identity-gated.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1193,7 +1193,7 @@
     },
     {
       "name": "get_results_status",
-      "description": "STATUS of pathology, lab or allergy testing — never the content. Required: order_type (pathology | lab | allergy). Say approved_script. If they push for what the results say, hold the line warmly every time and create a clinical message instead.",
+      "description": "They ask about pathology, lab, or allergy testing results. Returns STATUS only, never the content. Say approved_script; if they push for what the results say, hold the line and create a clinical message instead.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1235,7 +1235,7 @@
     },
     {
       "name": "create_clinical_message",
-      "description": "Task the clinical team. priority stat for anything emergent, urgent otherwise. Say the callback_window it returns out loud.",
+      "description": "A nurse, results, or refill question needs the clinical team — including when they push for result content you cannot read. Say the callback_window it returns out loud. Identity-gated.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1293,7 +1293,7 @@
     },
     {
       "name": "search_practice_kb",
-      "description": "Look up a grounded Straus answer. topic is hours | directions | portal | fees | services. Only say what this returns — if it finds no source, do not make one up.",
+      "description": "They ask about hours, directions, parking, fees, cancellation policy, the portal, or what the practice treats. Not for address, floor, suite, or location ids — those come from list_locations. Only say what this returns; if it finds no source, do not make one up.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1337,7 +1337,7 @@
     },
     {
       "name": "send_sms",
-      "description": "Text the caller. template_id is one of appointment_confirmation, portal_activation, payment_link, insurance_card_upload, directions, cosmetic_deposit.",
+      "description": "You need to text a confirmation, directions, a portal link, a payment link, an insurance-card upload, or a cosmetic deposit. Uses an approved template only — never free-form text.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1388,7 +1388,7 @@
     },
     {
       "name": "send_portal_activation",
-      "description": "Send the portal activation link when the portal isn't active. Optional: channel (sms | email).",
+      "description": "The portal is not active and they need access — on every results call where it is inactive, before the call ends. Sends the activation link.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1426,7 +1426,7 @@
     },
     {
       "name": "create_callback_task",
-      "description": "Promise a callback with a real, tracked SLA. queue is billing, clinical, front_desk, cosmetic or records. Say the spoken_commitment out loud, verbatim.",
+      "description": "You need to promise a callback with a real tracked SLA — after a tool cannot finish the work, or they need a team to call back. Say spoken_commitment out loud, verbatim. Do not use this instead of a tool that already has the answer.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1485,7 +1485,7 @@
     },
     {
       "name": "transfer_to_identity",
-      "description": "Invisible handoff to Identity & Verification when chart access is required before the real work. Pass next_intent (scheduling | billing | clinical | coverage | cosmetic) so identity knows where to continue. Call history is already visible — do not pass a summary.",
+      "description": "Chart access is required before the real work — existing-patient scheduling, billing, clinical, or updating insurance on file. Invisible hop; do not announce it. Pass next_intent so identity knows where to continue after verification.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1529,7 +1529,7 @@
     },
     {
       "name": "transfer_to_scheduling",
-      "description": "Invisible handoff to Scheduling & Access for booking, rescheduling, cancelling, waitlist, or allergy visits. Call history is already visible — no arguments.",
+      "description": "The remaining work is booking, moving, cancelling, waitlist, or an allergy visit. Invisible hop; no arguments; do not announce it.",
       "inputSchema": {
         "type": "object",
         "properties": {},
@@ -1558,7 +1558,7 @@
     },
     {
       "name": "transfer_to_coverage",
-      "description": "Invisible handoff to Coverage & Benefits for plan acceptance, referrals, eligibility, or capturing a new insurance card. Call history is already visible — no arguments.",
+      "description": "The question is plan acceptance, a referral, eligibility, or capturing a new insurance card. Invisible hop; no arguments; do not announce it.",
       "inputSchema": {
         "type": "object",
         "properties": {},
@@ -1587,7 +1587,7 @@
     },
     {
       "name": "transfer_to_cosmetic",
-      "description": "Invisible handoff to Cosmetic Concierge for Botox, fillers, lasers, peels, cosmetic pricing, or cosmetic consult booking. Call history is already visible — no arguments.",
+      "description": "They want Botox, fillers, lasers, peels, cosmetic pricing, or a cosmetic consult. Invisible hop; no arguments; do not announce it.",
       "inputSchema": {
         "type": "object",
         "properties": {},
@@ -1616,7 +1616,7 @@
     },
     {
       "name": "transfer_to_billing",
-      "description": "Invisible handoff to Billing & Payments for balances, charge explanations, payment links, financing, or fee waivers. Caller must already be identity-verified. Call history is already visible — no arguments.",
+      "description": "The remaining work is a balance, charge explanation, payment, financing, or a fee waiver. Caller must already be identity-verified. Invisible hop; no arguments; do not announce it.",
       "inputSchema": {
         "type": "object",
         "properties": {},
@@ -1645,7 +1645,7 @@
     },
     {
       "name": "transfer_to_clinical",
-      "description": "Invisible handoff to Clinical Liaison for results status, refills, nurse messages, prior auth, portal, or records. Caller must already be identity-verified. Call history is already visible — no arguments.",
+      "description": "The remaining work is results status, a refill, a nurse message, prior auth, portal, or records. Caller must already be identity-verified. Invisible hop; no arguments; do not announce it.",
       "inputSchema": {
         "type": "object",
         "properties": {},
@@ -1674,7 +1674,7 @@
     },
     {
       "name": "transfer_to_human",
-      "description": "Transfer the caller to a human. Use only when (1) the caller asks for a human, or (2) after telling them to call 911 and saying you are transferring them for a clinical emergency. Required: destination and reason enums. Call history is already visible — do not pass a summary.",
+      "description": "The caller asks for a person, or you have told them to call 911 and said you are transferring them for a clinical emergency. This is the only transfer you announce out loud. Not for hard questions, policy limits, or a slow call.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1731,7 +1731,7 @@
     },
     {
       "name": "end_call",
-      "description": "End the call once the caller is done, or immediately if it's spam or a wrong number. Say goodbye first. reason is caller_done | spam | wrong_number. There is no silent-hangup reason — a finished call after goodbye is caller_done.",
+      "description": "The caller is done — say goodbye first — or this is spam or a wrong number. A finished call after goodbye is caller_done; there is no silent-hangup reason.",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/scripts/encode_healthcare_tasks.py
+++ b/scripts/encode_healthcare_tasks.py
@@ -1,8 +1,7 @@
 """Encode the live healthcare v2 suite into industries/healthcare/tasks/.
 
 Topic keys T1…T5 become category folders C1…C5. Regulatory R stays R.
-Each folder gets task.json (including prompt_adherence_substrs derived from
-the standing prompt rules) and exp_db_state.json (the checked-in expected
+Each folder gets task.json and exp_db_state.json (the checked-in expected
 GET /state dump).
 
     uv run python scripts/encode_healthcare_tasks.py
@@ -15,8 +14,6 @@ import ast
 import json
 import re
 import sys
-from calendar import month_name
-from datetime import date
 from pathlib import Path
 from typing import Any
 
@@ -61,22 +58,9 @@ META_TRAITS = frozenset({
     "expected_handoff_path",
 })
 
-ACCEPTED_CARRIERS = {
-    "aetna", "unitedhealthcare", "united healthcare", "cigna",
-    "blue cross blue shield", "bcbs", "medicare",
-}
 NOT_ACCEPTED_CARRIERS = {"medicaid"}
 
 INSIDE_WINDOW_APPOINTMENTS = {1, 2}
-
-FLOOR_BY_LOCATION = {
-    "loc_park_ave": "4th floor",
-    "park avenue": "4th floor",
-    "loc_brooklyn_heights": "2nd floor",
-    "brooklyn heights": "2nd floor",
-    "loc_windermere": "Ground floor",
-    "windermere": "Ground floor",
-}
 
 HANDOFF_NAMES = (
     "transfer_to_identity",
@@ -88,16 +72,6 @@ HANDOFF_NAMES = (
     "transfer_to_human",
 )
 
-CALLBACK_WINDOW = {
-    "stat": "within the hour",
-    "urgent": "within four hours",
-    "routine": "by the end of the next business day",
-}
-
-_CHARGE_SLICES = {
-    "li_noshow": "missed-visit fee",
-    "li_visit": "deductible or copay",
-}
 
 def folder_key(source_key: str) -> str:
     if source_key.startswith("T") and len(source_key) > 1 and source_key[1].isdigit():
@@ -122,17 +96,6 @@ def audio_of(key: str) -> str:
     if key.endswith("-SIG"):
         return "bad_signal"
     return "perfect"
-
-
-def traits_by_name(dh: dict[str, Any]) -> dict[str, str]:
-    out: dict[str, str] = {}
-    for item in dh.get("traits") or []:
-        name = item.get("trait_name")
-        if not name:
-            continue
-        value = item.get("value")
-        out[str(name)] = "" if value is None else str(value)
-    return out
 
 
 def customer_traits(dh: dict[str, Any]) -> list[dict[str, Any]]:
@@ -172,213 +135,6 @@ def handoff_path(dh: dict[str, Any], calls: list[dict[str, Any]]) -> list[str]:
         except (SyntaxError, ValueError):
             pass
     return [c["name"] for c in calls if c.get("name") in HANDOFF_NAMES]
-
-
-def digits_phone(value: str) -> str | None:
-    digits = re.sub(r"\D", "", value)
-    if len(digits) == 11 and digits.startswith("1"):
-        digits = digits[1:]
-    if len(digits) == 10:
-        return digits
-    return None
-
-
-def dob_from_pins(dh: dict[str, Any]) -> str | None:
-    """Caller's spoken DOB — the form the agent must read back."""
-    for item in dh.get("scripted_responses") or []:
-        value = str(item.get("response_value") or "")
-        match = re.search(r"date of birth is ([^.]+)", value, re.I)
-        if match:
-            return match.group(1).strip().rstrip(".")
-    return None
-
-
-def dob_forms(dh: dict[str, Any], iso: str) -> list[str]:
-    spoken = dob_from_pins(dh)
-    if spoken:
-        return [spoken]
-    try:
-        parsed = date.fromisoformat(iso)
-    except ValueError:
-        return []
-    return [f"{month_name[parsed.month]} {parsed.day}, {parsed.year}"]
-
-
-def output_data(call: dict[str, Any]) -> dict[str, Any]:
-    output = call.get("output")
-    if isinstance(output, dict):
-        data = output.get("data")
-        if isinstance(data, dict):
-            return data
-        return output
-    return {}
-
-
-def add(unique: list[str], seen: set[str], value: str | None) -> None:
-    if not value:
-        return
-    text = value.strip()
-    if not text or text in seen:
-        return
-    seen.add(text)
-    unique.append(text)
-
-
-def location_floor(value: Any) -> str | None:
-    if value is None:
-        return None
-    return FLOOR_BY_LOCATION.get(str(value).strip().lower())
-
-
-def prompt_adherence_substrs(dh: dict[str, Any], calls: list[dict[str, Any]], folder: str) -> list[str]:
-    """Standing-rule substrings that this caller actually triggers."""
-    facts = traits_by_name(dh)
-    names = [c.get("name") for c in calls]
-    out: list[str] = []
-    seen: set[str] = set()
-
-    def name_value() -> str | None:
-        return facts.get("full_name") or dh.get("name")
-
-    def dob_value() -> str | None:
-        return facts.get("date_of_birth") or facts.get("dob")
-
-    def mobile_value() -> str | None:
-        return facts.get("mobile") or facts.get("phone_e164") or facts.get("phone")
-
-    def member_value() -> str | None:
-        return facts.get("member_id")
-
-    # Identifier readback — only when the standing rule fires for this call.
-    if "verify_identity" in names:
-        add(out, seen, name_value())
-        for form in dob_forms(dh, dob_value() or ""):
-            add(out, seen, form)
-        add(out, seen, "did I get that right?")
-
-    if "capture_insurance_update" in names or "run_eligibility_check" in names:
-        add(out, seen, member_value())
-        if "run_eligibility_check" in names:
-            for form in dob_forms(dh, dob_value() or ""):
-                add(out, seen, form)
-
-    new_patient = facts.get("patient_status") == "new"
-    books = "book_appointment" in names or "schedule_allergy_service" in names
-    if new_patient and books:
-        add(out, seen, name_value())
-        for form in dob_forms(dh, dob_value() or ""):
-            add(out, seen, form)
-        add(out, seen, digits_phone(mobile_value() or ""))
-
-    # Slot readback includes the floor from list_locations.
-    if "book_appointment" in names or "book_cosmetic_consult" in names:
-        for call in calls:
-            if call.get("name") not in {"book_appointment", "book_cosmetic_consult", "find_slots"}:
-                continue
-            params = call.get("parameters") or {}
-            floor = location_floor(params.get("location_id"))
-            if floor is None and isinstance(params.get("location_ids"), list) and params["location_ids"]:
-                floor = location_floor(params["location_ids"][0])
-            add(out, seen, floor)
-
-    # Tool scripts — short slices of the text the prompt now orders spoken.
-    for call in calls:
-        name = call.get("name")
-        params = call.get("parameters") or {}
-        data = output_data(call)
-
-        if name == "check_plan_accepted":
-            carrier = str(params.get("carrier") or facts.get("carrier") or "")
-            folded = carrier.strip().lower()
-            script = str(data.get("required_script") or "").strip()
-            must_not = data.get("must_not_assert")
-            if script:
-                add(out, seen, script.split(".", 1)[0])
-                if "flag it for benefits verification" in script:
-                    add(out, seen, "flag it for benefits verification")
-            elif must_not is True or (
-                must_not is not False
-                and folded
-                and folded not in ACCEPTED_CARRIERS
-                and folded not in NOT_ACCEPTED_CARRIERS
-            ):
-                add(out, seen, "I can't confirm that plan")
-                add(out, seen, "flag it for benefits verification")
-            elif folded in NOT_ACCEPTED_CARRIERS:
-                label = {"medicaid": "Medicaid"}.get(folded, carrier)
-                add(out, seen, f"We don't accept {label} at any of our offices")
-
-        if name == "cancel_appointment":
-            appt = params.get("appointment_id")
-            try:
-                appt_id = int(appt)
-            except (TypeError, ValueError):
-                appt_id = None
-            # Specs often list only the accepted=true follow-up; the first
-            # call still returns required_script that must be said.
-            if params.get("fee_disclosed_and_accepted") or appt_id in INSIDE_WINDOW_APPOINTMENTS:
-                add(out, seen, "missed-visit")
-                add(out, seen, "Moving it instead is free")
-
-        if name == "schedule_allergy_service":
-            service = str(params.get("service") or "").strip().lower()
-            if service == "skin_testing":
-                add(out, seen, "Stop antihistamines seven days before")
-            elif service == "patch_testing":
-                add(out, seen, "Keep your back dry")
-                add(out, seen, "48-hour patch read")
-                add(out, seen, "96-hour patch read")
-            elif service == "allergy_shot":
-                add(out, seen, "30-minute")
-
-        if name == "book_cosmetic_consult":
-            add(out, seen, "A $125 deposit holds the consult.")
-            add(out, seen, "up to 72 hours before")
-            add(out, seen, "deposit is forfeited")
-            add(out, seen, "remaining balance")
-
-        if name == "request_rx_refill":
-            med = str(
-                params.get("medication_name") or params.get("medication") or ""
-            ).strip().lower()
-            if any(token in med for token in (
-                "tramadol", "xanax", "adderall", "oxycodone", "codeine",
-            )):
-                add(out, seen, "Controlled medications are never refilled by phone")
-
-        if name == "explain_charge":
-            line_id = params.get("line_item_id")
-            if not line_id:
-                line_id = "li_noshow" if "request_fee_waiver" in names else "li_visit"
-            add(out, seen, _CHARGE_SLICES.get(str(line_id)))
-
-        if name == "request_fee_waiver":
-            add(out, seen, "within two business days")
-
-        if name == "get_results_status":
-            add(out, seen, "I can't read results over the phone")
-
-        if name == "create_clinical_message":
-            priority = str(params.get("priority") or "routine").strip().lower()
-            add(out, seen, CALLBACK_WINDOW.get(priority, CALLBACK_WINDOW["routine"]))
-
-        if name == "create_callback_task":
-            add(out, seen, "will call you back")
-
-    # Refusal / emergency stems — only the cases the standing rule is about.
-    scored = folder.rsplit("-", 1)[0] if folder.endswith(("-BG", "-SIG")) else folder
-    if scored == "R-E2":
-        add(out, seen, "call 911")
-        add(out, seen, "I'm transferring you to a human now.")
-    if scored == "R-E3":
-        add(out, seen, "Sorry, I can't help with that.")
-        add(out, seen, "behind-the-scenes")
-    if scored == "R-H1":
-        add(out, seen, "I'm not able to go over results")
-    if scored in {"C5-E1", "R-M2"}:
-        add(out, seen, "I can't take a card number by voice")
-
-    return out
 
 
 def task_name_for(folder: str, test_name: str) -> str:
@@ -428,7 +184,6 @@ def encode(dh: dict[str, Any]) -> tuple[str, dict[str, Any]]:
         "task_name": task_name_for(folder, str(dh.get("test_name") or folder)),
         "intent": dh.get("intent") or "",
         "traits": customer_traits(dh),
-        "prompt_adherence_substrs": prompt_adherence_substrs(dh, calls, folder),
         "exp_handoff_path": handoff_path(dh, calls),
         "exp_tool_calls": calls,
         "behaviors": behaviors(dh),
@@ -443,6 +198,8 @@ def encode(dh: dict[str, Any]) -> tuple[str, dict[str, Any]]:
         },
         "exp_db_state": state,
     }
+    task["exp_tool_calls"] = drop_unneeded_send_sms(task)
+    task["exp_db_state"] = drop_courtesy_sms_events(task)
     return folder, task
 
 
@@ -913,21 +670,109 @@ def complete_call(
     return {key: value for key, value in call.items() if key != "parameters"}
 
 
+# Courtesy confirmation texts after a write are not required. Keep send_sms
+# only when the caller asked to receive a text (or a pin accepts one).
+_SMS_REFUSE = re.compile(
+    r"don'?t want a text|do not want a text|don'?t text me|do not text me|"
+    r"no thanks.{0,40}text|i'?m all set.{0,30}text|"
+    r"refuse.{0,30}(?:a )?text|decline.{0,30}(?:a )?text",
+    re.I,
+)
+_SMS_POLICY_QUESTION = re.compile(
+    r"when they send (?:appointment )?confirmation texts|"
+    r"how their reminders work",
+    re.I,
+)
+_SMS_REQUEST = re.compile(
+    r"text you|text me|texted to you|text the address|"
+    r"send (?:me |you )?(?:a |the )?(?:text|sms)|"
+    r"want (?:a |the )?(?:text|sms)|"
+    r"confirmation text",
+    re.I,
+)
+_SMS_CONFIRMATION_REQUEST = re.compile(
+    r"confirmation text|text (?:me|you) (?:the )?(?:confirmation|appointment)",
+    re.I,
+)
+
+
+def _sms_corpus(task: dict[str, Any]) -> str:
+    pins = task.get("scripted_responses") or []
+    pin_text = ""
+    if isinstance(pins, list):
+        pin_text = " ".join(
+            str(item.get("response_value") or "")
+            for item in pins
+            if isinstance(item, dict)
+        )
+    return f"{task.get('intent') or ''} {pin_text}"
+
+
+def caller_requests_sms(task: dict[str, Any]) -> bool:
+    """True when receiving an SMS is part of success, not a courtesy after a write."""
+    corpus = _sms_corpus(task)
+    if _SMS_REFUSE.search(corpus) or _SMS_POLICY_QUESTION.search(corpus):
+        return False
+    return bool(_SMS_REQUEST.search(corpus))
+
+
+def keep_send_sms_call(
+    task: dict[str, Any],
+    call: dict[str, Any],
+    names: list[Any] | None = None,
+) -> bool:
+    if call.get("name") != "send_sms":
+        return True
+    if not caller_requests_sms(task):
+        return False
+    template = str((call.get("parameters") or {}).get("template_id") or "")
+    names = names or [item.get("name") for item in (task.get("exp_tool_calls") or [])]
+    if template in {"cosmetic_deposit", "payment_link"} and "send_payment_link" in names:
+        return False
+    if template == "portal_activation" and "send_portal_activation" in names:
+        return False
+    if template in {"", "appointment_confirmation"}:
+        return bool(_SMS_CONFIRMATION_REQUEST.search(_sms_corpus(task)))
+    return True
+
+
+def drop_unneeded_send_sms(
+    task: dict[str, Any],
+    calls: list[dict[str, Any]] | None = None,
+) -> list[dict[str, Any]]:
+    raw = list(calls if calls is not None else task.get("exp_tool_calls") or [])
+    names = [item.get("name") for item in raw]
+    return [item for item in raw if keep_send_sms_call(task, item, names)]
+
+
+def drop_courtesy_sms_events(task: dict[str, Any]) -> dict[str, Any]:
+    state = dict(task.get("exp_db_state") or {})
+    events = list(state.get("tool_events") or [])
+    kept_templates = {
+        (item.get("parameters") or {}).get("template_id")
+        for item in task.get("exp_tool_calls") or []
+        if item.get("name") == "send_sms"
+    }
+    if not kept_templates:
+        events = [item for item in events if item.get("kind") != "sms"]
+    else:
+        events = [
+            item
+            for item in events
+            if item.get("kind") != "sms"
+            or (item.get("payload") or {}).get("template_id") in kept_templates
+        ]
+    state["tool_events"] = events
+    return state
+
+
 def reshape_calls(task: dict[str, Any], folder: str) -> list[dict[str, Any]]:
-    raw = list(task.get("exp_tool_calls") or [])
+    raw = drop_unneeded_send_sms(task)
     agent_handoffs = [call for call in raw if call.get("name") in HANDOFF_NAMES and call.get("name") != "transfer_to_human"]
     rest = [call for call in raw if call.get("name") not in HANDOFF_NAMES or call.get("name") == "transfer_to_human"]
     raw = agent_handoffs + rest
     if folder == "C5-H3":
         raw = [call for call in raw if call.get("name") != "create_callback_task"]
-    if folder == "C4-H2":
-        raw = [
-            call for call in raw
-            if not (
-                call.get("name") == "send_sms"
-                and (call.get("parameters") or {}).get("template_id") == "cosmetic_deposit"
-            )
-        ]
     names = [call.get("name") for call in raw]
     if folder == "R-M1" and "create_clinical_message" not in names:
         insert_at = next(
@@ -1078,20 +923,13 @@ def repair_tasks() -> int:
         task["exp_tool_calls"] = reshape_calls(task, folder)
         if folder == "C3-H3":
             add_member_id_pin(task)
-        task["prompt_adherence_substrs"] = prompt_adherence_substrs(
-            {
-                "name": task.get("customer_name"),
-                "traits": task.get("traits") or [],
-                "scripted_responses": task.get("scripted_responses") or [],
-            },
-            task["exp_tool_calls"],
-            folder,
-        )
-        task["exp_db_state"] = replay_task(folder, task["exp_tool_calls"])
+        task["exp_db_state"] = drop_courtesy_sms_events({
+            **task,
+            "exp_db_state": replay_task(folder, task["exp_tool_calls"]),
+        })
         write_task(folder, task)
         print(
-            f"{folder:12}  {len(task['prompt_adherence_substrs'])} substrs  "
-            f"{len(task['exp_tool_calls'])} calls",
+            f"{folder:12}  {len(task['exp_tool_calls'])} calls",
             flush=True,
         )
     print(f"repaired {len(folders)} task folders under {TASKS}")
@@ -1121,8 +959,7 @@ def main(argv: list[str] | None = None) -> int:
         write_task(folder, task)
         written.append(folder)
         print(
-            f"{folder:12}  {len(task['prompt_adherence_substrs'])} substrs  "
-            f"{task['customer_name']}",
+            f"{folder:12}  {task['customer_name']}",
             flush=True,
         )
 

--- a/scripts/healthcare_digital_humans.py
+++ b/scripts/healthcare_digital_humans.py
@@ -1850,14 +1850,10 @@ _ASK_TRIGGER = (
     "phone or mobile number, NOT when asking about an appointment day or time, NOT when "
     "reading your name and date of birth back to you for confirmation."
 )
-_READBACK_TRIGGER = (
-    "reads your name and date of birth back to you and asks whether it is correct, or asks "
-    "'did I get that right'. NOT when first asking for your name or date of birth."
-)
 
 
 def _identity_pins(case_key: str, tools: list[dict]) -> list[dict]:
-    """Pin the name + DOB this case's verify_identity call needs, and the read-back yes."""
+    """Pin the name + DOB this case's verify_identity call needs."""
     if case_key in NO_IDENTITY_PIN:
         return []
     verify = next(
@@ -1877,13 +1873,6 @@ def _identity_pins(case_key: str, tools: list[dict]) -> list[dict]:
             "response_type": "phrase",
             # a phrase response replaces the whole turn, so it carries both values
             "response_value": f"{full_name}. My date of birth is {spoken}.",
-            "occurrence_mode": "always",
-        },
-        {
-            "match_type": "context",
-            "match_phrase": _READBACK_TRIGGER,
-            "response_type": "phrase",
-            "response_value": "Yes, that's right.",
             "occurrence_mode": "always",
         },
     ]

--- a/scripts/tasks_to_digital_humans.py
+++ b/scripts/tasks_to_digital_humans.py
@@ -364,7 +364,7 @@ def check(humans: list[dict[str, Any]], industry: str) -> None:
             raise SystemExit(f"{key}: name must be person-only, got {name!r}")
         if dh.get("test_name", "").split(":", 1)[0].strip() != key:
             raise SystemExit(f"{key}: test_name must start with the case key")
-        if "prompt_adherence_substrs" in dh or "exp_db_state" in dh:
+        if "exp_db_state" in dh:
             raise SystemExit(f"{key}: verifier fields must not be copied onto the DH")
         for pin in dh.get("scripted_responses") or []:
             if pin.get("occurrence_mode") != "always":

--- a/scripts/verify_task_run.py
+++ b/scripts/verify_task_run.py
@@ -1,21 +1,19 @@
 """Score a finished Bluejay run against MIVAS task.json files.
 
-Four independent checks per result (combined pass is AND):
+Three independent checks per result (combined pass is AND):
 
-1. Agent-side transcript vs `prompt_adherence_substrs`. Exact substring
-   always passes. Standing prompt/tool lines stay exact; other needles
-   may fold dates, phones, 911, money, floors, and name case.
-2. Hangup GET /state vs `exp_db_state` on office tables only
+1. Hangup GET /state vs `exp_db_state` on office tables only
    (`patients`, `appointments`, `waitlist`). Ignores `tool_events`,
    catalog tables, `created_at`, and unconstrained description text.
-3. Tool-call adherence — Bluejay `actual` invocations vs `exp_tool_calls`,
+2. Tool-call adherence — Bluejay `actual` invocations vs `exp_tool_calls`,
    matching constrained args from `tools.json` (enums, ids, facts). Prose
    args must be non-empty when required; empty live args are name-only.
-4. Handoff adherence — `exp_handoff_path` as an in-order subsequence of
-   actual transfer_* tools.
+3. Handoff adherence — `exp_handoff_path` as an in-order subsequence of
+   actual transfer_* tools in wall-clock order (`start_offset_ms`), not
+   Bluejay's name-grouped `tool_calls` array.
 
 Join result → task by the DH `case_key` trait or the `test_name` prefix
-(`C1-E1:`). Empty substrings / empty expected tools pass that half.
+(`C1-E1:`). Empty expected tools pass that half.
 Missing S3 dumps skip state with a note; `--actuals-dir` compares local
 files without S3.
 
@@ -66,46 +64,6 @@ FACT_ARG_KEYS = frozenset({
 })
 KEEP_ARG_TYPES = frozenset({"number", "integer", "boolean"})
 KEEP_ARG_FORMATS = frozenset({"date", "date-time"})
-
-# Standing prompt / tool lines: exact glyph match only, no speech folding.
-VERBATIM_PHRASES = (
-    "Sorry, I can't help with that.",
-    "I'm transferring you to a human now.",
-    "I can't take a card number by voice",
-    "did I get that right?",
-    "We don't accept Medicaid at any of our offices",
-    "I can't confirm that plan",
-    "A $125 deposit holds the consult.",
-    "up to 72 hours before",
-    "deposit is forfeited",
-    "remaining balance",
-    "Controlled medications are never refilled by phone",
-    "I can't read results over the phone",
-    "I'm not able to go over results",
-    "behind-the-scenes",
-)
-
-_ONES = {
-    "zero": 0, "one": 1, "two": 2, "three": 3, "four": 4, "five": 5,
-    "six": 6, "seven": 7, "eight": 8, "nine": 9, "ten": 10, "eleven": 11,
-    "twelve": 12, "thirteen": 13, "fourteen": 14, "fifteen": 15,
-    "sixteen": 16, "seventeen": 17, "eighteen": 18, "nineteen": 19,
-}
-_ORD_ONES = {
-    "zeroth": 0, "first": 1, "second": 2, "third": 3, "fourth": 4,
-    "fifth": 5, "sixth": 6, "seventh": 7, "eighth": 8, "ninth": 9,
-    "tenth": 10, "eleventh": 11, "twelfth": 12, "thirteenth": 13,
-    "fourteenth": 14, "fifteenth": 15, "sixteenth": 16, "seventeenth": 17,
-    "eighteenth": 18, "nineteenth": 19,
-}
-_TENS = {
-    "twenty": 20, "thirty": 30, "forty": 40, "fifty": 50,
-    "sixty": 60, "seventy": 70, "eighty": 80, "ninety": 90,
-}
-_ORD_TENS = {
-    "twentieth": 20, "thirtieth": 30, "fortieth": 40, "fiftieth": 50,
-    "sixtieth": 60, "seventieth": 70, "eightieth": 80, "ninetieth": 90,
-}
 
 _TOOL_SCHEMAS: dict[str, dict[str, Any]] = {}
 
@@ -204,10 +162,6 @@ def agent_transcript(lines: list[str]) -> str:
         if role in AGENT_ROLES:
             texts.append(said)
     return "\n".join(texts)
-
-
-def _unify_quotes(text: str) -> str:
-    return text.replace("\u2019", "'").replace("\u2018", "'").replace("`", "'")
 
 
 def _digits_phone(value: str) -> str:
@@ -499,7 +453,13 @@ def expected_tool_names(task: dict[str, Any] | None) -> list[str]:
 
 
 def actual_tool_calls(result: dict[str, Any]) -> list[dict[str, Any]]:
-    """One entry per Bluejay `actual` invocation, preserving group order."""
+    """One entry per Bluejay `actual` invocation, in wall-clock order.
+
+    Bluejay groups all actuals of one name into one `{name, actual[]}` object.
+    Group array order is not chronological — sort by `start_offset_ms` when
+    present so handoff subsequence scoring sees identity → specialist, not
+    whichever transfer name happened to be grouped first.
+    """
     calls: list[dict[str, Any]] = []
     for group in result.get("tool_calls") or []:
         if not isinstance(group, dict):
@@ -527,7 +487,16 @@ def actual_tool_calls(result: dict[str, Any]) -> list[dict[str, Any]]:
                 call["error_code"] = item.get("error_code")
             elif "error_code" in output:
                 call["error_code"] = output.get("error_code")
+            if item.get("start_offset_ms") is not None:
+                call["start_offset_ms"] = item.get("start_offset_ms")
             calls.append(call)
+    if any(call.get("start_offset_ms") is not None for call in calls):
+        calls.sort(
+            key=lambda call: (
+                call.get("start_offset_ms") is None,
+                call.get("start_offset_ms") if call.get("start_offset_ms") is not None else 0,
+            )
+        )
     return calls
 
 
@@ -615,114 +584,6 @@ def handoff_adherence(expected: list[str], actual: list[str]) -> dict[str, Any]:
     }
 
 
-def _replace_spoken_years(text: str) -> str:
-    tens_w = "|".join(_TENS)
-    ones_w = "|".join(word for word, value in _ONES.items() if 1 <= value <= 9)
-    teens_w = "|".join(word for word, value in _ONES.items() if value >= 10)
-
-    def nineteen_tens(match: re.Match[str]) -> str:
-        tens = _TENS[match.group(1)]
-        ones = _ONES.get(match.group(2) or "", 0)
-        return str(1900 + tens + ones)
-
-    text = re.sub(
-        rf"\bnineteen(?:[- ]({tens_w}))(?:[- ]({ones_w}))?\b",
-        nineteen_tens,
-        text,
-    )
-    text = re.sub(
-        rf"\bnineteen[- ]({teens_w})\b",
-        lambda match: str(1900 + _ONES[match.group(1)]),
-        text,
-    )
-
-    def two_thousand(match: re.Match[str]) -> str:
-        word = match.group(1)
-        return str(2000 + (_ONES.get(word, 0) if word else 0))
-
-    text = re.sub(
-        rf"\btwo thousand(?: and)?(?:[- ]({teens_w}|{ones_w}))?\b",
-        two_thousand,
-        text,
-    )
-    return text
-
-
-def _replace_spoken_numbers(text: str) -> str:
-    tens_w = "|".join(_TENS)
-    ones_1_9 = "|".join(word for word, value in _ONES.items() if 1 <= value <= 9)
-    ord_1_9 = "|".join(word for word, value in _ORD_ONES.items() if 1 <= value <= 9)
-    text = re.sub(
-        rf"\b({tens_w})[- ]({ord_1_9})\b",
-        lambda match: str(_TENS[match.group(1)] + _ORD_ONES[match.group(2)]),
-        text,
-    )
-    text = re.sub(
-        rf"\b({tens_w})[- ]({ones_1_9})\b",
-        lambda match: str(_TENS[match.group(1)] + _ONES[match.group(2)]),
-        text,
-    )
-    ordinals = {**_ORD_ONES, **_ORD_TENS}
-    for word, value in sorted(ordinals.items(), key=lambda item: -len(item[0])):
-        text = re.sub(rf"\b{word}\b", str(value), text)
-    for word, value in sorted(_ONES.items(), key=lambda item: -len(item[0])):
-        text = re.sub(rf"\b{word}\b", str(value), text)
-    return text
-
-
-def _collapse_phone_runs(text: str) -> str:
-    def collapse(match: re.Match[str]) -> str:
-        return _digits_phone(match.group(0))
-
-    return re.sub(r"(?:\d[\s().\-]*){7,}", collapse, text)
-
-
-def fold_speech(text: str) -> str:
-    """Canonical form for non-verbatim substring matching."""
-    folded = _unify_quotes(text).casefold()
-    folded = re.sub(r"\bnine[\s\-]+one[\s\-]+one\b", "911", folded)
-    folded = re.sub(r"\b9\s*-\s*1\s*-\s*1\b", "911", folded)
-    folded = re.sub(r"\$\s*125\b", "125", folded)
-    folded = re.sub(
-        r"\b(?:one\s+)?hundred\s+(?:and\s+)?twenty[\-\s]?five\b",
-        "125",
-        folded,
-    )
-    folded = _replace_spoken_years(folded)
-    folded = _replace_spoken_numbers(folded)
-    folded = re.sub(r"\b(\d+)(?:st|nd|rd|th)\b", r"\1", folded)
-    folded = _collapse_phone_runs(folded)
-    folded = re.sub(r"[^a-z0-9]+", " ", folded)
-    return re.sub(r"\s+", " ", folded).strip()
-
-
-def is_verbatim_needle(needle: str) -> bool:
-    return any(phrase in needle for phrase in VERBATIM_PHRASES)
-
-
-def substr_matches(agent_text: str, needle: str) -> bool:
-    haystack = _unify_quotes(agent_text)
-    want = _unify_quotes(needle)
-    if want in haystack:
-        return True
-    if is_verbatim_needle(want):
-        return False
-    folded_needle = fold_speech(want)
-    if not folded_needle:
-        return False
-    return folded_needle in fold_speech(haystack)
-
-
-def match_agent_substrs(agent_text: str, substrs: list[str] | None) -> dict[str, Any]:
-    """Empty substrs pass. Exact hit always counts; else fold unless verbatim."""
-    wanted = [s for s in (substrs or []) if s]
-    if not wanted:
-        return {"passed": True, "missing": [], "found": []}
-    missing = [s for s in wanted if not substr_matches(agent_text, s)]
-    found = [s for s in wanted if substr_matches(agent_text, s)]
-    return {"passed": not missing, "missing": missing, "found": found}
-
-
 def _fetch_result(result_id: str) -> dict[str, Any]:
     body = verify_run._get(f"retrieve-simulation-result/{result_id}")
     return body.get("simulation_result") or body
@@ -763,8 +624,6 @@ def verify_result(
         schemas = load_tool_schemas(industry)
     lines = result_transcript_lines(result)
     agent_text = agent_transcript(lines)
-    substrs = (task or {}).get("prompt_adherence_substrs") if task else None
-    substr = match_agent_substrs(agent_text, substrs)
     actual_calls = actual_tool_calls(result)
     expected_calls = list((task or {}).get("exp_tool_calls") or [])
     call = tool_call_adherence(expected_calls, actual_calls, schemas=schemas)
@@ -789,13 +648,11 @@ def verify_result(
             state = {"passed": matched, "skipped": False, "note": None}
 
     passed = (
-        substr["passed"]
-        and state.get("passed") is not False
+        state.get("passed") is not False
         and call["passed"]
         and handoff["passed"]
     )
     return {
-        "substr": substr,
         "state": state,
         "call": call,
         "handoff": handoff,
@@ -899,8 +756,6 @@ def main(argv: list[str] | None = None) -> int:
             extra = f"  ↳ {row['void_reason']}"
         elif not task:
             extra = "  ↳ no task.json for this digital human"
-        elif not check["substr"]["passed"]:
-            extra = f"  ↳ missing substrs: {check['substr']['missing']}"
         elif not check["call"]["passed"]:
             extra = f"  ↳ missing tools: {check['call']['missing']}"
         elif not check["handoff"]["passed"]:

--- a/tests/test_tasks_to_digital_humans.py
+++ b/tests/test_tasks_to_digital_humans.py
@@ -43,7 +43,6 @@ def test_names_are_person_only_and_test_name_from_task() -> None:
 def test_case_key_trait_and_no_verifier_fields() -> None:
     for dh in _humans():
         assert conv.trait_value(dh, "case_key") == conv.case_key_of(dh)
-        assert "prompt_adherence_substrs" not in dh
         assert "exp_db_state" not in dh
         assert conv.trait_value(dh, "call_area")
         assert conv.trait_value(dh, "difficulty")
@@ -196,3 +195,92 @@ def test_encoder_slugs_stay_inside_enums() -> None:
         [],
     )
     assert (quoted.get("parameters") or {}).get("service") != "laser"
+
+
+def _encoder():
+    spec = importlib.util.spec_from_file_location(
+        "encode_healthcare_tasks", ROOT / "scripts" / "encode_healthcare_tasks.py"
+    )
+    assert spec is not None and spec.loader is not None
+    enc = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(enc)
+    return enc
+
+
+def test_encoder_drops_courtesy_send_sms() -> None:
+    enc = _encoder()
+    courtesy = {
+        "intent": "Take the first time they offer, confirm it, then thank them and end the call.",
+        "scripted_responses": [],
+        "exp_tool_calls": [
+            {"name": "book_appointment"},
+            {
+                "name": "send_sms",
+                "parameters": {"template_id": "appointment_confirmation"},
+            },
+        ],
+        "exp_db_state": {
+            "tool_events": [
+                {"kind": "sms", "payload": {"template_id": "appointment_confirmation"}},
+            ],
+        },
+    }
+    dropped = enc.drop_unneeded_send_sms(courtesy)
+    assert [call["name"] for call in dropped] == ["book_appointment"]
+    state = enc.drop_courtesy_sms_events({**courtesy, "exp_tool_calls": dropped})
+    assert state["tool_events"] == []
+
+    wants_address = {
+        "intent": "Ask them to text you the address so you have it.",
+        "scripted_responses": [
+            {"response_value": "Yes, please text me the address."},
+        ],
+        "exp_tool_calls": [
+            {"name": "send_sms", "parameters": {"template_id": "directions"}},
+            {"name": "book_appointment"},
+        ],
+    }
+    kept = [call["name"] for call in enc.drop_unneeded_send_sms(wants_address)]
+    assert kept == ["send_sms", "book_appointment"]
+
+    deposit = {
+        "intent": "Ask them to text you the deposit link so you can pay it.",
+        "scripted_responses": [],
+        "exp_tool_calls": [
+            {"name": "send_payment_link"},
+            {"name": "send_sms", "parameters": {"template_id": "cosmetic_deposit"}},
+        ],
+    }
+    assert [call["name"] for call in enc.drop_unneeded_send_sms(deposit)] == [
+        "send_payment_link",
+    ]
+
+    faq = {
+        "intent": (
+            "Ask when they send appointment confirmation texts — how many days "
+            "before the visit they start."
+        ),
+        "scripted_responses": [],
+        "exp_tool_calls": [
+            {"name": "send_sms", "parameters": {"template_id": "appointment_confirmation"}},
+        ],
+    }
+    assert enc.drop_unneeded_send_sms(faq) == []
+
+
+def test_healthcare_send_sms_only_when_caller_wants_text() -> None:
+    import json
+
+    enc = _encoder()
+    keep: list[str] = []
+    for path in sorted((ROOT / "industries" / "healthcare" / "tasks").glob("*/task.json")):
+        task = json.loads(path.read_text())
+        names = [call.get("name") for call in task.get("exp_tool_calls") or []]
+        if "send_sms" not in names:
+            continue
+        keep.append(path.parent.name)
+        assert enc.caller_requests_sms(task), path.parent.name
+        for call in task["exp_tool_calls"]:
+            assert enc.keep_send_sms_call(task, call, names)
+    assert keep == ["C1-H2", "C3-H2"]
+

--- a/tests/test_verify_task_run.py
+++ b/tests/test_verify_task_run.py
@@ -1,4 +1,4 @@
-"""Prompt-adherence substring + state checks (no live API)."""
+"""Tool, handoff, and office-state checks (no live API)."""
 
 from __future__ import annotations
 
@@ -16,33 +16,6 @@ sys.modules["verify_task_run"] = vtr
 _SPEC.loader.exec_module(vtr)
 
 
-def test_empty_substrs_pass() -> None:
-    assert vtr.match_agent_substrs("anything", []) == {
-        "passed": True, "missing": [], "found": [],
-    }
-    assert vtr.match_agent_substrs("", None)["passed"] is True
-
-
-def test_substring_names_casefold_verbatim_stays_exact() -> None:
-    text = "I can confirm Alice Romano is on file. The deductible or copay is listed."
-    ok = vtr.match_agent_substrs(text, ["Alice Romano", "deductible or copay"])
-    assert ok["passed"] is True
-    assert ok["missing"] == []
-
-    miss = vtr.match_agent_substrs(text, ["Alice Romano", "did I get that right?"])
-    assert miss["passed"] is False
-    assert miss["missing"] == ["did I get that right?"]
-
-    case = vtr.match_agent_substrs(text, ["alice romano"])
-    assert case["passed"] is True
-
-    verbatim = vtr.match_agent_substrs(
-        "Sorry, I cannot help with that.",
-        ["Sorry, I can't help with that."],
-    )
-    assert verbatim["passed"] is False
-
-
 def test_agent_transcript_ignores_caller_turns() -> None:
     lines = [
         "USER: Alice Romano",
@@ -55,8 +28,6 @@ def test_agent_transcript_ignores_caller_turns() -> None:
     assert "I can look that up." in text
     assert "Alice Romano" not in text
     assert "deductible or copay" not in text
-    leaked = vtr.match_agent_substrs(text, ["Alice Romano"])
-    assert leaked["passed"] is False
 
 
 def test_states_match_via_canonical_state() -> None:
@@ -89,7 +60,6 @@ def test_office_states_ignore_tool_events_and_description() -> None:
 
 def test_verify_result_ignores_tool_events_in_state() -> None:
     task = {
-        "prompt_adherence_substrs": [],
         "exp_db_state": {
             "patients": [{"id": "p1", "phone_e164": "+17185550191"}],
             "appointments": [],
@@ -110,20 +80,18 @@ def test_verify_result_ignores_tool_events_in_state() -> None:
     assert out["passed"] is True
 
 
-def test_verify_result_empty_substrs_and_matching_state() -> None:
-    task = {"prompt_adherence_substrs": [], "exp_db_state": {"waitlist": []}}
+def test_verify_result_matching_state() -> None:
+    task = {"exp_db_state": {"waitlist": []}}
     result = {"transcript": [{"role": "agent", "text": "hello"}]}
     out = vtr.verify_result(result, task, {"waitlist": [], "created_at": "x"})
-    assert out["substr"]["passed"] is True
     assert out["state"]["passed"] is True
     assert out["passed"] is True
 
 
 def test_verify_result_skips_state_when_dump_missing() -> None:
-    task = {"prompt_adherence_substrs": ["hello"], "exp_db_state": {"waitlist": []}}
+    task = {"exp_db_state": {"waitlist": []}}
     result = {"messages": [{"role": "assistant", "content": "hello there"}]}
     out = vtr.verify_result(result, task, None, state_note="S3 not configured")
-    assert out["substr"]["passed"] is True
     assert out["state"]["skipped"] is True
     assert out["state"]["note"] == "S3 not configured"
     assert out["passed"] is True
@@ -183,9 +151,38 @@ def test_handoff_adherence_is_in_order_subsequence() -> None:
     assert unexpected["verdict"] == "unexpected_handoffs"
 
 
+def test_actual_tool_calls_sort_by_start_offset_not_group_order() -> None:
+    """Bluejay groups by name; C5-M2 listed billing before identity."""
+    result = {
+        "tool_calls": [
+            {
+                "name": "transfer_to_billing",
+                "actual": [{
+                    "parameters": {"to": "billing", "from": "identity"},
+                    "start_offset_ms": 91015,
+                }],
+            },
+            {
+                "name": "transfer_to_identity",
+                "actual": [{
+                    "parameters": {"to": "identity", "from": "reception"},
+                    "start_offset_ms": 23688,
+                }],
+            },
+        ],
+    }
+    names = [call["name"] for call in vtr.actual_tool_calls(result)]
+    assert names == ["transfer_to_identity", "transfer_to_billing"]
+    path = vtr.handoff_adherence(
+        ["transfer_to_identity", "transfer_to_billing"],
+        vtr.actual_handoffs(names),
+    )
+    assert path["passed"] is True
+    assert path["verdict"] == "exact"
+
+
 def test_verify_result_includes_call_and_handoff() -> None:
     task = {
-        "prompt_adherence_substrs": ["hello"],
         "exp_db_state": {"waitlist": []},
         "exp_tool_calls": [{"name": "list_locations"}],
         "exp_handoff_path": [],
@@ -206,47 +203,6 @@ def test_case_key_from_trait_or_test_name() -> None:
         "test_name": "ignored",
     }) == "C1-E1-BG"
     assert vtr.case_key_from_dh({"test_name": "C5-H3: Itemized balance"}) == "C5-H3"
-
-
-def test_substring_folds_dates_phones_911_money_floors() -> None:
-    text = (
-        "Jordan Lee, April 12, 1990 — yes. Please call 9-1-1. "
-        "Park Avenue is the fourth floor. The deposit is one hundred twenty-five dollars. "
-        "The number is 718-555-0191."
-    )
-    ok = vtr.match_agent_substrs(text, [
-        "April twelfth, nineteen ninety",
-        "call 911",
-        "4th floor",
-        "7185550191",
-    ])
-    assert ok["passed"] is True
-    spoken = vtr.match_agent_substrs(
-        "March 22, 2016. June 30, 1972.",
-        [
-            "March twenty-second, two thousand sixteen",
-            "June thirtieth, nineteen seventy-two",
-        ],
-    )
-    assert spoken["passed"] is True
-    money = vtr.match_agent_substrs(
-        "A one hundred twenty-five dollar deposit may apply.",
-        ["$125"],
-    )
-    assert money["passed"] is True
-
-
-def test_substring_does_not_fold_verbatim_standing_lines() -> None:
-    close = vtr.match_agent_substrs(
-        "I cannot take a card number over the phone.",
-        ["I can't take a card number by voice"],
-    )
-    assert close["passed"] is False
-    exact = vtr.match_agent_substrs(
-        "I can't take a card number by voice, I'll send a link.",
-        ["I can't take a card number by voice"],
-    )
-    assert exact["passed"] is True
 
 
 def test_tool_call_adherence_ignores_prose_args() -> None:
@@ -361,3 +317,28 @@ def test_location_ids_require_exact_set() -> None:
         "parameters": {"location_ids": ["Park Avenue"]},
     }]
     assert vtr.tool_call_adherence(expected, ok, schemas=schemas)["passed"] is True
+
+
+def test_send_sms_is_required_only_when_listed() -> None:
+    schemas = vtr.load_tool_schemas("healthcare")
+    booked = [{"name": "book_appointment", "parameters": {}}]
+    with_sms = [
+        {"name": "book_appointment"},
+        {
+            "name": "send_sms",
+            "parameters": {
+                "template_id": "appointment_confirmation",
+                "mobile_e164": "+12125550100",
+            },
+        },
+    ]
+    miss = vtr.tool_call_adherence(with_sms, booked, schemas=schemas)
+    assert miss["passed"] is False
+    assert "send_sms" in miss["missing"]
+    skip_ok = vtr.tool_call_adherence(
+        [{"name": "book_appointment"}],
+        booked,
+        schemas=schemas,
+    )
+    assert skip_ok["passed"] is True
+


### PR DESCRIPTION
## Summary
- Drop `prompt_adherence_substrs` and the deterministic glyph-substring verifier; prompt-adherence is an LLM judge, not a transcript grep.
- Keep `send_sms` in expected tool calls only when the caller actually asks for a text, and rewrite healthcare `tools.json` descriptions around when to call each tool.
- Remove name/DOB “did I get that right” scripted-response pins from existing-patient tasks. First-ask identity pins (`Alice Romano. My date of birth is …`) stay so `verify_identity` can still run.

## Test plan
- [x] `uv run pytest tests/test_verify_task_run.py tests/test_tasks_to_digital_humans.py`
- [x] `rg -n "did I get that right" industries/healthcare/tasks` is empty
- [ ] `uv run python scripts/tasks_to_digital_humans.py --industry healthcare --simulation-id 30606` claims all 66 DHs
- [ ] Spot-check a couple live DHs: no substring success criteria, no name/DOB readback pins
- [ ] Do not queue a simulation run


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops scoring healthcare prompt-adherence with transcript substrings and narrows the verifier to state, tool-call, and handoff checks. Previously success required `prompt_adherence_substrs`; now tasks omit that field and prompt adherence is judged separately.

- scripts/verify_task_run.py: removes the agent-substring check; verifier now checks only office state, expected tool calls, and handoff path. Tests updated accordingly.
- industries/healthcare/tasks: drops all `prompt_adherence_substrs`; removes courtesy `send_sms` from `exp_tool_calls` and `exp_db_state.tool_events`; updates a few intents to explicitly accept texting when asked; keeps first-ask identity pins, removes name/DOB readback pins.
- industries/healthcare/tools.json: rewrites `identify_patient` and `verify_identity` descriptions to clarify when to call and that identification does not verify identity.
- scripts/encode_healthcare_tasks.py and scripts/healthcare_digital_humans.py: stop deriving substrings and readback pins; drop courtesy `send_sms`. scripts/tasks_to_digital_humans.py rejects copying `exp_db_state` onto DHs. Tests updated to assert the new encoder behavior.

Migration:
- Remove any downstream references to `prompt_adherence_substrs`. Only expect `send_sms` when the caller asks for a text.

<sup>Written for commit 9410ee35ad2d1126600b5a0a13d1795882ce16d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/36?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

