### PR TITLE
Eliminate remaining healthcare mixed cases

### DIFF
--- a/industries/healthcare/tasks/C3-H2/task.json
+++ b/industries/healthcare/tasks/C3-H2/task.json
@@ -82,9 +82,27 @@
   "scripted_responses": [
     {
       "match_type": "context",
+      "match_phrase": "greets you and asks what you need, what they can help with, or why you are calling, before you have explained the reason for the call.",
+      "response_type": "phrase",
+      "response_value": "What would a visit cost out of pocket at Park Avenue?"
+    },
+    {
+      "match_type": "context",
+      "match_phrase": "says they cannot give a reliable out-of-pocket number or ballpark, or says coverage must be checked before they can estimate the visit cost. NOT when they are already choosing an appointment time.",
+      "response_type": "phrase",
+      "response_value": "Is there any rough ballpark at all? If not, I still want to book a routine rash visit at Park Avenue as a new patient."
+    },
+    {
+      "match_type": "context",
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
       "response_type": "phrase",
       "response_value": "Aggie Trumbull. My date of birth is May ninth, nineteen seventy-eight."
+    },
+    {
+      "match_type": "context",
+      "match_phrase": "reads your name back as Addie, Abby, Aggy, or anything other than Aggie Trumbull and asks whether it is correct.",
+      "response_type": "phrase",
+      "response_value": "No. It is Aggie Trumbull \u2014 Aggie, A-G-G-I-E. I am a new patient."
     },
     {
       "match_type": "context",

--- a/industries/healthcare/tasks/C3-M1/task.json
+++ b/industries/healthcare/tasks/C3-M1/task.json
@@ -96,9 +96,21 @@
     },
     {
       "match_type": "context",
-      "match_phrase": "reads your name and date of birth back to you and asks whether that is right, or asks you to confirm the name and date of birth they just repeated. NOT when first asking for your name and date of birth, NOT when asking for a phone or mobile number.",
+      "match_phrase": "reads your name and date of birth back to you and asks whether that is right before saying your identity was verified or your chart was opened. NOT when first asking for your name and date of birth, NOT when asking for a phone or mobile number, NOT after identity has already been verified.",
       "response_type": "phrase",
-      "response_value": "Yes, that's right."
+      "response_value": "Yes, that's right. Please verify me and pull my chart before checking the copay; my Aetna information is already on file."
+    },
+    {
+      "match_type": "context",
+      "match_phrase": "asks for your insurance carrier, member ID, provider, or other coverage details after only reading your name and date of birth back, without saying your identity was verified or your chart was opened. NOT when they have already verified you or pulled your chart.",
+      "response_type": "phrase",
+      "response_value": "Please verify me and pull my chart first. I am an existing patient, and my Aetna information is already on file."
+    },
+    {
+      "match_type": "context",
+      "match_phrase": "after verifying you or opening your chart, offers to continue with a coverage team, benefits check, eligibility check, or copay check to get the live copay. NOT when offering a human callback or front desk.",
+      "response_type": "phrase",
+      "response_value": "Yes, please continue with the coverage check and tell me the copay from the system."
     },
     {
       "match_type": "context",

--- a/industries/healthcare/tasks/C4-H2/task.json
+++ b/industries/healthcare/tasks/C4-H2/task.json
@@ -113,6 +113,12 @@
     },
     {
       "match_type": "context",
+      "match_phrase": "says CareCredit may qualify or may be available but refuses to check because the exact Botox amount is not known yet, or tells you to ask about financing at the consult instead of checking now.",
+      "response_type": "phrase",
+      "response_value": "Please check whether CareCredit is available for the low end of the quote, three hundred dollars. I need an answer from the system before I go."
+    },
+    {
+      "match_type": "context",
       "match_phrase": "thanks you, says goodbye, asks if you need anything else, or says financing may be available without checking CareCredit in the system. NOT when they have just confirmed CareCredit or a payment plan from a lookup.",
       "response_type": "phrase",
       "response_value": "Please look up CareCredit in the system before I go. I need to know whether I can spread the Botox cost out."

--- a/industries/healthcare/tasks/C5-H2/task.json
+++ b/industries/healthcare/tasks/C5-H2/task.json
@@ -79,9 +79,6 @@
       "name": "explain_charge",
       "output": {
         "ok": true
-      },
-      "parameters": {
-        "line_item_id": "li_noshow"
       }
     },
     {
@@ -111,6 +108,12 @@
     "creativity": 0
   },
   "scripted_responses": [
+    {
+      "match_type": "context",
+      "match_phrase": "greets you and asks what you need, what they can help with, or why you are calling, before you have explained the reason for the call.",
+      "response_type": "phrase",
+      "response_value": "I need to know my total balance and get a brief explanation of the charges."
+    },
     {
       "match_type": "context",
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",


### PR DESCRIPTION
## Summary
- refine fairness-grounded caller persistence/ordering and task-level verifier expectations
- preserve substantive booking, identity, eligibility, financing, and billing requirements
- reduce k=3 mixed cases [4 (run 237583)](https://app.getbluejay.ai/runs/237583) → [2 (run 237602)](https://app.getbluejay.ai/runs/237602) → [1 (run 237620)](https://app.getbluejay.ai/runs/237620) → [0 (run 237634)](https://app.getbluejay.ai/runs/237634)

[PR #37](https://github.com/bluejay-ai-dev/mivas-bench/pull/37) contained the earlier suite changes and is already merged; this PR carries the follow-up zero-mixed commit.

## Test plan
- [x] `uv run pytest tests/test_verify_task_run.py tests/test_tasks_to_digital_humans.py -q` (38 passed)
- [x] [Final Bluejay run 237634](https://app.getbluejay.ai/runs/237634) — mixed none; always C4-M1, C5-H1, R-M1; never C3-H2, C3-M1, C4-H2, C5-H2, R-H2

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Eliminates remaining mixed outcomes in healthcare tasks by tightening scripted responses and removing an irrelevant charge-line constraint. Previously runs produced mixed caller outcomes; now call flows consistently verify identity before coverage checks, confirm financing from the system, and open with clear intents.

- C3-H2: add greeting intent, add ballpark fallback when coverage is required, and correct name disambiguation to keep booking on track.
- C3-M1: require identity verification/chart open before any insurance questions; after verification, proceed with a system copay/eligibility check.
- C4-H2: require a CareCredit availability check now using the low-end quote, not deferring to the consult.
- C5-H2: add greeting intent and remove the hardcoded `line_item_id` from the charge explanation to avoid irrelevant constraints.

<sup>Written for commit 3f71d4cf083338c84ebc00da97618e1d40bfe1e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/38?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

