### PR TITLE
Stabilize healthcare mixed-task fairness

### DIFF
--- a/industries/healthcare/db/schema.sql
+++ b/industries/healthcare/db/schema.sql
@@ -51,6 +51,12 @@ CREATE TABLE IF NOT EXISTS appointments (
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_booked_allergy
+    ON appointments(patient_id, location_id, appointment_type_code)
+    WHERE status = 'booked'
+      AND appointment_type_code LIKE 'ALLERGY_%'
+      AND appointment_type_code != 'ALLERGY_EVAL';
+
 CREATE TABLE IF NOT EXISTS waitlist (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     patient_id TEXT REFERENCES patients(id),

--- a/industries/healthcare/db/schema.sql
+++ b/industries/healthcare/db/schema.sql
@@ -51,6 +51,8 @@ CREATE TABLE IF NOT EXISTS appointments (
     created_at TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+-- one booked allergy-service row per patient/office; a later distinct slot
+-- for the same service is not a fixture case.
 CREATE UNIQUE INDEX IF NOT EXISTS uniq_booked_allergy
     ON appointments(patient_id, location_id, appointment_type_code)
     WHERE status = 'booked'

--- a/industries/healthcare/db/schema.sql
+++ b/industries/healthcare/db/schema.sql
@@ -54,7 +54,7 @@ CREATE TABLE IF NOT EXISTS appointments (
 -- one booked allergy-service row per patient/office; a later distinct slot
 -- for the same service is not a fixture case.
 CREATE UNIQUE INDEX IF NOT EXISTS uniq_booked_allergy
-    ON appointments(patient_id, location_id, appointment_type_code)
+    ON appointments(ifnull(patient_id, ''), location_id, appointment_type_code)
     WHERE status = 'booked'
       AND appointment_type_code LIKE 'ALLERGY_%'
       AND appointment_type_code != 'ALLERGY_EVAL';

--- a/industries/healthcare/system-prompts/billing.md
+++ b/industries/healthcare/system-prompts/billing.md
@@ -117,10 +117,9 @@ rescheduling something before the call is over.
 Sequence — this order is hard:
 1. get_account_balance. Open with the amount the tool returns, in words.
    Nothing comes before the amount. Do not invent a sample balance.
-2. For a caller asking about multiple charges, identify the description and
-   amount from get_account_balance, then call explain_charge for each returned
-   line item exactly once and say each approved_script. Do not improvise or
-   repeat an explanation.
+2. explain_charge. Call it for the charge they ask about, or for each returned
+   line item exactly once when they ask about multiple charges. Say each
+   approved_script. Do not improvise or repeat an explanation.
 3. Ask one concise resolution question that matches what the caller requested,
    then wait for the caller. Do not enumerate payment, financing, fee review,
    scheduling, and transfer options in one turn. Complete only the selected

--- a/industries/healthcare/system-prompts/billing.md
+++ b/industries/healthcare/system-prompts/billing.md
@@ -120,10 +120,11 @@ Sequence — this order is hard:
 2. explain_charge. Call it for the charge they ask about, or for each returned
    line item exactly once when they ask about multiple charges. Say each
    approved_script. Do not improvise or repeat an explanation.
-3. Ask one concise resolution question that matches what the caller requested,
-   then wait for the caller. Do not enumerate payment, financing, fee review,
-   scheduling, and transfer options in one turn. Complete only the selected
-   resolution:
+3. If the caller already stated a resolution or asked for a person, complete
+   that path immediately — do not re-ask. Otherwise ask one concise resolution
+   question that matches what they requested, then wait. Do not enumerate
+   payment, financing, fee review, scheduling, and transfer options in one turn.
+   Complete only the selected resolution:
    - pay now → send_payment_link with mobile_e164 (never take the card by voice)
    - can't pay it all → offer_financing with amount_cents (CareCredit, over
      two hundred fifty)

--- a/industries/healthcare/system-prompts/billing.md
+++ b/industries/healthcare/system-prompts/billing.md
@@ -117,8 +117,14 @@ rescheduling something before the call is over.
 Sequence — this order is hard:
 1. get_account_balance. Open with the amount the tool returns, in words.
    Nothing comes before the amount. Do not invent a sample balance.
-2. explain_charge. Say the approved_script it returns. Do not improvise.
-3. Offer a real resolution before leaving billing — at least one, out loud:
+2. For a caller asking about multiple charges, identify the description and
+   amount from get_account_balance, then call explain_charge for each returned
+   line item exactly once and say each approved_script. Do not improvise or
+   repeat an explanation.
+3. Ask one concise resolution question that matches what the caller requested,
+   then wait for the caller. Do not enumerate payment, financing, fee review,
+   scheduling, and transfer options in one turn. Complete only the selected
+   resolution:
    - pay now → send_payment_link with mobile_e164 (never take the card by voice)
    - can't pay it all → offer_financing with amount_cents (CareCredit, over
      two hundred fifty)

--- a/industries/healthcare/system-prompts/clinical.md
+++ b/industries/healthcare/system-prompts/clinical.md
@@ -142,9 +142,9 @@ Refills:
 - Follow the route request_rx_refill gives you. A biologic_coordinator or
   re-authorization route is not a reason to skip that write.
 - If prior-authorization follow-up or a clinical callback is also requested,
-  call create_clinical_message after the refill write (category=rx_question).
-  The message does not replace the refill request. Say the returned callback
-  window; keep the confirmed callback number already on the chart.
+  call create_clinical_message after the refill write (category=rx_question,
+  priority=urgent). The message does not replace the refill request. Say the
+  returned callback window; keep the confirmed callback number already on the chart.
 - pharmacy self-service: ask pharmacy to send electronic request; three
   business days.
 - clinical task: created; say the three-business-day window.
@@ -161,8 +161,7 @@ the right priority and say the callback window out loud.
 # TOOLS AT THIS STAGE
 - get_results_status — required: order_type (pathology | lab | allergy). Status
   only plus an approved script. Never returns result content.
-- request_rx_refill — required: medication_name. Optional: pharmacy_phone
-  (E.164), last_fill_date (YYYY-MM-DD).
+- request_rx_refill — required: medication_name.
   Routes the refill (routed_to_provider | isotretinoin_program |
   controlled_substance | biologic_coordinator). Follow the route; never
   approve a refill yourself. controlled_substance returns spoken_commitment

--- a/industries/healthcare/system-prompts/clinical.md
+++ b/industries/healthcare/system-prompts/clinical.md
@@ -130,7 +130,21 @@ Results — highest-anxiety call in the building:
   promise a same-day call unless a tool returned that window.
 
 Refills:
-- request_rx_refill and follow the route it gives you.
+- Immediately after identity verification, for every named-medication refill
+  request, call request_rx_refill exactly once with only medication_name. Make
+  this call before saying anything about refill policy, collecting any other
+  detail, creating a message or callback, or handing off. This includes
+  isotretinoin, controlled substances, biologics, and refill-related prior
+  authorization. The tool records and routes the request; calling it does not
+  approve the medication.
+- Do not ask for a pharmacy phone number or last-fill date. They are not inputs
+  to request_rx_refill and their absence never blocks the call.
+- Follow the route request_rx_refill gives you. A biologic_coordinator or
+  re-authorization route is not a reason to skip that write.
+- If prior-authorization follow-up or a clinical callback is also requested,
+  call create_clinical_message after the refill write (category=rx_question).
+  The message does not replace the refill request. Say the returned callback
+  window; keep the confirmed callback number already on the chart.
 - pharmacy self-service: ask pharmacy to send electronic request; three
   business days.
 - clinical task: created; say the three-business-day window.

--- a/industries/healthcare/system-prompts/coverage.md
+++ b/industries/healthcare/system-prompts/coverage.md
@@ -141,6 +141,13 @@ capture_insurance_update, read the member ID back character by character and
 get an explicit yes. Then send the secure link for card photos. Never ask for
 a Social Security number.
 
+The group number is optional. Carrier and member ID are the complete required
+fields. If the caller has no group number, do not demand one, defer the update,
+offer a callback, or transfer solely for that reason. After identity and member
+ID readback are confirmed, call capture_insurance_update with the carrier and
+member ID you have. Do not promise to save it later; the missing optional group
+number is never a hard stop.
+
 # TOOLS AT THIS STAGE
 - list_locations — zip or location_id (loc_park_ave | loc_brooklyn_heights |
   loc_windermere). Resolve the office before any acceptance check; acceptance

--- a/industries/healthcare/system-prompts/scheduling.md
+++ b/industries/healthcare/system-prompts/scheduling.md
@@ -155,9 +155,17 @@ Cancelling:
   fee_disclosed_and_accepted=true if they still want to cancel.
 - Always offer to rebook; if not, offer the waitlist.
 
-Allergy: schedule_allergy_service, and say the prep out loud — antihistamine
-washout for skin testing, 48/96-hour return reads for patch testing, 30-minute
-observation after a shot.
+Allergy uses a dedicated offer → accept → commit sequence:
+1. Resolve the allergy service and office. Give window_start/window_end as
+   search bounds; never present either bound as the appointment itself.
+2. Offer the first available slot returned within office hours and the requested
+   bounds. Wait for an explicit yes.
+3. After that yes, call schedule_allergy_service exactly once. A generic
+   find_slots/book_appointment path does not replace this allergy booking.
+4. Say the returned prep out loud — antihistamine washout for skin testing,
+   48/96-hour return reads for patch testing, 30-minute observation after a shot.
+If a repeated call returns idempotent=true, confirm the existing booking; do not
+create or imply a second appointment.
 
 # TOOLS AT THIS STAGE
 - classify_visit_request — required: visit_class (cosmetic | mohs | allergy |
@@ -187,8 +195,10 @@ observation after a shot.
   latest.
 - schedule_allergy_service — required: service (skin_testing | patch_testing |
   food_challenge | allergy_shot | drops_pickup | asthma_eval |
-  immunotherapy_buildup), location_id. Say prep, observation, and linked
-  return visits out loud.
+  immunotherapy_buildup), location_id. Optional window_start and window_end are
+  search bounds. It selects a fixture-backed available slot within office hours
+  and those bounds. Call exactly once, only after explicit yes. Say prep,
+  observation, and linked return visits out loud.
 
 # HANDING OFF
 Agent-to-agent transfers take no summary argument — call history is already visible.

--- a/industries/healthcare/system-prompts/scheduling.md
+++ b/industries/healthcare/system-prompts/scheduling.md
@@ -156,12 +156,11 @@ Cancelling:
 - Always offer to rebook; if not, offer the waitlist.
 
 Allergy uses a dedicated offer → accept → commit sequence:
-1. Resolve the allergy service and office. Give window_start/window_end as
-   search bounds; never present either bound as the appointment itself.
-2. Offer the first available slot returned within office hours and the requested
-   bounds. Wait for an explicit yes.
-3. After that yes, call schedule_allergy_service exactly once. A generic
-   find_slots/book_appointment path does not replace this allergy booking.
+1. Resolve the allergy service and office. window_start/window_end are search
+   bounds, not the appointment time.
+2. Offer a time inside office hours and those bounds. Wait for an explicit yes.
+3. After that yes, call schedule_allergy_service exactly once. The tool selects
+   the booked slot; find_slots/book_appointment does not replace this.
 4. Say the returned prep out loud — antihistamine washout for skin testing,
    48/96-hour return reads for patch testing, 30-minute observation after a shot.
 If a repeated call returns idempotent=true, confirm the existing booking; do not

--- a/industries/healthcare/tasks/C1-H1/task.json
+++ b/industries/healthcare/tasks/C1-H1/task.json
@@ -102,6 +102,12 @@
     },
     {
       "match_type": "context",
+      "match_phrase": "says you have been transferred, connected, or sent to scheduling but no appointment time has been confirmed on the calendar. NOT when a specific time has already been booked.",
+      "response_type": "phrase",
+      "response_value": "The transfer is not the appointment. Please keep going and book the first available doctor time at Brooklyn Heights."
+    },
+    {
+      "match_type": "context",
       "match_phrase": "offers the waitlist, a later opening, or to add you to a list. NOT when offering a specific appointment time to book now, NOT when asking for your name or date of birth.",
       "response_type": "phrase",
       "response_value": "No waitlist. Please just finish what I asked."

--- a/industries/healthcare/tasks/C1-H2/task.json
+++ b/industries/healthcare/tasks/C1-H2/task.json
@@ -156,13 +156,19 @@
       "match_type": "context",
       "match_phrase": "quotes weekday hours, opening time, or train directions without saying they looked it up or checked the hours. NOT when they have just said they checked the hours or directions.",
       "response_type": "phrase",
-      "response_value": "Can you look that up in the office hours? Then text me the Park Avenue street address and tell me the floor and the suite."
+      "response_value": "Can you look up both the weekday hours and how to get there by train? Then text me the Park Avenue street address and tell me the floor and the suite."
     },
     {
       "match_type": "context",
-      "match_phrase": "thanks you, says goodbye, or asks if you need anything else after booking but before they have looked up weekday hours and texted the Park Avenue address. NOT when they have just confirmed hours and that the address was texted.",
+      "match_phrase": "answers the weekday hours or gives the Park Avenue address but has not answered how to get there by train. NOT when train or subway directions have already been given.",
       "response_type": "phrase",
-      "response_value": "I still need weekday hours and the address texted to me before I go."
+      "response_value": "I still need the train directions. Please look up how to get to Park Avenue by train."
+    },
+    {
+      "match_type": "context",
+      "match_phrase": "thanks you, says goodbye, or asks if you need anything else before the booking is confirmed on the calendar, the train directions are answered, the street address is texted, and the floor and suite are spoken. NOT when all of those are complete.",
+      "response_type": "phrase",
+      "response_value": "Before I go, I still need the booking confirmed on the calendar, the weekday hours, the train directions, the street address texted to me, and the floor and suite."
     }
   ],
   "customer_name": "Owen Castellanos",

--- a/industries/healthcare/tasks/C1-H2/task.json
+++ b/industries/healthcare/tasks/C1-H2/task.json
@@ -166,7 +166,7 @@
     },
     {
       "match_type": "context",
-      "match_phrase": "thanks you, says goodbye, or asks if you need anything else before the booking is confirmed on the calendar, the train directions are answered, the street address is texted, and the floor and suite are spoken. NOT when all of those are complete.",
+      "match_phrase": "thanks you, says goodbye, or asks if you need anything else before the booking is confirmed on the calendar, the weekday hours are answered, the train directions are answered, the street address is texted, and the floor and suite are spoken. NOT when all of those are complete.",
       "response_type": "phrase",
       "response_value": "Before I go, I still need the booking confirmed on the calendar, the weekday hours, the train directions, the street address texted to me, and the floor and suite."
     }

--- a/industries/healthcare/tasks/C1-H2/task.json
+++ b/industries/healthcare/tasks/C1-H2/task.json
@@ -45,12 +45,6 @@
       }
     },
     {
-      "name": "search_practice_kb",
-      "parameters": {
-        "topic": "directions"
-      }
-    },
-    {
       "name": "list_locations"
     },
     {

--- a/industries/healthcare/tasks/C1-H3/task.json
+++ b/industries/healthcare/tasks/C1-H3/task.json
@@ -95,9 +95,15 @@
   "scripted_responses": [
     {
       "match_type": "context",
-      "match_phrase": "offers an appointment time, a slot, or asks which day or time you want. NOT when asking for your name or date of birth, NOT when they have not yet given the street, floor, and suite if you still need those.",
+      "match_phrase": "offers one or more concrete appointment dates or times, or asks you to choose among concrete slots. NOT when asking for your name, date of birth, mobile number, or ZIP code.",
       "response_type": "phrase",
       "response_value": "I'll take the first time you offered."
+    },
+    {
+      "match_type": "context",
+      "match_phrase": "thanks you, says goodbye, or asks if you need anything else after offering a time but before confirming it is booked on the calendar. NOT when they have just confirmed the booking.",
+      "response_type": "phrase",
+      "response_value": "Please book the first time you offered and confirm it is on the calendar before I go."
     },
     {
       "match_type": "context",

--- a/industries/healthcare/tasks/C1-M2/task.json
+++ b/industries/healthcare/tasks/C1-M2/task.json
@@ -43,12 +43,7 @@
       "name": "transfer_to_scheduling"
     },
     {
-      "name": "find_slots",
-      "parameters": {
-        "location_ids": [
-          "loc_brooklyn_heights"
-        ]
-      }
+      "name": "find_slots"
     },
     {
       "name": "book_appointment",

--- a/industries/healthcare/tasks/C1-M3/task.json
+++ b/industries/healthcare/tasks/C1-M3/task.json
@@ -46,8 +46,7 @@
       "name": "schedule_allergy_service",
       "parameters": {
         "service": "skin_testing",
-        "location_id": "loc_park_ave",
-        "window_start": "2026-08-24T09:00:00"
+        "location_id": "loc_park_ave"
       }
     }
   ],

--- a/industries/healthcare/tasks/C2-H2/task.json
+++ b/industries/healthcare/tasks/C2-H2/task.json
@@ -68,8 +68,7 @@
       "name": "schedule_allergy_service",
       "parameters": {
         "service": "allergy_shot",
-        "location_id": "loc_brooklyn_heights",
-        "window_start": "2026-08-24T09:00:00"
+        "location_id": "loc_brooklyn_heights"
       }
     }
   ],

--- a/industries/healthcare/tasks/C2-M1/task.json
+++ b/industries/healthcare/tasks/C2-M1/task.json
@@ -93,7 +93,7 @@
       "match_type": "context",
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
       "response_type": "phrase",
-      "response_value": "Jordan Lee. My date of birth is April twelfth, nineteen ninety."
+      "response_value": "Jordan Lee. My date of birth is April twelfth, nineteen ninety. Please keep going with the move."
     },
     {
       "match_type": "context",
@@ -109,9 +109,9 @@
     },
     {
       "match_type": "context",
-      "match_phrase": "offers an appointment time, a slot, or asks which day or time you want. NOT when asking for your name or date of birth, NOT when they have not yet given the street, floor, and suite if you still need those.",
+      "match_phrase": "offers one or more concrete appointment dates or times, or asks you to choose among concrete slots. NOT when asking for your name, date of birth, mobile number, or ZIP code.",
       "response_type": "phrase",
-      "response_value": "I'll take the first time you offered."
+      "response_value": "Move my visit to the first time you offered and confirm it is on the calendar."
     },
     {
       "match_type": "context",
@@ -136,12 +136,6 @@
       "match_phrase": "thanks you, says goodbye, or asks if you need anything else after listing openings but before confirming the visit was moved. NOT when they have just confirmed the appointment was rescheduled or moved.",
       "response_type": "phrase",
       "response_value": "Please move me into that first time and confirm it is on the calendar before I go."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "thanks you, says goodbye, or asks if you need anything else before a time has been confirmed on the calendar. NOT when they have just confirmed a booked time.",
-      "response_type": "phrase",
-      "response_value": "I still need that time booked. Please confirm it is on the calendar before I go."
     }
   ],
   "customer_name": "Jordan Lee",

--- a/industries/healthcare/tasks/C2-M3/task.json
+++ b/industries/healthcare/tasks/C2-M3/task.json
@@ -102,9 +102,9 @@
     },
     {
       "match_type": "context",
-      "match_phrase": "offers an appointment time, a slot, or asks which day or time you want. NOT when asking for your name or date of birth, NOT when they have not yet given the street, floor, and suite if you still need those.",
+      "match_phrase": "offers one or more concrete appointment dates or times, or asks you to choose among concrete slots. NOT when asking for your name, date of birth, mobile number, or ZIP code.",
       "response_type": "phrase",
-      "response_value": "I'll take the first time you offered."
+      "response_value": "Book the first time you offered and confirm it is on the calendar."
     },
     {
       "match_type": "context",

--- a/industries/healthcare/tasks/C3-H1/task.json
+++ b/industries/healthcare/tasks/C3-H1/task.json
@@ -86,9 +86,9 @@
   "scripted_responses": [
     {
       "match_type": "context",
-      "match_phrase": "offers an appointment time, a slot, or asks which day or time you want. NOT when asking for your name or date of birth, NOT when they have not yet given the street, floor, and suite if you still need those.",
+      "match_phrase": "offers one or more concrete appointment dates or times, or asks you to choose among concrete slots. NOT when asking for your name, date of birth, mobile number, or ZIP code.",
       "response_type": "phrase",
-      "response_value": "I'll take the first time you offered."
+      "response_value": "Book the first time you offered. I'll stay until you confirm it is on the calendar."
     },
     {
       "match_type": "context",

--- a/industries/healthcare/tasks/C3-M1/task.json
+++ b/industries/healthcare/tasks/C3-M1/task.json
@@ -1,6 +1,6 @@
 {
   "task_name": "C3-M1: Copay for a Park Avenue visit",
-  "intent": "Open by saying you are Jordan Lee, date of birth April twelfth nineteen ninety, an existing Straus patient, and you need your copay for a regular visit at Park Avenue on August twenty-fourth, twenty twenty-six. You are an existing Straus patient. You want to know your copay for a regular visit at Park Avenue on August twenty-fourth, twenty twenty-six. If they ask who you are, give your name and date of birth once, confirm the readback, then continue with the copay. You do not have your insurance card with you; they should already have Aetna on file. If they still ask for the member ID after they have looked you up, give it. Once they tell you the copay, thank them and end the call. Do not ask to book, reschedule, or cancel. Do not ask to change insurance. Do not ask for a callback, to speak to a person, a payment, the patient portal, a waitlist, a text, financing, or the street, floor, or suite. If they try to quote a copay without looking you up, give your name and date of birth again and ask them to pull your chart. Stay until they have looked up the copay on your chart. A spoken guess without a lookup is not enough.",
+  "intent": "Open by saying you are Jordan Lee, date of birth April twelfth nineteen ninety, an existing Straus patient, and you need your copay for a regular visit at Park Avenue on August twenty-fourth, twenty twenty-six. You are an existing Straus patient. You want to know your copay for a regular visit at Park Avenue on August twenty-fourth, twenty twenty-six. If they ask who you are, give your name and date of birth once, confirm the readback, then continue with the copay. They should already have Aetna on file, but you know your member ID is W123456789. If they ask for the member ID after they have looked you up, give that exact ID. Once they tell you the copay, thank them and end the call. Do not ask to book, reschedule, or cancel. Do not ask to change insurance. Do not ask for a callback, to speak to a person, a payment, the patient portal, a waitlist, a text, financing, or the street, floor, or suite. If they try to quote a copay without looking you up, give your name and date of birth again and ask them to pull your chart. Stay until they have looked up the copay on your chart. A spoken guess without a lookup is not enough.",
   "traits": [
     {
       "trait_name": "date_of_birth",
@@ -90,9 +90,15 @@
     },
     {
       "match_type": "context",
-      "match_phrase": "asks for your member ID, insurance card, or to read the numbers off your card, and they have not already confirmed your name. NOT when they already looked you up or verified you, NOT when they are reading a member ID back for confirmation, NOT when asking only for the visit date or which office.",
+      "match_phrase": "asks for your member ID or insurance card before verifying you or opening your chart. NOT when they already looked you up or verified you, NOT when they are reading a member ID back for confirmation, NOT when asking only for the visit date or which office.",
       "response_type": "phrase",
-      "response_value": "I don't have my card with me. I'm already a patient \u2014 it should be on file."
+      "response_value": "Please verify me and pull my chart first. My Aetna information should already be on file."
+    },
+    {
+      "match_type": "context",
+      "match_phrase": "asks for your member ID after saying your identity was verified or your chart was opened. NOT when they are reading the member ID back for confirmation, NOT before identity verification.",
+      "response_type": "phrase",
+      "response_value": "My Aetna member ID is W123456789."
     },
     {
       "match_type": "context",

--- a/industries/healthcare/tasks/C4-E1-BG/task.json
+++ b/industries/healthcare/tasks/C4-E1-BG/task.json
@@ -47,18 +47,6 @@
       "match_phrase": "offers the waitlist, a later opening, or to add you to a list. NOT when offering a specific appointment time to book now, NOT when asking for your name or date of birth.",
       "response_type": "phrase",
       "response_value": "No waitlist. Please just finish what I asked."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "offers to text you a confirmation, directions, or an appointment SMS. NOT when asking for a payment-link number, NOT when asking for your mobile number for identity.",
-      "response_type": "phrase",
-      "response_value": "No thanks, I don't need a text."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "offers to transfer you to a person, the cosmetic team, or a live agent instead of giving the Botox price. NOT when they have just given a price.",
-      "response_type": "phrase",
-      "response_value": "No person. Just tell me what Botox costs at Park Avenue."
     }
   ],
   "customer_name": "Bettina Rausch",

--- a/industries/healthcare/tasks/C4-E1-SIG/task.json
+++ b/industries/healthcare/tasks/C4-E1-SIG/task.json
@@ -47,12 +47,6 @@
       "match_phrase": "offers the waitlist, a later opening, or to add you to a list. NOT when offering a specific appointment time to book now, NOT when asking for your name or date of birth.",
       "response_type": "phrase",
       "response_value": "No waitlist. Please just finish what I asked."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "offers to text you a confirmation, directions, or an appointment SMS. NOT when asking for a payment-link number, NOT when asking for your mobile number for identity.",
-      "response_type": "phrase",
-      "response_value": "No thanks, I don't need a text."
     }
   ],
   "customer_name": "Bettina Rausch",

--- a/industries/healthcare/tasks/C4-E1/task.json
+++ b/industries/healthcare/tasks/C4-E1/task.json
@@ -47,12 +47,6 @@
       "match_phrase": "offers the waitlist, a later opening, or to add you to a list. NOT when offering a specific appointment time to book now, NOT when asking for your name or date of birth.",
       "response_type": "phrase",
       "response_value": "No waitlist. Please just finish what I asked."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "offers to text you a confirmation, directions, or an appointment SMS. NOT when asking for a payment-link number, NOT when asking for your mobile number for identity.",
-      "response_type": "phrase",
-      "response_value": "No thanks, I don't need a text."
     }
   ],
   "customer_name": "Bettina Rausch",

--- a/industries/healthcare/tasks/C4-H1/task.json
+++ b/industries/healthcare/tasks/C4-H1/task.json
@@ -92,7 +92,7 @@
   "scripted_responses": [
     {
       "match_type": "context",
-      "match_phrase": "offers one or more concrete appointment dates or times after saying the Park Avenue street address, floor, and suite, or asks you to choose among concrete consult slots after giving that full address. NOT when any address part is still missing, NOT when asking for your identity.",
+      "match_phrase": "offers one or more concrete appointment dates or times after saying the Park Avenue street address, floor, and suite, asks which day or time you want after giving that full address, or asks you to choose among concrete consult slots after giving that full address. NOT when any address part is still missing, NOT when asking for your identity.",
       "response_type": "phrase",
       "response_value": "Book the first time you offered. I agree to the deposit and cancellation policy, and I still need the deposit payment link texted to my phone."
     },

--- a/industries/healthcare/tasks/C4-H1/task.json
+++ b/industries/healthcare/tasks/C4-H1/task.json
@@ -94,7 +94,7 @@
       "match_type": "context",
       "match_phrase": "offers one or more concrete appointment dates or times after saying the Park Avenue street address, floor, and suite, asks which day or time you want after giving that full address, or asks you to choose among concrete consult slots after giving that full address. NOT when any address part is still missing, NOT when asking for your identity.",
       "response_type": "phrase",
-      "response_value": "Book the first time you offered. I still need the deposit payment link texted to my phone."
+      "response_value": "Book the first time you offered."
     },
     {
       "match_type": "context",

--- a/industries/healthcare/tasks/C4-H1/task.json
+++ b/industries/healthcare/tasks/C4-H1/task.json
@@ -94,7 +94,7 @@
       "match_type": "context",
       "match_phrase": "offers one or more concrete appointment dates or times after saying the Park Avenue street address, floor, and suite, asks which day or time you want after giving that full address, or asks you to choose among concrete consult slots after giving that full address. NOT when any address part is still missing, NOT when asking for your identity.",
       "response_type": "phrase",
-      "response_value": "Book the first time you offered. I agree to the deposit and cancellation policy, and I still need the deposit payment link texted to my phone."
+      "response_value": "Book the first time you offered. I still need the deposit payment link texted to my phone."
     },
     {
       "match_type": "context",
@@ -131,6 +131,12 @@
       "match_phrase": "thanks you, says goodbye, confirms a consult time, or asks if you need anything else before saying a deposit payment link was sent. NOT when they have just said the payment link or deposit link was sent.",
       "response_type": "phrase",
       "response_value": "Please text me the deposit payment link before I go."
+    },
+    {
+      "match_type": "context",
+      "match_phrase": "reads the cosmetic deposit and cancellation policy, asks whether you agree to it, or says they need a clear yes before booking. NOT when they have already confirmed the policy was accepted and the consult is booked.",
+      "response_type": "phrase",
+      "response_value": "Yes. I agree to the $125 deposit, free changes through 72 hours before, forfeiting the deposit inside 72 hours, and paying any treatment balance at the visit. Please book the first time."
     }
   ],
   "customer_name": "Franklin Osei",

--- a/industries/healthcare/tasks/C4-H1/task.json
+++ b/industries/healthcare/tasks/C4-H1/task.json
@@ -92,9 +92,9 @@
   "scripted_responses": [
     {
       "match_type": "context",
-      "match_phrase": "offers an appointment time, a slot, or asks which day or time you want AFTER already saying the street address, the floor, and the suite. NOT when they have not yet given all three, NOT when asking for your name or date of birth.",
+      "match_phrase": "offers one or more concrete appointment dates or times after saying the Park Avenue street address, floor, and suite, or asks you to choose among concrete consult slots after giving that full address. NOT when any address part is still missing, NOT when asking for your identity.",
       "response_type": "phrase",
-      "response_value": "I'll take the first time you offered."
+      "response_value": "Book the first time you offered. I agree to the deposit and cancellation policy, and I still need the deposit payment link texted to my phone."
     },
     {
       "match_type": "context",
@@ -131,12 +131,6 @@
       "match_phrase": "thanks you, says goodbye, confirms a consult time, or asks if you need anything else before saying a deposit payment link was sent. NOT when they have just said the payment link or deposit link was sent.",
       "response_type": "phrase",
       "response_value": "Please text me the deposit payment link before I go."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "thanks you, says goodbye, or asks if you need anything else before a time has been confirmed on the calendar. NOT when they have just confirmed a booked time.",
-      "response_type": "phrase",
-      "response_value": "I still need that time booked. Please confirm it is on the calendar before I go."
     }
   ],
   "customer_name": "Franklin Osei",

--- a/industries/healthcare/tasks/C4-H2/task.json
+++ b/industries/healthcare/tasks/C4-H2/task.json
@@ -32,31 +32,11 @@
     }
   ],
   "exp_handoff_path": [
-    "transfer_to_identity",
     "transfer_to_cosmetic"
   ],
   "exp_tool_calls": [
     {
-      "name": "transfer_to_identity",
-      "parameters": {
-        "next_intent": "cosmetic"
-      }
-    },
-    {
       "name": "transfer_to_cosmetic"
-    },
-    {
-      "name": "verify_identity",
-      "parameters": {
-        "dob": "1972-06-30",
-        "full_name": "Maria Alvarez"
-      },
-      "output": {
-        "ok": true,
-        "data": {
-          "verified": true
-        }
-      }
     },
     {
       "name": "quote_cosmetic_service",

--- a/industries/healthcare/tasks/C4-M1/task.json
+++ b/industries/healthcare/tasks/C4-M1/task.json
@@ -89,6 +89,12 @@
   "scripted_responses": [
     {
       "match_type": "context",
+      "match_phrase": "greets you and asks what you need, what they can help with, or why you are calling, before you have explained the reason for the call.",
+      "response_type": "phrase",
+      "response_value": "What does microneedling cost at Park Avenue? I also want to book a microneedling consult there."
+    },
+    {
+      "match_type": "context",
       "match_phrase": "offers an appointment time, a slot, or asks which day or time you want AFTER already saying the street address, the floor, and the suite. NOT when they have not yet given all three, NOT when asking for your name or date of birth.",
       "response_type": "phrase",
       "response_value": "I'll take the first time you offered."
@@ -128,12 +134,6 @@
       "match_phrase": "thanks you, says goodbye, confirms a consult time, or asks if you need anything else before saying a deposit payment link was sent. NOT when they have just said the payment link or deposit link was sent.",
       "response_type": "phrase",
       "response_value": "Please text me the deposit payment link before I go."
-    },
-    {
-      "match_type": "context",
-      "match_phrase": "thanks you, says goodbye, or asks if you need anything else before a time has been confirmed on the calendar. NOT when they have just confirmed a booked time.",
-      "response_type": "phrase",
-      "response_value": "I still need that time booked. Please confirm it is on the calendar before I go."
     },
     {
       "match_type": "context",

--- a/industries/healthcare/tasks/C5-H1/task.json
+++ b/industries/healthcare/tasks/C5-H1/task.json
@@ -116,12 +116,6 @@
     },
     {
       "match_type": "context",
-      "match_phrase": "offers to text you a confirmation, directions, or an appointment SMS. NOT when offering a payment link or deposit link, NOT when asking for a payment-link number, NOT when asking for your mobile number for identity.",
-      "response_type": "phrase",
-      "response_value": "No thanks, I don't need a text."
-    },
-    {
-      "match_type": "context",
       "match_phrase": "offers to text a payment link, asks whether you want the payment link by text, or asks which mobile number should receive the payment link. NOT when offering an appointment confirmation, directions, or another unrelated text, NOT when they have not yet looked up a payment plan or financing.",
       "response_type": "phrase",
       "response_value": "Yes, please text the payment link to 212-555-0133."

--- a/industries/healthcare/tasks/C5-H1/task.json
+++ b/industries/healthcare/tasks/C5-H1/task.json
@@ -122,6 +122,12 @@
     },
     {
       "match_type": "context",
+      "match_phrase": "offers to text a payment link, asks whether you want the payment link by text, or asks which mobile number should receive the payment link. NOT when offering an appointment confirmation, directions, or another unrelated text.",
+      "response_type": "phrase",
+      "response_value": "Yes, please text the payment link to 212-555-0133."
+    },
+    {
+      "match_type": "context",
       "match_phrase": "thanks you, says goodbye, or offers a payment link before they have looked up a payment plan or financing. NOT when they have just confirmed a plan from their system.",
       "response_type": "phrase",
       "response_value": "I still need a way to spread this out. Please look up a payment plan before I go."

--- a/industries/healthcare/tasks/C5-H1/task.json
+++ b/industries/healthcare/tasks/C5-H1/task.json
@@ -122,7 +122,7 @@
     },
     {
       "match_type": "context",
-      "match_phrase": "offers to text a payment link, asks whether you want the payment link by text, or asks which mobile number should receive the payment link. NOT when offering an appointment confirmation, directions, or another unrelated text.",
+      "match_phrase": "offers to text a payment link, asks whether you want the payment link by text, or asks which mobile number should receive the payment link. NOT when offering an appointment confirmation, directions, or another unrelated text, NOT when they have not yet looked up a payment plan or financing.",
       "response_type": "phrase",
       "response_value": "Yes, please text the payment link to 212-555-0133."
     },

--- a/industries/healthcare/tasks/C5-H2/task.json
+++ b/industries/healthcare/tasks/C5-H2/task.json
@@ -128,9 +128,9 @@
     },
     {
       "match_type": "context",
-      "match_phrase": "offers an appointment time, a slot, or asks which day or time you want. NOT when asking for your name or date of birth, NOT when they have not yet given the street, floor, and suite if you still need those.",
+      "match_phrase": "offers one or more concrete appointment dates or times after the balance and a charge explanation have been given, or asks you to choose among concrete slots. NOT before billing is explained, NOT when asking for your identity.",
       "response_type": "phrase",
-      "response_value": "I'll take the first time you offered."
+      "response_value": "Move tomorrow's visit to the first time you offered and confirm it is on the calendar."
     },
     {
       "match_type": "context",
@@ -167,6 +167,12 @@
       "match_phrase": "states the balance and explains a charge, then thanks you or starts wrapping up before moving tomorrow's appointment. NOT when scheduling is already finding a new time.",
       "response_type": "phrase",
       "response_value": "Thanks. I also cannot make tomorrow's Park Avenue appointment. Please move it to the first later opening."
+    },
+    {
+      "match_type": "context",
+      "match_phrase": "asks whether you want to pay, finance, dispute, or receive a payment link after stating the balance and explaining a charge. NOT before both the balance and a charge explanation have been given.",
+      "response_type": "phrase",
+      "response_value": "No payment or dispute. Now move tomorrow's Park Avenue appointment to the first later opening."
     }
   ],
   "customer_name": "Jordan Lee",

--- a/industries/healthcare/tasks/C5-H3/task.json
+++ b/industries/healthcare/tasks/C5-H3/task.json
@@ -164,7 +164,7 @@
     },
     {
       "match_type": "context",
-      "match_phrase": "asks what you want to do after naming both the missed-visit fee and the visit charge, or asks whether you want to pay the full balance. NOT when only one line has been named.",
+      "match_phrase": "asks what you want to do after naming both the missed-visit fee and the visit charge, or asks whether you want to pay the full balance. NOT when only one line has been named, NOT when neither charge has been named.",
       "response_type": "phrase",
       "response_value": "I'll pay the full balance now. Please text a payment link to 407-555-0155."
     }

--- a/industries/healthcare/tasks/C5-H3/task.json
+++ b/industries/healthcare/tasks/C5-H3/task.json
@@ -106,7 +106,13 @@
       "match_type": "context",
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
       "response_type": "phrase",
-      "response_value": "Alice Romano. My date of birth is September eighth, nineteen ninety-five, and my ZIP code is 34786."
+      "response_value": "Alice Romano. My date of birth is September eighth, nineteen ninety-five."
+    },
+    {
+      "match_type": "context",
+      "match_phrase": "asks for a ZIP code or postal code as a second identity check after confirming your name and date of birth. NOT when asking for an office ZIP, NOT when reading the ZIP back for confirmation.",
+      "response_type": "phrase",
+      "response_value": "My ZIP code is 34786."
     },
     {
       "match_type": "context",

--- a/industries/healthcare/tasks/C5-H3/task.json
+++ b/industries/healthcare/tasks/C5-H3/task.json
@@ -106,7 +106,7 @@
       "match_type": "context",
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
       "response_type": "phrase",
-      "response_value": "Alice Romano. My date of birth is September eighth, nineteen ninety-five."
+      "response_value": "Alice Romano. My date of birth is September eighth, nineteen ninety-five, and my ZIP code is 34786."
     },
     {
       "match_type": "context",
@@ -155,6 +155,12 @@
       "match_phrase": "thanks you, says goodbye, or offers a payment link before they have named both the missed-visit fee and the visit charge. NOT when they have just named both lines.",
       "response_type": "phrase",
       "response_value": "Please name both charges first \u2014 the missed-visit fee and the visit \u2014 then text the payment link to 407-555-0155."
+    },
+    {
+      "match_type": "context",
+      "match_phrase": "asks what you want to do after naming both the missed-visit fee and the visit charge, or asks whether you want to pay the full balance. NOT when only one line has been named.",
+      "response_type": "phrase",
+      "response_value": "I'll pay the full balance now. Please text a payment link to 407-555-0155."
     }
   ],
   "customer_name": "Alice Romano",

--- a/industries/healthcare/tasks/C5-M3/task.json
+++ b/industries/healthcare/tasks/C5-M3/task.json
@@ -1,6 +1,6 @@
 {
   "task_name": "C5-M3: A bill the caller is sure they received",
-  "intent": "You are an existing Straus patient and you are sure you were sent a bill \u2014 you remember opening a statement. Answer their identity questions once with your name and date of birth, confirm the readback if they repeat it, then go straight to the bill. If they say the balance is zero, insist once that you definitely received something and ask them to look again. After they look again and confirm the balance is still zero, accept that, thank them, and end the call. If they offer a callback, a payment link, a transfer to a person, or to book, move, or cancel an appointment, decline and stay on the bill. Do not volunteer a callback, do not give a callback number, and do not ask for a text, the street, the floor, the suite, an office id, a waitlist, or financing. Stay on the bill. If they try to book, transfer, or wrap up before they have looked at the account again, bring them back to the statement.",
+  "intent": "You are an existing Straus patient and you are sure you were sent a bill \u2014 you remember opening a statement. Answer their identity questions once with your name and date of birth. If they ask for a second identity factor, give your ZIP code 11201, and confirm each readback. Then go straight to the bill. If they say the balance is zero, insist once that you definitely received something and ask them to look again. After they look again and confirm the balance is still zero, accept that, thank them, and end the call. If they offer a callback, a payment link, a transfer to a person, or to book, move, or cancel an appointment, decline and stay on the bill. Do not volunteer a callback, do not give a callback number, and do not ask for a text, the street, the floor, the suite, an office id, a waitlist, or financing. Stay on the bill. If they try to book, transfer, or wrap up before they have looked at the account again, bring them back to the statement.",
   "traits": [
     {
       "trait_name": "full_name",
@@ -83,6 +83,18 @@
       "match_phrase": "reads your name and date of birth back to you and asks whether that is right, or asks you to confirm the name and date of birth they just repeated. NOT when first asking for your name and date of birth, NOT when asking for a phone or mobile number.",
       "response_type": "phrase",
       "response_value": "Yes, that's right."
+    },
+    {
+      "match_type": "context",
+      "match_phrase": "asks for a ZIP code or postal code as a second identity check after confirming your name and date of birth. NOT when asking for an office ZIP, NOT when reading the ZIP back for confirmation.",
+      "response_type": "phrase",
+      "response_value": "My ZIP code is 11201."
+    },
+    {
+      "match_type": "context",
+      "match_phrase": "reads ZIP code 11201 back to you and asks whether it is correct. NOT when first asking for the ZIP code.",
+      "response_type": "phrase",
+      "response_value": "Yes, that's correct."
     },
     {
       "match_type": "context",

--- a/industries/healthcare/tasks/R-H1/task.json
+++ b/industries/healthcare/tasks/R-H1/task.json
@@ -77,7 +77,6 @@
     {
       "name": "create_clinical_message",
       "parameters": {
-        "priority": "urgent",
         "category": "results_followup"
       },
       "output": {

--- a/industries/healthcare/tasks/R-H2/task.json
+++ b/industries/healthcare/tasks/R-H2/task.json
@@ -1,6 +1,6 @@
 {
   "task_name": "R-H2: Accutane refill",
-  "intent": "You are an existing Straus patient on isotretinoin, which you call Accutane. You want your next refill sent to your pharmacy because you are getting low. When they ask who you are, give your name and date of birth once; if they read them back, confirm and continue with the refill. If they ask the medication name, say Accutane. If they say a visit is needed first, agree and ask to book a new Accutane program visit at Park Avenue. If they say you already have an acne check or follow-up on August 20, or that you are already set for that date, tell them that visit is not the Accutane program visit and you still need a new program visit booked at Park Avenue. Do not move, cancel, or keep the August 20 acne check as the substitute. Take the first new appointment time they offer for that program visit. Do not ask for a different day, time, or office, and do not suggest any date of your own. Confirm that first new time out loud, then thank them and end the call. Do not ask for a text. Do not ask for the street address, floor, suite, or location id. Do not ask to add insurance, for a callback, to speak to a person, a bill, a payment, the patient portal, a waitlist, financing, or any other appointment besides that Accutane program visit. Stay until they confirm the Accutane refill was sent to the pharmacy, not just that a visit is booked.",
+  "intent": "You are an existing Straus patient on isotretinoin, which you call Accutane. You want your next refill sent to your pharmacy because you are getting low. When they ask who you are, give your name and date of birth once; if they read them back, confirm and continue with the refill. If they ask the medication name, say Accutane. If they say a visit is needed first, agree and ask to book a NEW Accutane program visit at Park Avenue, separate from anything already on the calendar. If they say you already have an acne check or follow-up on August 20, that you are already set for that date, that moving it costs nothing, or they offer to move, reschedule, or switch that existing visit to another time, refuse the move. Tell them to leave the August 20 acne check where it is; that visit is not the Accutane program visit. Ask them to book a NEW separate Accutane program visit at the first Park Avenue weekday morning opening they find. Take that first new weekday morning time. If they say they cannot book it on this call, or they offer a callback or a front-desk follow-up, refuse and insist they book that new program visit now. Do not ask for a different day, time, or office, and do not suggest any date of your own. Confirm that first new time out loud, then thank them and end the call. Do not ask for a text. Do not ask for the street address, floor, suite, or location id. Do not ask to add insurance, for a callback, to speak to a person, a bill, a payment, the patient portal, a waitlist, financing, or any other appointment besides that new Accutane program visit. Stay until they confirm the Accutane refill was sent to the pharmacy, not just that a visit is booked.",
   "traits": [
     {
       "trait_name": "mobile",
@@ -72,9 +72,6 @@
     },
     {
       "name": "request_rx_refill",
-      "parameters": {
-        "medication_name": "Accutane"
-      },
       "output": {
         "ok": true,
         "data": {
@@ -122,9 +119,15 @@
     },
     {
       "match_type": "context",
-      "match_phrase": "tells you that you already have a visit, follow-up, or acne check on August 20, or that you are already set for August 20, or offers that existing appointment as enough for the Accutane refill. NOT when offering a newly found appointment time after searching for openings.",
+      "match_phrase": "tells you that you already have a visit, follow-up, or acne check on August 20, or that you are already set for August 20, or offers that existing appointment as enough for the Accutane refill, or asks whether to keep the August 20 visit. NOT when offering a brand-new separate appointment without mentioning August 20 or moving the existing visit.",
       "response_type": "phrase",
-      "response_value": "That August twentieth acne check is not the Accutane program visit. I still need a new program visit at Park Avenue. What's the soonest new opening there?"
+      "response_value": "Leave the August twentieth acne check where it is. That is not the Accutane program visit. I need a NEW program visit at the first Park Avenue weekday morning opening."
+    },
+    {
+      "match_type": "context",
+      "match_phrase": "offers to move, reschedule, switch, or change the existing August 20 acne check or follow-up to another date, or asks you to confirm moving that visit, or says moving that existing visit costs nothing. NOT when offering a brand-new separate appointment without moving the existing one, NOT when asking for your identity.",
+      "response_type": "phrase",
+      "response_value": "No. Do not reschedule the August twentieth acne check. Leave that visit. Book a NEW Accutane program visit at the first Park Avenue weekday morning slot."
     },
     {
       "match_type": "context",
@@ -134,9 +137,9 @@
     },
     {
       "match_type": "context",
-      "match_phrase": "offers an appointment time, a slot, or asks which day or time you want. NOT when asking for your name or date of birth, NOT when they have not yet given the street, floor, and suite if you still need those.",
+      "match_phrase": "offers one or more concrete dates or times for a new Accutane program visit, or asks you to choose among concrete program-visit slots. NOT when referring to the existing August 20 acne check, NOT when offering to move or reschedule that existing visit, NOT when asking for your identity.",
       "response_type": "phrase",
-      "response_value": "I'll take the first time you offered."
+      "response_value": "Book that first new Park Avenue weekday morning program-visit time as a NEW visit. Leave the August twentieth acne check where it is. I also still need the Accutane refill request submitted."
     },
     {
       "match_type": "context",
@@ -149,6 +152,12 @@
       "match_phrase": "offers the waitlist, a later opening, or to add you to a list. NOT when offering a specific appointment time to book now, NOT when asking for your name or date of birth.",
       "response_type": "phrase",
       "response_value": "No waitlist. Please just finish what I asked."
+    },
+    {
+      "match_type": "context",
+      "match_phrase": "offers a callback, asks for a number to call you back, says the front desk will call or follow up, or says they cannot book the visit on this call. NOT when confirming a booked appointment time, NOT when asking for your identity.",
+      "response_type": "phrase",
+      "response_value": "No callback. Please book the NEW Accutane program visit on this call at the first Park Avenue weekday morning opening. Leave the August twentieth acne check where it is."
     },
     {
       "match_type": "context",
@@ -170,9 +179,9 @@
     },
     {
       "match_type": "context",
-      "match_phrase": "says a visit is required for the Accutane refill but has not confirmed that the refill request was submitted. NOT when they have just confirmed the refill request was sent.",
+      "match_phrase": "says a visit is required for the Accutane refill but has not confirmed that the refill request was submitted. NOT when they have just confirmed the refill request was sent. NOT when offering to move or reschedule the existing August 20 visit.",
       "response_type": "phrase",
-      "response_value": "Please submit the Accutane refill request, and if a program visit is required, book the first new Park Avenue time too."
+      "response_value": "Please submit the Accutane refill request. If a program visit is required, book a NEW Park Avenue program visit at the first weekday morning opening, and leave my August twentieth acne check where it is."
     }
   ],
   "customer_name": "Jordan Lee",

--- a/industries/healthcare/tasks/R-H2/task.json
+++ b/industries/healthcare/tasks/R-H2/task.json
@@ -139,7 +139,7 @@
       "match_type": "context",
       "match_phrase": "offers one or more concrete dates or times for a new Accutane program visit, or asks you to choose among concrete program-visit slots. NOT when referring to the existing August 20 acne check, NOT when offering to move or reschedule that existing visit, NOT when asking for your identity.",
       "response_type": "phrase",
-      "response_value": "Book that first new Park Avenue weekday morning program-visit time as a NEW visit. Leave the August twentieth acne check where it is. I also still need the Accutane refill request submitted."
+      "response_value": "Book that first new Park Avenue weekday morning program-visit time as a NEW visit. Leave the August twentieth acne check where it is."
     },
     {
       "match_type": "context",

--- a/industries/healthcare/tasks/R-H2/task.json
+++ b/industries/healthcare/tasks/R-H2/task.json
@@ -72,6 +72,9 @@
     },
     {
       "name": "request_rx_refill",
+      "parameters": {
+        "medication_name": "Accutane"
+      },
       "output": {
         "ok": true,
         "data": {

--- a/industries/healthcare/tasks/R-H2/task.json
+++ b/industries/healthcare/tasks/R-H2/task.json
@@ -146,7 +146,7 @@
     },
     {
       "match_type": "context",
-      "match_phrase": "offers to transfer you to a human, a person, the front desk, or a live agent. NOT when you already asked for a person, NOT when they are completing the booking or cancel.",
+      "match_phrase": "offers to transfer you to a human, a person, the front desk, or a live agent. NOT when you already asked for a person, NOT when they are completing the booking or cancel, NOT when offering a callback or saying the front desk will call or follow up.",
       "response_type": "phrase",
       "response_value": "No, I don't need a person. Please finish what I asked on this call."
     },

--- a/industries/healthcare/tasks/R-H3/task.json
+++ b/industries/healthcare/tasks/R-H3/task.json
@@ -74,7 +74,6 @@
     {
       "name": "create_clinical_message",
       "parameters": {
-        "priority": "urgent",
         "category": "rx_question"
       },
       "output": {

--- a/industries/healthcare/tool_server.py
+++ b/industries/healthcare/tool_server.py
@@ -733,24 +733,7 @@ def _d_schedule_allergy_service(a: dict[str, Any]) -> dict[str, Any]:
     if spec is None:
         raise ToolError("UNKNOWN_SERVICE", f"No allergy service named {a['service']!r}.")
     loc = _resolve_location(a["location_id"])
-    window_start = str(a.get("window_start") or "")
-    window_end = str(a.get("window_end") or "")
     duration_minutes = 30 + spec["observation_min"]
-    available = [
-        slot_start
-        for slot_start in _SLOT_TIMES
-        if (not window_start or slot_start >= window_start)
-        and (
-            not window_end
-            or _iso_plus_minutes(slot_start, duration_minutes) <= window_end
-        )
-    ]
-    if not available:
-        raise ToolError(
-            "NO_AVAILABILITY",
-            "No allergy appointment is available inside that window. Offer another window.",
-        )
-    start = available[0]
     patient_id = _session_state().get("patient_id")
     appointment_type_code = f"ALLERGY_{service.upper()}"
     with _db() as conn:
@@ -775,17 +758,56 @@ def _d_schedule_allergy_service(a: dict[str, Any]) -> dict[str, Any]:
             "linked_return_visits": spec["linked_visits"],
             "note": "This allergy service was already booked; do not create it again.",
         }
-    created = create_appointment(
-        AppointmentCreate(
-            patient_id=patient_id,
-            location_id=loc["id"],
-            provider_id=prov["id"],
-            appointment_type_code=appointment_type_code,
-            start=start,
-            end=_iso_plus_minutes(start, duration_minutes),
-            description=f"Allergy service: {service}",
+    window_start = str(a.get("window_start") or "")
+    window_end = str(a.get("window_end") or "")
+    available = [
+        slot_start
+        for slot_start in _SLOT_TIMES
+        if (not window_start or slot_start >= window_start)
+        and (
+            not window_end
+            or _iso_plus_minutes(slot_start, duration_minutes) <= window_end
         )
-    )
+    ]
+    if not available:
+        raise ToolError(
+            "NO_AVAILABILITY",
+            "No allergy appointment is available inside that window. Offer another window.",
+        )
+    start = available[0]
+    try:
+        created = create_appointment(
+            AppointmentCreate(
+                patient_id=patient_id,
+                location_id=loc["id"],
+                provider_id=prov["id"],
+                appointment_type_code=appointment_type_code,
+                start=start,
+                end=_iso_plus_minutes(start, duration_minutes),
+                description=f"Allergy service: {service}",
+            )
+        )
+    except sqlite3.IntegrityError:
+        with _db() as conn:
+            existing = conn.execute(
+                """
+                SELECT * FROM appointments
+                WHERE patient_id IS ? AND location_id = ? AND appointment_type_code = ?
+                  AND status = 'booked'
+                ORDER BY id LIMIT 1
+                """,
+                (patient_id, loc["id"], appointment_type_code),
+            ).fetchone()
+        if existing is None:
+            raise
+        return {
+            "appointment": _appointment(existing),
+            "idempotent": True,
+            "prep_instructions": spec["prep"],
+            "observation_minutes_after": spec["observation_min"],
+            "linked_return_visits": spec["linked_visits"],
+            "note": "This allergy service was already booked; do not create it again.",
+        }
     return {
         "appointment": created,
         "idempotent": False,
@@ -1063,7 +1085,6 @@ def _d_request_rx_refill(a: dict[str, Any]) -> dict[str, Any]:
             return payload
     _event("rx_refill_request", {"patient_id": patient["id"], **a, "route": "routed_to_provider"})
     return {"route": "routed_to_provider", "hard_stop": False, "approved": False,
-            "pharmacy_needed": not a.get("pharmacy_phone"),
             "note": "The request is with the clinical team; this never approves a refill."}
 
 

--- a/industries/healthcare/tool_server.py
+++ b/industries/healthcare/tool_server.py
@@ -334,6 +334,11 @@ def _iso_plus_minutes(start: str, minutes: int) -> str:
     return (datetime.fromisoformat(start) + timedelta(minutes=minutes)).isoformat()
 
 
+def _naive_iso(ts: str) -> str:
+    ts = str(ts or "")
+    return ts.replace("Z", "+00:00")[:19] if ts else ts
+
+
 # --- identity ----------------------------------------------------------------
 
 
@@ -758,15 +763,15 @@ def _d_schedule_allergy_service(a: dict[str, Any]) -> dict[str, Any]:
             "linked_return_visits": spec["linked_visits"],
             "note": "This allergy service was already booked; do not create it again.",
         }
-    window_start = str(a.get("window_start") or "")
-    window_end = str(a.get("window_end") or "")
+    window_start = _naive_iso(str(a.get("window_start") or ""))
+    window_end = _naive_iso(str(a.get("window_end") or ""))
     available = [
         slot_start
         for slot_start in _SLOT_TIMES
         if (not window_start or slot_start >= window_start)
         and (
             not window_end
-            or _iso_plus_minutes(slot_start, duration_minutes) <= window_end
+            or _naive_iso(_iso_plus_minutes(slot_start, duration_minutes)) <= window_end
         )
     ]
     if not available:

--- a/industries/healthcare/tool_server.py
+++ b/industries/healthcare/tool_server.py
@@ -185,26 +185,42 @@ def create_appointment(body: AppointmentCreate) -> dict[str, Any]:
             "SELECT 1 FROM providers WHERE id = ?", (body.provider_id,)
         ).fetchone() is None:
             raise HTTPException(status_code=400, detail="unknown provider_id")
-        cur = conn.execute(
-            """
-            INSERT INTO appointments (
-              patient_id, location_id, provider_id, appointment_type_code,
-              start, end, description
-            ) VALUES (?, ?, ?, ?, ?, ?, ?)
-            """,
-            (
-                body.patient_id,
-                body.location_id,
-                body.provider_id,
-                body.appointment_type_code,
-                body.start,
-                body.end,
-                body.description,
-            ),
-        )
-        row = conn.execute(
-            "SELECT * FROM appointments WHERE id = ?", (cur.lastrowid,)
-        ).fetchone()
+        try:
+            cur = conn.execute(
+                """
+                INSERT INTO appointments (
+                  patient_id, location_id, provider_id, appointment_type_code,
+                  start, end, description
+                ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    body.patient_id,
+                    body.location_id,
+                    body.provider_id,
+                    body.appointment_type_code,
+                    body.start,
+                    body.end,
+                    body.description,
+                ),
+            )
+        except sqlite3.IntegrityError:
+            row = conn.execute(
+                """
+                SELECT * FROM appointments
+                WHERE ifnull(patient_id, '') = ifnull(?, '')
+                  AND location_id = ?
+                  AND appointment_type_code = ?
+                  AND status = 'booked'
+                ORDER BY id LIMIT 1
+                """,
+                (body.patient_id, body.location_id, body.appointment_type_code),
+            ).fetchone()
+            if row is None:
+                raise HTTPException(status_code=409, detail="appointment conflict")
+        else:
+            row = conn.execute(
+                "SELECT * FROM appointments WHERE id = ?", (cur.lastrowid,)
+            ).fetchone()
     if row is None:
         raise HTTPException(status_code=500, detail="insert failed")
     return _appointment(row)

--- a/industries/healthcare/tool_server.py
+++ b/industries/healthcare/tool_server.py
@@ -733,24 +733,62 @@ def _d_schedule_allergy_service(a: dict[str, Any]) -> dict[str, Any]:
     if spec is None:
         raise ToolError("UNKNOWN_SERVICE", f"No allergy service named {a['service']!r}.")
     loc = _resolve_location(a["location_id"])
+    window_start = str(a.get("window_start") or "")
+    window_end = str(a.get("window_end") or "")
+    duration_minutes = 30 + spec["observation_min"]
+    available = [
+        slot_start
+        for slot_start in _SLOT_TIMES
+        if (not window_start or slot_start >= window_start)
+        and (
+            not window_end
+            or _iso_plus_minutes(slot_start, duration_minutes) <= window_end
+        )
+    ]
+    if not available:
+        raise ToolError(
+            "NO_AVAILABILITY",
+            "No allergy appointment is available inside that window. Offer another window.",
+        )
+    start = available[0]
+    patient_id = _session_state().get("patient_id")
+    appointment_type_code = f"ALLERGY_{service.upper()}"
     with _db() as conn:
         prov = conn.execute(
             "SELECT * FROM providers WHERE location_id = ? ORDER BY id LIMIT 1", (loc["id"],)
         ).fetchone()
-    start = str(a.get("window_start") or _SLOT_TIMES[0])
+        existing = conn.execute(
+            """
+            SELECT * FROM appointments
+            WHERE patient_id IS ? AND location_id = ? AND appointment_type_code = ?
+              AND status = 'booked'
+            ORDER BY id LIMIT 1
+            """,
+            (patient_id, loc["id"], appointment_type_code),
+        ).fetchone()
+    if existing is not None:
+        return {
+            "appointment": _appointment(existing),
+            "idempotent": True,
+            "prep_instructions": spec["prep"],
+            "observation_minutes_after": spec["observation_min"],
+            "linked_return_visits": spec["linked_visits"],
+            "note": "This allergy service was already booked; do not create it again.",
+        }
     created = create_appointment(
         AppointmentCreate(
-            patient_id=_session_state().get("patient_id"),
+            patient_id=patient_id,
             location_id=loc["id"],
             provider_id=prov["id"],
-            appointment_type_code=f"ALLERGY_{service.upper()}",
+            appointment_type_code=appointment_type_code,
             start=start,
-            end=_iso_plus_minutes(start, 30 + spec["observation_min"]),
+            end=_iso_plus_minutes(start, duration_minutes),
             description=f"Allergy service: {service}",
         )
     )
     return {
         "appointment": created,
+        "idempotent": False,
         "prep_instructions": spec["prep"],
         "observation_minutes_after": spec["observation_min"],
         "linked_return_visits": spec["linked_visits"],

--- a/industries/healthcare/tools.json
+++ b/industries/healthcare/tools.json
@@ -560,7 +560,7 @@
     },
     {
       "name": "schedule_allergy_service",
-      "description": "They need an allergy service — testing, shots, drops pickup, food challenge, asthma eval, or immunotherapy — not a generic medical visit. Say the prep, the observation time after a shot, and the linked return visits out loud.",
+      "description": "Book a dedicated allergy service after an explicit yes. window_start/window_end are search bounds; the tool picks the first available slot in office hours. Call once after acceptance; repeats return the existing booking. Say prep, observation time, and linked return visits out loud.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -589,12 +589,12 @@
           "window_start": {
             "type": "string",
             "format": "date-time",
-            "description": "ISO-8601 local datetime, e.g. 2026-08-24T09:00:00."
+            "description": "Inclusive search bound, not the booked start. The tool picks an available slot at or after this time."
           },
           "window_end": {
             "type": "string",
             "format": "date-time",
-            "description": "ISO-8601 local datetime, e.g. 2026-08-24T09:00:00."
+            "description": "Inclusive search bound. The selected slot, including duration, must end by this time."
           }
         },
         "required": [
@@ -1143,7 +1143,7 @@
     },
     {
       "name": "request_rx_refill",
-      "description": "They want a medication refill. This never approves a refill — follow the route it returns; on a no-recent-visit hard stop, offer to book the visit on this call. Identity-gated.",
+      "description": "Call immediately after identity verification for any named-medication refill or refill-related prior authorization, before policy talk, extra details, a clinical message, callback, or handoff. medication_name is the only input. Records and routes; never approves. Follow the returned route.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1153,16 +1153,6 @@
             "maxLength": 80,
             "pattern": "^[A-Za-z][A-Za-z0-9 ./()&\\-]{0,79}$",
             "description": "Medication name as stated."
-          },
-          "pharmacy_phone": {
-            "type": "string",
-            "pattern": "^\\+[1-9][0-9]{7,14}$",
-            "description": "E.164, e.g. +12125550100."
-          },
-          "last_fill_date": {
-            "type": "string",
-            "format": "date",
-            "description": "YYYY-MM-DD."
           }
         },
         "required": [
@@ -1235,7 +1225,7 @@
     },
     {
       "name": "create_clinical_message",
-      "description": "A nurse, results, or refill question needs the clinical team — including when they push for result content you cannot read. Say the callback_window it returns out loud. Identity-gated.",
+      "description": "A nurse, results, or refill question needs the clinical team — including when they push for result content you cannot read. For any named-medication refill or refill-related prior authorization, call request_rx_refill first; this message never replaces the refill request. Say the callback_window it returns out loud. Identity-gated.",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/tests/test_tasks_to_digital_humans.py
+++ b/tests/test_tasks_to_digital_humans.py
@@ -411,8 +411,8 @@ def test_healthcare_leftover_holes_are_closed() -> None:
         and "any line" in (p.get("match_phrase") or "")
         for p in c5h3["scripted_responses"]
     )
-    assert "34786" in pin_blob(c5h3)
-    assert "407-555-0155" in pin_blob(c5h3)
+    assert "34786" in pin_blob(c5h3), "C5-H3"
+    assert "407-555-0155" in pin_blob(c5h3), "C5-H3"
 
     c2h3 = load("C2-H3")
     assert "join_waitlist" not in [c["name"] for c in c2h3["exp_tool_calls"]]
@@ -422,12 +422,13 @@ def test_healthcare_leftover_holes_are_closed() -> None:
     captured = next(c for c in load("C3-M2")["exp_tool_calls"] if c["name"] == "capture_insurance_update")
     assert "group_number" not in (captured.get("parameters") or {})
 
-    assert "w123456789" in pin_blob(load("C3-M1"))
-    assert "11201" in pin_blob(load("C5-M3"))
-    assert "transfer is not the appointment" in pin_blob(load("C1-H1"))
-    assert "No thanks, I don't need a text." not in [
-        pin.get("response_value") for pin in load("C4-E1").get("scripted_responses") or []
-    ]
+    assert "w123456789" in pin_blob(load("C3-M1")), "C3-M1"
+    assert "11201" in pin_blob(load("C5-M3")), "C5-M3"
+    assert "transfer is not the appointment" in pin_blob(load("C1-H1")), "C1-H1"
+    for key in ("C4-E1", "C4-E1-BG", "C4-E1-SIG"):
+        assert "No thanks, I don't need a text." not in [
+            pin.get("response_value") for pin in load(key).get("scripted_responses") or []
+        ], key
 
     c4h2 = load("C4-H2")
     assert "verify_identity" not in [c["name"] for c in c4h2["exp_tool_calls"]]
@@ -439,22 +440,22 @@ def test_healthcare_leftover_holes_are_closed() -> None:
 
     rh2 = load("R-H2")
     rh2_blob = rh2["intent"].lower() + " " + pin_blob(rh2)
-    assert "parameters" not in next(c for c in rh2["exp_tool_calls"] if c["name"] == "request_rx_refill")
-    assert "do not reschedule the august twentieth acne check" in rh2_blob
-    assert "weekday morning" in rh2_blob
-    assert "reschedule_appointment" not in [c["name"] for c in rh2["exp_tool_calls"]]
+    assert "parameters" not in next(c for c in rh2["exp_tool_calls"] if c["name"] == "request_rx_refill"), "R-H2"
+    assert "do not reschedule the august twentieth acne check" in rh2_blob, "R-H2"
+    assert "weekday morning" in rh2_blob, "R-H2"
+    assert "reschedule_appointment" not in [c["name"] for c in rh2["exp_tool_calls"]], "R-H2"
 
     rh3_names = [c["name"] for c in load("R-H3")["exp_tool_calls"]]
     assert rh3_names.index("request_rx_refill") < rh3_names.index("create_clinical_message")
 
     c4m1 = load("C4-M1")
-    assert "microneedling" in pin_blob(c4m1)
-    assert not any("before a time has been confirmed" in (p.get("match_phrase") or "") for p in c4m1["scripted_responses"])
+    assert "microneedling" in pin_blob(c4m1), "C4-M1"
+    assert not any("before a time has been confirmed" in (p.get("match_phrase") or "") for p in c4m1["scripted_responses"]), "C4-M1"
 
-    assert "212-555-0133" in pin_blob(load("C5-H1"))
+    assert "212-555-0133" in pin_blob(load("C5-H1")), "C5-H1"
     c5h2 = load("C5-H2")
-    assert "move" not in c5h2["scripted_responses"][0]["response_value"].lower()
-    assert "no payment or dispute" in pin_blob(c5h2)
+    assert "move" not in c5h2["scripted_responses"][0]["response_value"].lower(), "C5-H2"
+    assert "no payment or dispute" in pin_blob(c5h2), "C5-H2"
 
     for path in tasks.glob("*/task.json"):
         phrases = [p["match_phrase"] for p in json.loads(path.read_text()).get("scripted_responses") or []]

--- a/tests/test_tasks_to_digital_humans.py
+++ b/tests/test_tasks_to_digital_humans.py
@@ -440,7 +440,7 @@ def test_healthcare_leftover_holes_are_closed() -> None:
 
     rh2 = load("R-H2")
     rh2_blob = rh2["intent"].lower() + " " + pin_blob(rh2)
-    assert "parameters" not in next(c for c in rh2["exp_tool_calls"] if c["name"] == "request_rx_refill"), "R-H2"
+    assert next(c for c in rh2["exp_tool_calls"] if c["name"] == "request_rx_refill").get("parameters", {}).get("medication_name") == "Accutane", "R-H2"
     assert "do not reschedule the august twentieth acne check" in rh2_blob, "R-H2"
     assert "weekday morning" in rh2_blob, "R-H2"
     assert "reschedule_appointment" not in [c["name"] for c in rh2["exp_tool_calls"]], "R-H2"
@@ -454,7 +454,8 @@ def test_healthcare_leftover_holes_are_closed() -> None:
 
     assert "212-555-0133" in pin_blob(load("C5-H1")), "C5-H1"
     c5h2 = load("C5-H2")
-    assert "move" not in c5h2["scripted_responses"][0]["response_value"].lower(), "C5-H2"
+    greeting = next(p for p in c5h2["scripted_responses"] if "greets you" in (p.get("match_phrase") or ""))
+    assert "move" not in greeting["response_value"].lower(), "C5-H2"
     assert "no payment or dispute" in pin_blob(c5h2), "C5-H2"
 
     for path in tasks.glob("*/task.json"):

--- a/tests/test_tasks_to_digital_humans.py
+++ b/tests/test_tasks_to_digital_humans.py
@@ -447,12 +447,18 @@ def test_healthcare_leftover_holes_are_closed() -> None:
 
     rh3_names = [c["name"] for c in load("R-H3")["exp_tool_calls"]]
     assert rh3_names.index("request_rx_refill") < rh3_names.index("create_clinical_message")
+    rh3_message = next(c for c in load("R-H3")["exp_tool_calls"] if c["name"] == "create_clinical_message")
+    assert rh3_message["parameters"] == {"category": "rx_question"}
 
     c4m1 = load("C4-M1")
     assert "microneedling" in pin_blob(c4m1), "C4-M1"
     assert not any("before a time has been confirmed" in (p.get("match_phrase") or "") for p in c4m1["scripted_responses"]), "C4-M1"
 
-    assert "212-555-0133" in pin_blob(load("C5-H1")), "C5-H1"
+    c5h1 = load("C5-H1")
+    assert "212-555-0133" in pin_blob(c5h1), "C5-H1"
+    assert "No thanks, I don't need a text." not in [
+        pin.get("response_value") for pin in c5h1.get("scripted_responses") or []
+    ], "C5-H1"
     c5h2 = load("C5-H2")
     greeting = next(p for p in c5h2["scripted_responses"] if "greets you" in (p.get("match_phrase") or ""))
     assert "move" not in greeting["response_value"].lower(), "C5-H2"
@@ -461,6 +467,16 @@ def test_healthcare_leftover_holes_are_closed() -> None:
     for path in tasks.glob("*/task.json"):
         phrases = [p["match_phrase"] for p in json.loads(path.read_text()).get("scripted_responses") or []]
         assert len(phrases) == len(set(phrases)), path.parent.name
+
+    c1h2 = load("C1-H2")
+    kb_topics = [
+        call.get("parameters", {}).get("topic")
+        for call in c1h2["exp_tool_calls"]
+        if call["name"] == "search_practice_kb"
+    ]
+    assert kb_topics == ["hours"]
+    c1m2_find = next(call for call in load("C1-M2")["exp_tool_calls"] if call["name"] == "find_slots")
+    assert not c1m2_find.get("parameters")
 
     by_key = {conv.case_key_of(dh): dh for dh in _humans()}
     for case_key in ("C1-M3", "C2-H2"):

--- a/tests/test_tasks_to_digital_humans.py
+++ b/tests/test_tasks_to_digital_humans.py
@@ -465,8 +465,9 @@ def test_healthcare_leftover_holes_are_closed() -> None:
     by_key = {conv.case_key_of(dh): dh for dh in _humans()}
     for case_key in ("C1-M3", "C2-H2"):
         allergy = next(c for c in by_key[case_key]["expected_tool_calls"] if c["name"] == "schedule_allergy_service")
-        assert "window_start" not in allergy["parameters"]
-        assert "window_end" not in allergy["parameters"]
+        params = allergy.get("parameters") or {}
+        assert "window_start" not in params
+        assert "window_end" not in params
     rh2_dh = by_key["R-H2"]
     book = next(c for c in rh2_dh["expected_tool_calls"] if c["name"] == "book_appointment")
     assert book["parameters"]["slot_id"] == "slot_loc_park_ave_1"

--- a/tests/test_tasks_to_digital_humans.py
+++ b/tests/test_tasks_to_digital_humans.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import sys
 from collections import Counter
 from pathlib import Path
@@ -72,6 +73,36 @@ def test_clones_share_source_easy_voice() -> None:
         clone = by_key[key]
         assert (clone["accent"], clone["gender"]) == (source["accent"], source["gender"])
         assert clone["name"] == source["name"]
+
+
+def test_clones_match_source_semantics_except_audio_metadata() -> None:
+    tasks_dir = ROOT / "industries" / "healthcare" / "tasks"
+    for clone_path in sorted(tasks_dir.glob("*-BG/task.json")) + sorted(
+        tasks_dir.glob("*-SIG/task.json")
+    ):
+        clone_key = clone_path.parent.name
+        source_key = conv.source_case_key(clone_key)
+        clone = json.loads(clone_path.read_text())
+        source = json.loads((tasks_dir / source_key / "task.json").read_text())
+
+        assert {
+            item["trait_name"]: item.get("value") for item in clone["traits"]
+        } == {
+            item["trait_name"]: item.get("value") for item in source["traits"]
+        }, clone_key
+        for field in (
+            "intent",
+            "exp_handoff_path",
+            "exp_tool_calls",
+            "behaviors",
+            "scripted_responses",
+            "customer_name",
+            "customer_available_tools",
+            "exp_db_state",
+        ):
+            assert clone.get(field) == source.get(field), f"{clone_key}: {field}"
+        for field in ("category", "category_slug", "difficulty"):
+            assert clone["metadata"][field] == source["metadata"][field], clone_key
 
 
 def test_audio_condition_mapping() -> None:
@@ -170,8 +201,6 @@ def test_api_url_reads_env_after_import(monkeypatch) -> None:
 
 
 def test_json_emits_raw_digital_humans(capsys) -> None:
-    import json
-
     conv.main(["--industry", "healthcare", "--json"])
     body = json.loads(capsys.readouterr().out)
     humans = body["digital_humans"]
@@ -282,8 +311,6 @@ def test_encoder_stamps_creativity_zero() -> None:
 
 
 def test_healthcare_send_sms_only_when_caller_wants_text() -> None:
-    import json
-
     enc = _encoder()
     keep: list[str] = []
     for path in sorted((ROOT / "industries" / "healthcare" / "tasks").glob("*/task.json")):
@@ -338,50 +365,107 @@ def test_encoder_omits_waitlist_latest_and_location_zip() -> None:
 
 
 def test_healthcare_leftover_holes_are_closed() -> None:
-    import json
-
     tasks = ROOT / "industries" / "healthcare" / "tasks"
 
-    c2h1 = json.loads((tasks / "C2-H1" / "task.json").read_text())
+    def load(key: str) -> dict:
+        return json.loads((tasks / key / "task.json").read_text())
+
+    def pin_blob(task: dict) -> str:
+        return " ".join(
+            f"{pin.get('match_phrase', '')} {pin.get('response_value', '')}"
+            for pin in task.get("scripted_responses") or []
+        ).lower()
+
+    c2h1 = load("C2-H1")
     wait = next(c for c in c2h1["exp_tool_calls"] if c["name"] == "join_waitlist")
     assert "latest" not in (wait.get("parameters") or {})
     assert "23:59:59" not in json.dumps(wait)
 
-    c1h2 = json.loads((tasks / "C1-H2" / "task.json").read_text())
+    c1h2 = load("C1-H2")
     loc = next(c for c in c1h2["exp_tool_calls"] if c["name"] == "list_locations")
     assert "zip" not in (loc.get("parameters") or {})
+    opening = c1h2["intent"].split("Stay until", 1)[0].lower()
+    assert "weekday" in opening and "train" in opening
+    for requirement in ("train", "street address", "floor", "suite", "calendar"):
+        assert requirement in pin_blob(c1h2)
+    spoken = (c1h2["intent"] + " " + pin_blob(c1h2)).lower()
+    assert "search_practice_kb" not in spoken
+    assert "verifier" not in spoken
 
     for key in ("C4-M1", "C4-M2"):
-        task = json.loads((tasks / key / "task.json").read_text())
-        pins = task.get("scripted_responses") or []
-        assert isinstance(pins, list) and pins, key
+        task = load(key)
+        assert task.get("scripted_responses"), key
         loc = next(c for c in task["exp_tool_calls"] if c["name"] == "list_locations")
-        assert (loc.get("parameters") or {}) in ({}, None) or "zip" not in loc.get("parameters", {})
+        assert "zip" not in (loc.get("parameters") or {})
 
-    c4m2 = json.loads((tasks / "C4-M2" / "task.json").read_text())
+    c4m2 = load("C4-M2")
     names = [c["name"] for c in c4m2["exp_tool_calls"]]
     assert "offer_financing" not in names
     assert "find_slots" in names
-    pin_text = " ".join(p.get("response_value") or "" for p in c4m2["scripted_responses"])
-    assert "calendar" in pin_text.lower() or "booked" in pin_text.lower()
+    assert "calendar" in pin_blob(c4m2) or "booked" in pin_blob(c4m2)
 
-    c5h3 = json.loads((tasks / "C5-H3" / "task.json").read_text())
-    explains = [c for c in c5h3["exp_tool_calls"] if c["name"] == "explain_charge"]
-    assert len(explains) == 2
-    premature = [
-        p for p in c5h3["scripted_responses"]
-        if "I'll pay the full balance now" in (p.get("response_value") or "")
+    c5h3 = load("C5-H3")
+    assert len([c for c in c5h3["exp_tool_calls"] if c["name"] == "explain_charge"]) == 2
+    assert not any(
+        "I'll pay the full balance now" in (p.get("response_value") or "")
         and "any line" in (p.get("match_phrase") or "")
-    ]
-    assert not premature
+        for p in c5h3["scripted_responses"]
+    )
+    assert "34786" in pin_blob(c5h3)
+    assert "407-555-0155" in pin_blob(c5h3)
 
-    c2h3 = json.loads((tasks / "C2-H3" / "task.json").read_text())
+    c2h3 = load("C2-H3")
     assert "join_waitlist" not in [c["name"] for c in c2h3["exp_tool_calls"]]
     assert (c2h3.get("exp_db_state") or {}).get("waitlist") == []
-    sibling = json.loads((tasks / "C2-H3" / "exp_db_state.json").read_text())
-    assert sibling.get("waitlist") == []
+    assert json.loads((tasks / "C2-H3" / "exp_db_state.json").read_text()).get("waitlist") == []
 
-    c3m2 = json.loads((tasks / "C3-M2" / "task.json").read_text())
-    captured = next(c for c in c3m2["exp_tool_calls"] if c["name"] == "capture_insurance_update")
+    captured = next(c for c in load("C3-M2")["exp_tool_calls"] if c["name"] == "capture_insurance_update")
     assert "group_number" not in (captured.get("parameters") or {})
+
+    assert "w123456789" in pin_blob(load("C3-M1"))
+    assert "11201" in pin_blob(load("C5-M3"))
+    assert "transfer is not the appointment" in pin_blob(load("C1-H1"))
+    assert "No thanks, I don't need a text." not in [
+        pin.get("response_value") for pin in load("C4-E1").get("scripted_responses") or []
+    ]
+
+    c4h2 = load("C4-H2")
+    assert "verify_identity" not in [c["name"] for c in c4h2["exp_tool_calls"]]
+    assert "transfer_to_identity" not in c4h2["exp_handoff_path"]
+
+    rh1 = load("R-H1")
+    message = next(c for c in rh1["exp_tool_calls"] if c["name"] == "create_clinical_message")
+    assert message["parameters"] == {"category": "results_followup"}
+
+    rh2 = load("R-H2")
+    rh2_blob = rh2["intent"].lower() + " " + pin_blob(rh2)
+    assert "parameters" not in next(c for c in rh2["exp_tool_calls"] if c["name"] == "request_rx_refill")
+    assert "do not reschedule the august twentieth acne check" in rh2_blob
+    assert "weekday morning" in rh2_blob
+    assert "reschedule_appointment" not in [c["name"] for c in rh2["exp_tool_calls"]]
+
+    rh3_names = [c["name"] for c in load("R-H3")["exp_tool_calls"]]
+    assert rh3_names.index("request_rx_refill") < rh3_names.index("create_clinical_message")
+
+    c4m1 = load("C4-M1")
+    assert "microneedling" in pin_blob(c4m1)
+    assert not any("before a time has been confirmed" in (p.get("match_phrase") or "") for p in c4m1["scripted_responses"])
+
+    assert "212-555-0133" in pin_blob(load("C5-H1"))
+    c5h2 = load("C5-H2")
+    assert "move" not in c5h2["scripted_responses"][0]["response_value"].lower()
+    assert "no payment or dispute" in pin_blob(c5h2)
+
+    for path in tasks.glob("*/task.json"):
+        phrases = [p["match_phrase"] for p in json.loads(path.read_text()).get("scripted_responses") or []]
+        assert len(phrases) == len(set(phrases)), path.parent.name
+
+    by_key = {conv.case_key_of(dh): dh for dh in _humans()}
+    for case_key in ("C1-M3", "C2-H2"):
+        allergy = next(c for c in by_key[case_key]["expected_tool_calls"] if c["name"] == "schedule_allergy_service")
+        assert "window_start" not in allergy["parameters"]
+        assert "window_end" not in allergy["parameters"]
+    rh2_dh = by_key["R-H2"]
+    book = next(c for c in rh2_dh["expected_tool_calls"] if c["name"] == "book_appointment")
+    assert book["parameters"]["slot_id"] == "slot_loc_park_ave_1"
 

--- a/tests/test_tool_server.py
+++ b/tests/test_tool_server.py
@@ -377,6 +377,9 @@ def test_allergy_service_window_and_idempotent() -> None:
         assert first["ok"] and repeated["ok"]
         assert repeated["data"]["appointment"]["id"] == first["data"]["appointment"]["id"]
         assert repeated["data"]["idempotent"] is True
+        tight = {**args, "window_end": "2026-08-24T01:00:00"}
+        again = client.post("/tools/schedule_allergy_service", json={"arguments": tight}).json()
+        assert again["ok"] and again["data"]["idempotent"] is True
         matching = [
             row for row in client.get("/state").json()["appointments"]
             if row["patient_id"] == "pat_leo_park"

--- a/tests/test_tool_server.py
+++ b/tests/test_tool_server.py
@@ -337,6 +337,62 @@ def test_healthcare_prompt_demands_are_satisfiable() -> None:
         assert "not accepted at any" in med["data"]["notes"], med["data"]
 
 
+def test_allergy_service_window_and_idempotent() -> None:
+    with _load_tool_server("healthcare") as module, TestClient(module.app) as client:
+        booked = client.post(
+            "/tools/schedule_allergy_service",
+            json={"arguments": {
+                "service": "skin_testing",
+                "location_id": "loc_park_ave",
+                "window_start": "2026-08-24T00:00:00",
+                "window_end": "2026-08-24T17:00:00",
+            }},
+        ).json()
+        assert booked["ok"], booked
+        assert booked["data"]["appointment"]["start"] == "2026-08-24T09:00:00"
+
+        unavailable = client.post(
+            "/tools/schedule_allergy_service",
+            json={"arguments": {
+                "service": "patch_testing",
+                "location_id": "loc_park_ave",
+                "window_start": "2026-08-24T00:00:00",
+                "window_end": "2026-08-24T01:00:00",
+            }},
+        ).json()
+        assert unavailable["error_code"] == "NO_AVAILABILITY"
+
+        args = {
+            "service": "allergy_shot",
+            "location_id": "loc_brooklyn_heights",
+            "window_start": "2026-08-24T00:00:00",
+            "window_end": "2026-08-24T17:00:00",
+        }
+        assert client.post(
+            "/tools/verify_identity",
+            json={"arguments": {"full_name": "Leo Park", "dob": "2016-03-22"}},
+        ).json()["ok"]
+        first = client.post("/tools/schedule_allergy_service", json={"arguments": args}).json()
+        repeated = client.post("/tools/schedule_allergy_service", json={"arguments": args}).json()
+        assert first["ok"] and repeated["ok"]
+        assert repeated["data"]["appointment"]["id"] == first["data"]["appointment"]["id"]
+        assert repeated["data"]["idempotent"] is True
+        matching = [
+            row for row in client.get("/state").json()["appointments"]
+            if row["patient_id"] == "pat_leo_park"
+            and row["appointment_type_code"] == "ALLERGY_ALLERGY_SHOT"
+            and row["status"] == "booked"
+        ]
+        assert len(matching) == 1
+
+
+def test_refill_tool_takes_only_medication_name() -> None:
+    tools = json.loads((ROOT / "industries" / "healthcare" / "tools.json").read_text())["tools"]
+    refill = next(tool for tool in tools if tool["name"] == "request_rx_refill")
+    assert refill["inputSchema"]["required"] == ["medication_name"]
+    assert set(refill["inputSchema"]["properties"]) == {"medication_name"}
+
+
 def test_healthcare_calls_are_isolated() -> None:
     """Two concurrent calls must not share an identity pin, a balance or a row.
 

--- a/tests/test_tool_server.py
+++ b/tests/test_tool_server.py
@@ -351,6 +351,18 @@ def test_allergy_service_window_and_idempotent() -> None:
         assert booked["ok"], booked
         assert booked["data"]["appointment"]["start"] == "2026-08-24T09:00:00"
 
+        tz_ok = client.post(
+            "/tools/schedule_allergy_service",
+            json={"arguments": {
+                "service": "food_challenge",
+                "location_id": "loc_park_ave",
+                "window_start": "2026-08-24T09:00:00-04:00",
+                "window_end": "2026-08-24T17:00:00-04:00",
+            }},
+        ).json()
+        assert tz_ok["ok"], tz_ok
+        assert tz_ok["data"]["appointment"]["start"] == "2026-08-24T09:00:00"
+
         unavailable = client.post(
             "/tools/schedule_allergy_service",
             json={"arguments": {

--- a/tests/test_verify_task_run.py
+++ b/tests/test_verify_task_run.py
@@ -378,8 +378,7 @@ def test_clinical_message_allows_irrelevant_optional_parameters() -> None:
         "parameters": {
             "category": "results_followup",
             "priority": "urgent",
-            "callback_number": "212-555-0100",
-            "patient_safe_message": "Please call about pathology results.",
+            "callback_number": "+12125550100",
         },
         "ok": True,
     }]

--- a/tests/test_verify_task_run.py
+++ b/tests/test_verify_task_run.py
@@ -388,7 +388,7 @@ def test_clinical_message_allows_irrelevant_optional_parameters() -> None:
     wrong_category = [{
         "name": "create_clinical_message",
         "parameters": {
-            "category": "medication_question",
+            "category": "nurse_question",
             "priority": "routine",
         },
     }]

--- a/tests/test_verify_task_run.py
+++ b/tests/test_verify_task_run.py
@@ -366,3 +366,33 @@ def test_send_sms_is_required_only_when_listed() -> None:
     )
     assert skip_ok["passed"] is True
 
+
+def test_clinical_message_allows_irrelevant_optional_parameters() -> None:
+    schemas = vtr.load_tool_schemas("healthcare")
+    expected = [{
+        "name": "create_clinical_message",
+        "parameters": {"category": "results_followup"},
+    }]
+    actual = [{
+        "name": "create_clinical_message",
+        "parameters": {
+            "category": "results_followup",
+            "priority": "urgent",
+            "callback_number": "212-555-0100",
+            "patient_safe_message": "Please call about pathology results.",
+        },
+        "ok": True,
+    }]
+    assert vtr.tool_call_adherence(expected, actual, schemas=schemas)["passed"] is True
+
+    wrong_category = [{
+        "name": "create_clinical_message",
+        "parameters": {
+            "category": "medication_question",
+            "priority": "routine",
+        },
+    }]
+    result = vtr.tool_call_adherence(expected, wrong_category, schemas=schemas)
+    assert result["passed"] is False
+    assert result["missing"] == ["create_clinical_message"]
+

--- a/voice-agent-harnesses/openai/report.py
+++ b/voice-agent-harnesses/openai/report.py
@@ -420,11 +420,14 @@ class RealtimeEventTracer:
             tool = getattr(event, "tool", None)
             name = getattr(tool, "name", None) or "unknown_tool"
             args = getattr(event, "arguments", None)
+            call_id = getattr(event, "call_id", None) or getattr(tool, "call_id", None)
             attrs: dict[str, Any] = {
                 GenAIAttributes.GEN_AI_OPERATION_NAME: "execute_tool",
                 GenAIAttributes.GEN_AI_TOOL_NAME: name,
                 "mivas.event": "tool_start",
             }
+            if call_id is not None:
+                attrs["mivas.tool.call_id"] = str(call_id)
             if args is not None:
                 attrs[GenAIAttributes.GEN_AI_TOOL_CALL_ARGUMENTS] = _clip(args)
             self._tool_spans.setdefault(name, []).append(
@@ -441,11 +444,18 @@ class RealtimeEventTracer:
             name = getattr(tool, "name", None) or "unknown_tool"
             output = getattr(event, "output", None)
             args = getattr(event, "arguments", None)
+            call_id = getattr(event, "call_id", None) or getattr(tool, "call_id", None)
             spans = self._tool_spans.get(name)
             span = None
             if spans:
                 idx = 0
-                if args is not None:
+                if call_id is not None:
+                    want = str(call_id)
+                    for i, candidate in enumerate(spans):
+                        if candidate.attributes.get("mivas.tool.call_id") == want:
+                            idx = i
+                            break
+                elif args is not None:
                     clipped = _clip(args)
                     for i, candidate in enumerate(spans):
                         if candidate.attributes.get(

--- a/voice-agent-harnesses/openai/report.py
+++ b/voice-agent-harnesses/openai/report.py
@@ -448,7 +448,7 @@ class RealtimeEventTracer:
             spans = self._tool_spans.get(name)
             span = None
             if spans:
-                idx = 0
+                idx = None
                 if call_id is not None:
                     want = str(call_id)
                     for i, candidate in enumerate(spans):
@@ -463,9 +463,12 @@ class RealtimeEventTracer:
                         ) == clipped:
                             idx = i
                             break
-                span = spans.pop(idx)
-                if not spans:
-                    self._tool_spans.pop(name, None)
+                else:
+                    idx = 0
+                if idx is not None:
+                    span = spans.pop(idx)
+                    if not spans:
+                        self._tool_spans.pop(name, None)
             if span is not None:
                 if output is not None:
                     span.set_attribute(

--- a/voice-agent-harnesses/openai/report.py
+++ b/voice-agent-harnesses/openai/report.py
@@ -25,7 +25,6 @@ import json
 import logging
 import os
 import time
-from collections import deque
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Optional
 
@@ -286,7 +285,7 @@ class RealtimeEventTracer:
         self._model = model
         self._turn: Span | None = None
         self._turn_index = 0
-        self._tool_spans: dict[str, deque[Span]] = {}
+        self._tool_spans: dict[str, list[Span]] = {}
         self._seen_user_text: set[str] = set()
         # One generation span per Realtime response (response.created → response.done),
         # carrying tokens + TTFT, the way LangSmith/Langfuse report a model call.
@@ -428,7 +427,7 @@ class RealtimeEventTracer:
             }
             if args is not None:
                 attrs[GenAIAttributes.GEN_AI_TOOL_CALL_ARGUMENTS] = _clip(args)
-            self._tool_spans.setdefault(name, deque()).append(
+            self._tool_spans.setdefault(name, []).append(
                 self._tracer.start_span(
                     f"execute_tool {name}",
                     context=self._turn_ctx(),
@@ -441,10 +440,22 @@ class RealtimeEventTracer:
             tool = getattr(event, "tool", None)
             name = getattr(tool, "name", None) or "unknown_tool"
             output = getattr(event, "output", None)
+            args = getattr(event, "arguments", None)
             spans = self._tool_spans.get(name)
-            span = spans.popleft() if spans else None
-            if spans is not None and not spans:
-                self._tool_spans.pop(name, None)
+            span = None
+            if spans:
+                idx = 0
+                if args is not None:
+                    clipped = _clip(args)
+                    for i, candidate in enumerate(spans):
+                        if candidate.attributes.get(
+                            GenAIAttributes.GEN_AI_TOOL_CALL_ARGUMENTS
+                        ) == clipped:
+                            idx = i
+                            break
+                span = spans.pop(idx)
+                if not spans:
+                    self._tool_spans.pop(name, None)
             if span is not None:
                 if output is not None:
                     span.set_attribute(

--- a/voice-agent-harnesses/openai/report.py
+++ b/voice-agent-harnesses/openai/report.py
@@ -25,6 +25,7 @@ import json
 import logging
 import os
 import time
+from collections import deque
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator, Optional
 
@@ -285,7 +286,7 @@ class RealtimeEventTracer:
         self._model = model
         self._turn: Span | None = None
         self._turn_index = 0
-        self._tool_spans: dict[str, Span] = {}
+        self._tool_spans: dict[str, deque[Span]] = {}
         self._seen_user_text: set[str] = set()
         # One generation span per Realtime response (response.created → response.done),
         # carrying tokens + TTFT, the way LangSmith/Langfuse report a model call.
@@ -318,9 +319,10 @@ class RealtimeEventTracer:
         """End the model span, any open tools, and the turn itself."""
         if self._llm_span is not None:
             self._finish_llm(None)
-        for span in list(self._tool_spans.values()):
-            span.set_status(Status(StatusCode.OK))
-            span.end()
+        for spans in list(self._tool_spans.values()):
+            for span in spans:
+                span.set_status(Status(StatusCode.OK))
+                span.end()
         self._tool_spans.clear()
         if self._turn is not None:
             self._turn.set_status(Status(StatusCode.OK))
@@ -426,18 +428,23 @@ class RealtimeEventTracer:
             }
             if args is not None:
                 attrs[GenAIAttributes.GEN_AI_TOOL_CALL_ARGUMENTS] = _clip(args)
-            self._tool_spans[name] = self._tracer.start_span(
-                f"execute_tool {name}",
-                context=self._turn_ctx(),
-                kind=SpanKind.INTERNAL,
-                attributes=attrs,
+            self._tool_spans.setdefault(name, deque()).append(
+                self._tracer.start_span(
+                    f"execute_tool {name}",
+                    context=self._turn_ctx(),
+                    kind=SpanKind.INTERNAL,
+                    attributes=attrs,
+                )
             )
 
         elif etype == "tool_end":
             tool = getattr(event, "tool", None)
             name = getattr(tool, "name", None) or "unknown_tool"
             output = getattr(event, "output", None)
-            span = self._tool_spans.pop(name, None)
+            spans = self._tool_spans.get(name)
+            span = spans.popleft() if spans else None
+            if spans is not None and not spans:
+                self._tool_spans.pop(name, None)
             if span is not None:
                 if output is not None:
                     span.set_attribute(

--- a/voice-agent-harnesses/openai/report.py
+++ b/voice-agent-harnesses/openai/report.py
@@ -74,8 +74,12 @@ def _api_key() -> str | None:
     return os.environ.get("BLUEJAY_API_KEY") or None
 
 
+def _as_str(value: Any) -> str:
+    return value if isinstance(value, str) else json.dumps(value, default=str)
+
+
 def _clip(value: Any, n: int = _MAX_ATTR) -> str:
-    s = value if isinstance(value, str) else json.dumps(value, default=str)
+    s = _as_str(value)
     return s if len(s) <= n else s[: n - 3] + "..."
 
 
@@ -286,6 +290,8 @@ class RealtimeEventTracer:
         self._turn: Span | None = None
         self._turn_index = 0
         self._tool_spans: dict[str, list[Span]] = {}
+        # unclipped (call_id, args) aligned with `_tool_spans`; clip is telemetry-only
+        self._tool_match_keys: dict[str, list[tuple[str | None, str | None]]] = {}
         self._seen_user_text: set[str] = set()
         # One generation span per Realtime response (response.created → response.done),
         # carrying tokens + TTFT, the way LangSmith/Langfuse report a model call.
@@ -323,6 +329,7 @@ class RealtimeEventTracer:
                 span.set_status(Status(StatusCode.OK))
                 span.end()
         self._tool_spans.clear()
+        self._tool_match_keys.clear()
         if self._turn is not None:
             self._turn.set_status(Status(StatusCode.OK))
             self._turn.end()
@@ -438,6 +445,12 @@ class RealtimeEventTracer:
                     attributes=attrs,
                 )
             )
+            self._tool_match_keys.setdefault(name, []).append(
+                (
+                    str(call_id) if call_id is not None else None,
+                    _as_str(args) if args is not None else None,
+                )
+            )
 
         elif etype == "tool_end":
             tool = getattr(event, "tool", None)
@@ -446,29 +459,31 @@ class RealtimeEventTracer:
             args = getattr(event, "arguments", None)
             call_id = getattr(event, "call_id", None) or getattr(tool, "call_id", None)
             spans = self._tool_spans.get(name)
+            keys = self._tool_match_keys.get(name)
             span = None
-            if spans:
+            if spans and keys:
                 idx = None
                 if call_id is not None:
                     want = str(call_id)
-                    for i, candidate in enumerate(spans):
-                        if candidate.attributes.get("mivas.tool.call_id") == want:
+                    for i, (stored_id, _) in enumerate(keys):
+                        if stored_id == want:
                             idx = i
                             break
                 elif args is not None:
-                    clipped = _clip(args)
-                    for i, candidate in enumerate(spans):
-                        if candidate.attributes.get(
-                            GenAIAttributes.GEN_AI_TOOL_CALL_ARGUMENTS
-                        ) == clipped:
+                    want_args = _as_str(args)
+                    for i, (_, stored_args) in enumerate(keys):
+                        if stored_args == want_args:
                             idx = i
                             break
                 else:
                     idx = 0
                 if idx is not None:
                     span = spans.pop(idx)
+                    keys.pop(idx)
                     if not spans:
                         self._tool_spans.pop(name, None)
+                    if not keys:
+                        self._tool_match_keys.pop(name, None)
             if span is not None:
                 if output is not None:
                     span.set_attribute(

--- a/voice-agent-harnesses/openai/test_llm_usage_span.py
+++ b/voice-agent-harnesses/openai/test_llm_usage_span.py
@@ -31,6 +31,65 @@ def _raw(payload: dict) -> SimpleNamespace:
     return SimpleNamespace(type="raw_model_event", data=payload)
 
 
+def test_repeated_tool_calls_keep_request_output_pairs() -> None:
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+    tracer = provider.get_tracer("tool-pair-test")
+    root = tracer.start_span("realtime_session")
+    event_tracer = report.RealtimeEventTracer(tracer, root)
+    tool = SimpleNamespace(name="explain_charge")
+
+    event_tracer.handle(
+        SimpleNamespace(
+            type="tool_start",
+            tool=tool,
+            arguments='{"line_item_id":"li_noshow"}',
+        )
+    )
+    event_tracer.handle(
+        SimpleNamespace(
+            type="tool_start",
+            tool=tool,
+            arguments='{"line_item_id":"li_visit"}',
+        )
+    )
+    event_tracer.handle(
+        SimpleNamespace(
+            type="tool_end",
+            tool=tool,
+            output='{"line_item_id":"li_noshow"}',
+        )
+    )
+    event_tracer.handle(
+        SimpleNamespace(
+            type="tool_end",
+            tool=tool,
+            output='{"line_item_id":"li_visit"}',
+        )
+    )
+    event_tracer.close()
+    root.end()
+
+    spans = [
+        span
+        for span in exporter.get_finished_spans()
+        if span.name == "execute_tool explain_charge"
+    ]
+    assert len(spans) == 2
+    pairs = [
+        (
+            span.attributes["gen_ai.tool.call.arguments"],
+            span.attributes["gen_ai.tool.call.result"],
+        )
+        for span in spans
+    ]
+    assert pairs == [
+        ('{"line_item_id":"li_noshow"}', '{"line_item_id":"li_noshow"}'),
+        ('{"line_item_id":"li_visit"}', '{"line_item_id":"li_visit"}'),
+    ]
+
+
 def main() -> None:
     exporter = InMemorySpanExporter()
     provider = TracerProvider()
@@ -82,4 +141,5 @@ def main() -> None:
 
 
 if __name__ == "__main__":
+    test_repeated_tool_calls_keep_request_output_pairs()
     main()

--- a/voice-agent-harnesses/openai/test_llm_usage_span.py
+++ b/voice-agent-harnesses/openai/test_llm_usage_span.py
@@ -114,6 +114,35 @@ def test_repeated_tool_calls_keep_request_output_pairs() -> None:
         ('{"id":"b"}', '{"ok":"b"}'),
     ]
 
+    # arguments that only differ past the 4000-char telemetry clip must still pair
+    prefix = "x" * report._MAX_ATTR
+    long_a = prefix + "A"
+    long_b = prefix + "B"
+    assert report._clip(long_a) == report._clip(long_b)
+    exporter3 = InMemorySpanExporter()
+    provider3 = TracerProvider()
+    provider3.add_span_processor(SimpleSpanProcessor(exporter3))
+    tracer3 = provider3.get_tracer("tool-pair-clip")
+    root3 = tracer3.start_span("realtime_session")
+    tracer3_events = report.RealtimeEventTracer(tracer3, root3)
+    tracer3_events.handle(SimpleNamespace(type="tool_start", tool=tool, arguments=long_a))
+    tracer3_events.handle(SimpleNamespace(type="tool_start", tool=tool, arguments=long_b))
+    tracer3_events.handle(
+        SimpleNamespace(type="tool_end", tool=tool, arguments=long_b, output='{"ok":"b"}')
+    )
+    assert tracer3_events._tool_match_keys["explain_charge"] == [(None, long_a)]
+    tracer3_events.handle(
+        SimpleNamespace(type="tool_end", tool=tool, arguments=long_a, output='{"ok":"a"}')
+    )
+    tracer3_events.close()
+    root3.end()
+    clipped_pairs = [
+        span.attributes["gen_ai.tool.call.result"]
+        for span in exporter3.get_finished_spans()
+        if span.name == "execute_tool explain_charge"
+    ]
+    assert clipped_pairs == ['{"ok":"b"}', '{"ok":"a"}']
+
 
 def main() -> None:
     exporter = InMemorySpanExporter()

--- a/voice-agent-harnesses/openai/test_llm_usage_span.py
+++ b/voice-agent-harnesses/openai/test_llm_usage_span.py
@@ -89,6 +89,31 @@ def test_repeated_tool_calls_keep_request_output_pairs() -> None:
         ('{"line_item_id":"li_visit"}', '{"line_item_id":"li_visit"}'),
     ]
 
+    exporter2 = InMemorySpanExporter()
+    provider2 = TracerProvider()
+    provider2.add_span_processor(SimpleSpanProcessor(exporter2))
+    tracer2 = provider2.get_tracer("tool-pair-reorder")
+    root2 = tracer2.start_span("realtime_session")
+    tracer2_events = report.RealtimeEventTracer(tracer2, root2)
+    tracer2_events.handle(SimpleNamespace(type="tool_start", tool=tool, arguments='{"id":"a"}'))
+    tracer2_events.handle(SimpleNamespace(type="tool_start", tool=tool, arguments='{"id":"b"}'))
+    tracer2_events.handle(SimpleNamespace(type="tool_end", tool=tool, arguments='{"id":"b"}', output='{"ok":"b"}'))
+    tracer2_events.handle(SimpleNamespace(type="tool_end", tool=tool, arguments='{"id":"a"}', output='{"ok":"a"}'))
+    tracer2_events.close()
+    root2.end()
+    reordered = [
+        (
+            span.attributes["gen_ai.tool.call.arguments"],
+            span.attributes["gen_ai.tool.call.result"],
+        )
+        for span in exporter2.get_finished_spans()
+        if span.name == "execute_tool explain_charge"
+    ]
+    assert sorted(reordered) == [
+        ('{"id":"a"}', '{"ok":"a"}'),
+        ('{"id":"b"}', '{"ok":"b"}'),
+    ]
+
 
 def main() -> None:
     exporter = InMemorySpanExporter()


### PR DESCRIPTION
## Summary
- Close remaining healthcare mixed-case fairness holes: DH pins that caused caller-script failures, allergy booking windows/idempotency, refill-before-message contracts, and Realtime trace pairing for repeated tool calls.
- Do not weaken verifier checks; optional clinical-message args still fail on the wrong category, and expected tool/handoff contracts stay strict.
- Ponytail-reduced the test surface: folded pin regressions into the existing leftover-holes test and kept behavior tests for allergy windows, refill schema, and span pairing.

## Test plan
- [x] `uv run pytest tests/test_tasks_to_digital_humans.py tests/test_tool_server.py tests/test_verify_task_run.py`
- [x] `uv run python voice-agent-harnesses/openai/test_llm_usage_span.py`
- [x] `git diff --check`
- [ ] Cubic 5/5 on this PR
- [ ] After merge: claim/sync DHs on simulation 30606 if needed, then queue k=6


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes mixed-task fairness by making allergy bookings idempotent and race-safe, moving refills to a single early write, hardening Realtime tool-call pairing, and trimming over-pinning in verifier tasks. Old: allergy bookings could double-book or 500 on retries and ignore tight/timezone windows; refills collected extra details and delayed the write; coverage sometimes demanded a group number; repeated tool spans mispaired on long arguments; several tasks over-constrained KB/slot/SMS/priority. New: `schedule_allergy_service` is idempotent with bound-based, timezone-normalized searches; `request_rx_refill` writes immediately with only `medication_name`; coverage proceeds without a group number; tracing preserves per-call request/output pairs using call_id or full (unclipped) arguments; pins drop redundant assertions.

- Tool server/DB: `schedule_allergy_service` returns the existing booking with `idempotent=true` on repeats or unique-index conflicts, treats `window_start`/`window_end` as inclusive bounds (normalized to naive fixture times), and returns `NO_AVAILABILITY` when none. A partial unique index enforces one booked allergy service per patient/office (non-`ALLERGY_EVAL`). `create_appointment` now returns the existing row instead of 500 on those conflicts.
- Tool schemas/docs: `request_rx_refill` now accepts only `medication_name` (callers must remove `pharmacy_phone` and `last_fill_date`). `create_clinical_message` clarifies it never replaces a refill write. `schedule_allergy_service` documents single post-accept call, bounds handling, and idempotent repeats.
- Prompts/tasks/pins: Billing states each charge once and completes a stated resolution without re-asking; Coverage makes the group number optional; Scheduling enforces offer → explicit yes → one commit for allergy; Cosmetic keeps policy consent on the policy pin; R‑H2 requires “Accutane” and books a new program visit without moving Aug 20. Trimmed verifier pins to avoid over‑constraining: removed directions-KB in C1‑H2, extra slot params in C1‑M2, SMS‑refusal pins in cosmetic/billing tasks, and the “urgent” priority requirement in R‑H3.
- Tracing: Realtime tool spans maintain per-tool queues and match by call_id or full arguments; telemetry clipping is display-only. Repeated calls pair with the right outputs; no overwrites or collisions on long arguments.
- Tests: New assertions for allergy idempotency and window handling (including timezone), integrity-conflict idempotence, per-call span pairing including unclipped-argument cases, and R‑H2’s Accutane/new-visit behavior. Verifier allows irrelevant optional args on clinical messages but still fails wrong categories. Clone tasks keep semantics except audio metadata.

<sup>Written for commit d8c04f9de64531b757467ac48c3d9c06587c778d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/39?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

