### PR TITLE
Fix hangup minute-datetime matching and pin C1-E3 / C4-H3 / C4-M2 stay greetings

### DIFF
--- a/industries/healthcare/tasks/C1-E3/task.json
+++ b/industries/healthcare/tasks/C1-E3/task.json
@@ -54,6 +54,12 @@
       "match_phrase": "says they take the plan, accept the insurance, or that you are covered, without naming the office they just checked. NOT when they have just said they checked Park Avenue specifically.",
       "response_type": "phrase",
       "response_value": "Which office did you check? I need Park Avenue specifically, not the whole practice."
+    },
+    {
+      "match_type": "context",
+      "match_phrase": "thanks you, says goodbye, wraps up, or offers a callback after a question or a non-answer, before they have named Park Avenue and said whether Medicaid is accepted there. NOT when they have just named Park Avenue with a yes or no for Medicaid, NOT when asking for your name.",
+      "response_type": "phrase",
+      "response_value": "I still need a yes or no for Medicaid at Park Avenue. Please look it up on this call before I go."
     }
   ],
   "customer_name": "Terrell Baines",

--- a/industries/healthcare/tasks/C4-H3/task.json
+++ b/industries/healthcare/tasks/C4-H3/task.json
@@ -82,6 +82,12 @@
   "scripted_responses": [
     {
       "match_type": "context",
+      "match_phrase": "greets you, asks how they can help, asks what you need, or says they are listening, before you have asked about filler or a consult. NOT when they have just confirmed a booked time, NOT when quoting filler, NOT when asking for your name or date of birth.",
+      "response_type": "phrase",
+      "response_value": "How much does cheek filler cost? I'd like to come in for a filler consult at Brooklyn Heights."
+    },
+    {
+      "match_type": "context",
       "match_phrase": "offers an appointment time, a slot, or asks which day or time you want. NOT when asking for your name or date of birth, NOT when they have not yet given the street, floor, and suite if you still need those.",
       "response_type": "phrase",
       "response_value": "I'll take the first time you offered."
@@ -106,7 +112,7 @@
     },
     {
       "match_type": "context",
-      "match_phrase": "thanks you, says goodbye, or asks if you need anything else before a time has been confirmed on the calendar. NOT when they have just confirmed a booked time.",
+      "match_phrase": "thanks you, says goodbye, or wraps up after you have asked for a filler consult, before a consult time has been confirmed on the calendar. NOT when greeting you or asking how they can help at the start of the call, NOT when they have just confirmed a booked time, NOT when asking for your name or date of birth.",
       "response_type": "phrase",
       "response_value": "I still need that time booked. Please confirm it is on the calendar before I go."
     }

--- a/industries/healthcare/tasks/C4-M2/task.json
+++ b/industries/healthcare/tasks/C4-M2/task.json
@@ -77,6 +77,12 @@
   "scripted_responses": [
     {
       "match_type": "context",
+      "match_phrase": "greets you, asks how they can help, asks what you need, or says they are listening, before you have asked about cheek filler cost. NOT when they have just confirmed a booked time, NOT when quoting filler, NOT when asking for your name or date of birth.",
+      "response_type": "phrase",
+      "response_value": "What does cheek filler cost? I'd like a filler consult at Park Avenue."
+    },
+    {
+      "match_type": "context",
       "match_phrase": "offers an appointment time, a slot, or asks which day or time you want AFTER already saying the street address, the floor, and the suite. NOT when they have not yet given all three, NOT when asking for your name or date of birth.",
       "response_type": "phrase",
       "response_value": "I'll take the first time you offered."
@@ -107,13 +113,13 @@
     },
     {
       "match_type": "context",
-      "match_phrase": "thanks you, says goodbye, or asks if you need anything else before a consult time has been confirmed on the calendar. NOT when they have just confirmed a booked time.",
+      "match_phrase": "thanks you, says goodbye, or wraps up after you have asked for a Park Avenue filler consult, before a consult time has been confirmed on the calendar. NOT when greeting you or asking how they can help at the start of the call, NOT when they have just confirmed a booked time, NOT when asking for your name or date of birth.",
       "response_type": "phrase",
       "response_value": "I still need the consult booked. Please confirm a time on the calendar before I go."
     },
     {
       "match_type": "context",
-      "match_phrase": "thanks you, says goodbye, or asks if you need anything else before a time has been confirmed on the calendar. NOT when they have just confirmed a booked time.",
+      "match_phrase": "thanks you, says goodbye, or wraps up after quoting filler, financing, or an address, before a time is on the calendar. NOT when greeting you or asking how they can help at the start of the call, NOT when they have just confirmed a booked time.",
       "response_type": "phrase",
       "response_value": "I still need that time booked. Please confirm it is on the calendar before I go."
     }

--- a/scripts/verify_task_run.py
+++ b/scripts/verify_task_run.py
@@ -31,6 +31,7 @@ import json
 import os
 import re
 import sys
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -129,6 +130,12 @@ LEGAL_EXTRA_OK_TABLES = frozenset({
     "messages", "intake_notes", "documents", "holds", "evaluations",
 })
 PHONE_KEY_RE = re.compile(r"phone|_e164$", re.I)
+# ISO date + hour + minute; seconds, micros, and timezone are optional.
+_DATETIME_RE = re.compile(
+    r"^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}"
+    r"(?::\d{2}(?:\.\d+)?)?"
+    r"(?:Z|[+-]\d{2}:?\d{2})?$"
+)
 
 _TOOL_SCHEMAS: dict[str, dict[str, Any]] = {}
 
@@ -246,6 +253,20 @@ def _ignore_row_keys(industry: str | None) -> frozenset[str]:
     return IGNORE_ROW_KEYS
 
 
+def _minute_datetime(value: Any) -> Any:
+    """Collapse datetime-like strings to date+hour+minute (drop seconds/micros)."""
+    if not isinstance(value, str):
+        return value
+    text = value.strip()
+    if not _DATETIME_RE.match(text):
+        return value
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return value
+    return parsed.strftime("%Y-%m-%dT%H:%M")
+
+
 def _canon_row(row: Any, industry: str | None = None) -> Any:
     if not isinstance(row, dict):
         return row
@@ -257,7 +278,10 @@ def _canon_row(row: Any, industry: str | None = None) -> Any:
         if isinstance(value, str) and _is_phone_key(key):
             out[key] = _digits_phone(value)
         elif isinstance(value, str):
-            out[key] = value.strip().casefold()
+            # collapse T15:30 vs T15:30:00 first; casefold after so dump seconds
+            # cannot disagree with a minute-precision seed.
+            collapsed = _minute_datetime(value)
+            out[key] = collapsed.strip().casefold() if isinstance(collapsed, str) else collapsed
         else:
             out[key] = value
     return out

--- a/tests/test_tasks_to_digital_humans.py
+++ b/tests/test_tasks_to_digital_humans.py
@@ -551,6 +551,46 @@ def test_healthcare_leftover_holes_are_closed() -> None:
     assert book["parameters"]["slot_id"] == "slot_loc_park_ave_1"
 
 
+def test_healthcare_greeting_and_stay_pins_lock_path() -> None:
+    tasks = ROOT / "industries" / "healthcare" / "tasks"
+
+    def load(key: str) -> dict:
+        return json.loads((tasks / key / "task.json").read_text())
+
+    c1e3 = load("C1-E3")
+    stay = next(
+        p for p in c1e3["scripted_responses"]
+        if "before they have named Park Avenue" in (p.get("match_phrase") or "")
+    )
+    assert "yes or no for Medicaid at Park Avenue" in stay["response_value"]
+    assert not any(
+        "here is my zip" in (p.get("response_value") or "").lower()
+        for p in c1e3["scripted_responses"]
+    )
+
+    c4h3 = load("C4-H3")
+    greeting_h3 = next(p for p in c4h3["scripted_responses"] if "greets you" in (p.get("match_phrase") or ""))
+    assert "cheek filler" in greeting_h3["response_value"].lower()
+    assert "brooklyn heights" in greeting_h3["response_value"].lower()
+    wrap_h3 = [p for p in c4h3["scripted_responses"] if "wraps up" in (p.get("match_phrase") or "")]
+    assert wrap_h3
+    for pin in wrap_h3:
+        assert "NOT when greeting you" in (pin.get("match_phrase") or "")
+
+    c4m2 = load("C4-M2")
+    greeting_m2 = next(p for p in c4m2["scripted_responses"] if "greets you" in (p.get("match_phrase") or ""))
+    assert "cheek filler" in greeting_m2["response_value"].lower()
+    assert "park avenue" in greeting_m2["response_value"].lower()
+    wrap_m2 = [p for p in c4m2["scripted_responses"] if "wraps up" in (p.get("match_phrase") or "")]
+    assert wrap_m2
+    for pin in wrap_m2:
+        assert "NOT when greeting you" in (pin.get("match_phrase") or "")
+
+    for path in tasks.glob("*/task.json"):
+        phrases = [p["match_phrase"] for p in json.loads(path.read_text()).get("scripted_responses") or []]
+        assert len(phrases) == len(set(phrases)), path.parent.name
+
+
 def test_legal_fairness_c2h1_state_pin_and_rm_lookup_only() -> None:
     tasks = ROOT / "industries" / "legal" / "tasks"
 

--- a/tests/test_verify_task_run.py
+++ b/tests/test_verify_task_run.py
@@ -81,6 +81,54 @@ def test_office_waitlist_allows_extra_rows_when_expected_is_nonempty() -> None:
     assert vtr.office_states_match(empty_expected, {"patients": [], "appointments": [], "waitlist": []}, industry="healthcare") is True
 
 
+def test_office_datetimes_match_at_minute_precision() -> None:
+    expected_row = {
+        "patient_id": "pat_jordan_lee",
+        "location_id": "loc_park_ave",
+        "earliest": "2026-08-24T00:00:00",
+        "latest": "2026-09-30T23:59:59",
+    }
+    actual_row = {
+        **expected_row,
+        "latest": "2026-09-30T23:59:00",
+    }
+    expected = {"patients": [], "appointments": [], "waitlist": [expected_row]}
+    actual = {"patients": [], "appointments": [], "waitlist": [actual_row]}
+    assert vtr.office_canonical(expected)["waitlist"][0]["latest"] == "2026-09-30t23:59"
+    assert vtr.office_canonical(actual)["waitlist"][0]["latest"] == "2026-09-30t23:59"
+    assert vtr.office_states_match(expected, actual, industry="healthcare") is True
+    minute_off = {
+        "patients": [],
+        "appointments": [],
+        "waitlist": [{**actual_row, "latest": "2026-09-30T23:58:00"}],
+    }
+    assert vtr.office_states_match(expected, minute_off, industry="healthcare") is False
+    expected_apt = {
+        "patients": [],
+        "appointments": [{"id": 1, "start": "2026-08-24T09:00:00"}],
+        "waitlist": [],
+    }
+    actual_apt = {
+        "patients": [],
+        "appointments": [{"id": 1, "start": "2026-08-24T09:00:59.500000"}],
+        "waitlist": [],
+    }
+    assert vtr.office_states_match(expected_apt, actual_apt) is True
+    omitted_seconds = {
+        "patients": [],
+        "appointments": [{"id": 2, "end": "2026-08-21T15:30"}],
+        "waitlist": [],
+    }
+    with_seconds = {
+        "patients": [],
+        "appointments": [{"id": 2, "end": "2026-08-21T15:30:00"}],
+        "waitlist": [],
+    }
+    assert vtr.office_canonical(omitted_seconds)["appointments"][0]["end"] == "2026-08-21t15:30"
+    assert vtr.office_canonical(with_seconds)["appointments"][0]["end"] == "2026-08-21t15:30"
+    assert vtr.office_states_match(omitted_seconds, with_seconds, industry="healthcare") is True
+
+
 def test_verify_result_ignores_tool_events_in_state() -> None:
     task = {
         "exp_db_state": {


### PR DESCRIPTION
## Summary
- Hangup DB comparer collapses datetimes to the minute before casefold so seed `T15:30` matches dump `T15:30:00` (was 0/72 hangup on run 241253).
- Lock C1-E3 stay-until-office, C4-H3 and C4-M2 greeting pins so wrap-up/hang-up-after-non-answer cannot fire as the opening ask.

## Test plan
- [ ] unit test for T15:30 vs T15:30:00
- [ ] leftover pin assertions
- [ ] k=3 run 241299: those three tasks FAIR


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Matches hangup datetimes at minute precision and pins healthcare greeting/stay responses so wrap-up prompts do not trigger at call start. Previously the verifier compared full ISO strings (e.g., T15:30 vs T15:30:00 failed); now it collapses to YYYY-MM-DDTHH:MM before casefold. Second-level differences within the same minute are ignored; minute-level differences still fail.

**Review notes**
- scripts/verify_task_run.py: add `_DATETIME_RE` and `_minute_datetime`; normalize datetime-like strings (supports seconds, micros, `Z`, and offsets) before casefold in `_canon_row`.
- Tasks `C1-E3`, `C4-H3`, `C4-M2`: add greeting pins and a stay-until-office pin; tighten wrap-up pins with explicit “NOT when greeting you…” guards to prevent opening asks from firing as wrap-ups.
- Tests: add minute-precision matching cases in test_verify_task_run and pin coverage/uniqueness checks in test_tasks_to_digital_humans.

<sup>Written for commit 76ef003799f6fc27c259716bd12984049b2ce501. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/41?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

