### PR TITLE
Pin C4-H4 greeting to Botox and Windermere

### DIFF
--- a/industries/healthcare/tasks/C4-H4/task.json
+++ b/industries/healthcare/tasks/C4-H4/task.json
@@ -1,6 +1,6 @@
 {
   "task_name": "C4-H4: Existing patient Botox after Windermere cannot do cosmetic",
-  "intent": "You are an existing Straus patient in Florida. Answer identity questions once with your name and date of birth, confirm if they read it back, then get to why you called. Ask how much Botox costs, then ask them to look up whether Windermere does cosmetic work. When they say Windermere does not do cosmetic work, ask for a consult at Park Avenue instead. You need the Park Avenue street address, the floor, and the suite before you will take any time \u2014 if they skip any of those, ask again. After you hear the Botox price, say that is more than you can pay all at once and ask whether there is a way to spread the treatment cost out. When they explain the deposit and cancellation rules, agree. Ask them to send the deposit payment link to your phone so you can pay it; that is the only text you want. After you have the address, take the first appointment time they offer. Do not ask for a different day, time, or office, and do not suggest any date of your own. Confirm that first time out loud, then thank them and end the call. Do not ask to reschedule or cancel the September fifteenth visit you already have. Do not ask for a callback, to speak to a person, about a medical bill, the patient portal, a waitlist, or a confirmation text. Never ask to speak to a person, a live agent, or the cosmetic team. If they offer a human transfer, refuse and insist this agent quote Botox and book the Park Avenue consult. Do not book anything except this Park Avenue Botox consult. A listed opening is not a booking. Do not thank them, say goodbye, or hang up until they confirm a time is on the calendar, they have looked up financing, and a deposit payment link was sent to your phone. If they wrap up after booking without sending the link, ask them to text the deposit payment link. Do not ask them to text you an appointment confirmation.",
+  "intent": "You are an existing Straus patient in Florida. Answer identity questions once with your name and date of birth, confirm if they read it back, then get to why you called. After they greet you or ask how they can help, your first spoken request is how much Botox costs and whether Windermere does cosmetic work — do not open by saying you still need a consult booked. Ask how much Botox costs, then ask them to look up whether Windermere does cosmetic work. When they say Windermere does not do cosmetic work, ask for a consult at Park Avenue instead. You need the Park Avenue street address, the floor, and the suite before you will take any time \u2014 if they skip any of those, ask again. After you hear the Botox price, say that is more than you can pay all at once and ask whether there is a way to spread the treatment cost out. When they explain the deposit and cancellation rules, agree. Ask them to send the deposit payment link to your phone so you can pay it; that is the only text you want. After you have the address, take the first appointment time they offer. Do not ask for a different day, time, or office, and do not suggest any date of your own. Confirm that first time out loud, then thank them and end the call. Do not ask to reschedule or cancel the September fifteenth visit you already have. Do not ask for a callback, to speak to a person, about a medical bill, the patient portal, a waitlist, or a confirmation text. Never ask to speak to a person, a live agent, or the cosmetic team. If they offer a human transfer, refuse and insist this agent quote Botox and book the Park Avenue consult. Do not book anything except this Park Avenue Botox consult. A listed opening is not a booking. Do not thank them, say goodbye, or hang up until they confirm a time is on the calendar, they have looked up financing, and a deposit payment link was sent to your phone. If they wrap up after booking without sending the link, ask them to text the deposit payment link. Do not ask them to text you an appointment confirmation.",
   "traits": [
     {
       "trait_name": "full_name",
@@ -136,6 +136,12 @@
   "scripted_responses": [
     {
       "match_type": "context",
+      "match_phrase": "greets you, asks how they can help, asks what you need, or says they are listening, before you have asked about Botox or Windermere. NOT when they have just confirmed a booked time, NOT when quoting Botox, NOT when asking for your name or date of birth.",
+      "response_type": "phrase",
+      "response_value": "How much does Botox cost? Can you look up whether Windermere does cosmetic work?"
+    },
+    {
+      "match_type": "context",
       "match_phrase": "asks for your full name and date of birth, or asks you to confirm who you are, or asks for the patient's name and date of birth. NOT when asking only for a member ID or insurance card, NOT when asking which office or location, NOT when asking for a phone or mobile number, NOT when asking about an appointment day or time, NOT when reading your name and date of birth back to you for confirmation.",
       "response_type": "phrase",
       "response_value": "Alice Romano. My date of birth is September eighth, nineteen ninety-five."
@@ -196,7 +202,7 @@
     },
     {
       "match_type": "context",
-      "match_phrase": "thanks you, says goodbye, or asks if you need anything else before a consult time has been confirmed on the calendar. NOT when they have just confirmed a booked time.",
+      "match_phrase": "thanks you, says goodbye, or wraps up after you have asked for a Botox consult or a Windermere lookup, before a consult time has been confirmed on the calendar. NOT when greeting you or asking how they can help at the start of the call, NOT when they have just confirmed a booked time, NOT when asking for your name or date of birth.",
       "response_type": "phrase",
       "response_value": "I still need the consult booked. Please confirm a time on the calendar before I go."
     },

--- a/tests/test_tasks_to_digital_humans.py
+++ b/tests/test_tasks_to_digital_humans.py
@@ -802,6 +802,15 @@ def test_healthcare_greeting_and_stay_pins_lock_path() -> None:
     for pin in wrap_m2:
         assert "NOT when greeting you" in (pin.get("match_phrase") or "")
 
+    c4h4 = load("C4-H4")
+    greeting_h4 = next(p for p in c4h4["scripted_responses"] if "greets you" in (p.get("match_phrase") or ""))
+    assert "botox" in greeting_h4["response_value"].lower()
+    assert "windermere" in greeting_h4["response_value"].lower()
+    wrap_h4 = [p for p in c4h4["scripted_responses"] if "wraps up" in (p.get("match_phrase") or "")]
+    assert wrap_h4
+    for pin in wrap_h4:
+        assert "NOT when greeting you" in (pin.get("match_phrase") or "")
+
     for path in tasks.glob("*/task.json"):
         phrases = [p["match_phrase"] for p in json.loads(path.read_text()).get("scripted_responses") or []]
         assert len(phrases) == len(set(phrases)), path.parent.name


### PR DESCRIPTION
## Summary
- Lock C4-H4 so the first spoken request after greeting is Botox cost plus a Windermere cosmetic lookup, not a leftover “still need a consult booked” wrap-up.
- Add a greeting pin and tighten the wrap-up pin with `NOT when greeting you`.
- Lock those pins in `test_healthcare_greeting_and_stay_pins_lock_path`.

## Test plan
- [ ] `pytest tests/test_tasks_to_digital_humans.py -k test_healthcare_greeting_and_stay_pins_lock_path`
- [ ] Confirm C4-H4 DH greeting asks Botox/Windermere and wrap-up does not fire on hello


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins C4-H4 greeting so the first spoken request is Botox price and a Windermere cosmetic lookup. Previously the wrap-up pin could fire on hello; now a greeting pin handles the opening and the wrap-up pin excludes greeting contexts.

- Updates `industries/healthcare/tasks/C4-H4/task.json`: adds a greeting scripted response, tightens the wrap-up match phrase with “NOT when greeting you,” and clarifies the `intent` to require Botox/Windermere as the first request.
- Adds tests in `tests/test_tasks_to_digital_humans.py` to assert the greeting includes Botox/Windermere, wrap-up pins include the new exclusion, and scripted response match phrases are unique.
- Verify with: pytest tests/test_tasks_to_digital_humans.py -k test_healthcare_greeting_and_stay_pins_lock_path

<sup>Written for commit dbae01b5e24dedb2bea2a845778e3400fa7203fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/43?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

