### PR TITLE
Add Bluejay run CSV exporter and qwen harness fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,11 @@ uv.toml
 # downloaded hangup dumps (slug/run/dh/result)
 actual-final-state/
 
+# local Bluejay CSV exports (not tracked)
+/eval_outputs/
+/.mivas-monitor/
+/healthcare-*.csv
+
 # cached provider-side agent IDs (e.g. ElevenLabs ensure_agents)
 **/.agents.json
 

--- a/scripts/bluejay_run_to_csv.py
+++ b/scripts/bluejay_run_to_csv.py
@@ -1,0 +1,729 @@
+"""Write one Bluejay simulation run as a conversation-per-row CSV.
+
+Each CSV row is one Bluejay simulation result (`result_id`) — one
+conversation. k repeats of the same digital human stay as k rows; they
+are never rolled up. `conversation_index` is 1..k in run order for the
+same `digital_human_id` + `case_key` so dashboards can still do
+always/mixed/never bands. It is not a rollup of those conversations.
+
+This CSV is the dashboard source of record for a full simulation — task
+link, tool/handoff/hangup evals (args + DB diffs), custom-metric values
+and reasoning, builtin quality metrics, and transcript — so a later
+dashboard can visualize the run without going back to Bluejay.
+
+Scoring is our verifier (tools ∧ handoff ∧ hangup DB), not Bluejay's goal
+judge. `goal_success`, `goal_reasoning`, and platform `tests_passed` are
+never columns.
+
+    uv run python scripts/bluejay_run_to_csv.py RUN_ID --industry healthcare --out /tmp/run-RUN_ID.csv
+    uv run python scripts/bluejay_run_to_csv.py --sim SIM_ID --industry healthcare --out /tmp/run.csv
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import importlib.util
+import io
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any, Iterable, TextIO
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS = ROOT / "scripts"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+verify_task_run = _load("verify_task_run", SCRIPTS / "verify_task_run.py")
+verify_run = verify_task_run.verify_run
+
+# stable header. extra custom metrics (if any) append after these.
+HEADERS = [
+    # run / conversation identity
+    "run_id",
+    "simulation_id",
+    "agent_id",
+    "result_id",
+    "digital_human_id",
+    "industry",
+    "case_key",
+    "task_path",
+    "task_dir",
+    "task_name",
+    "dh_name",
+    "category",
+    "difficulty",
+    "audio_condition",
+    "conversation_index",
+    "status",
+    "mark",
+    "pending",
+    "void_reason",
+    "duration_s",
+    "start_time",
+    "end_time",
+    # combined + component pass (ours, not Bluejay goal)
+    "combined_pass",
+    "tools_pass",
+    "handoff_pass",
+    "hangup_db_pass",
+    # tool-call eval (names + args)
+    "tools_score",
+    "missing_tools",
+    "hit_tools",
+    "extra_tools",
+    "actual_tools",
+    "expected_tools",
+    "expected_tool_calls_json",
+    "actual_tool_calls_json",
+    # handoff eval
+    "handoff_verdict",
+    "handoff_score",
+    "expected_handoffs",
+    "actual_handoffs",
+    # hangup DB eval
+    "hangup_expected_json",
+    "hangup_actual_json",
+    "hangup_diff",
+    "hangup_note",
+    # Bluejay custom metrics (never goal_*)
+    "prompt_adherence",
+    "prompt_adherence_reasoning",
+    "task_completion",
+    "task_completion_reasoning",
+    "premature_end",
+    "premature_end_reasoning",
+    # builtin quality / latency / barge-in
+    "builtin_duration",
+    "builtin_num_turns",
+    "builtin_interface",
+    "builtin_agent_interruption_count",
+    "builtin_customer_interruption_count",
+    "builtin_avg_agent_latency",
+    "builtin_max_agent_latency",
+    "builtin_p50_agent_latency",
+    "builtin_p90_agent_latency",
+    "builtin_p95_agent_latency",
+    "builtin_p99_agent_latency",
+    "builtin_avg_customer_latency",
+    "builtin_p50_customer_latency",
+    "builtin_p90_customer_latency",
+    "builtin_avg_punctuation_latency",
+    "builtin_p50_punctuation_latency",
+    "builtin_p90_punctuation_latency",
+    "builtin_time_to_first_agent_utterance",
+    "builtin_agent_audio_clarity",
+    "builtin_agent_perceived_loudness",
+    "builtin_agent_audio_clipping",
+    "builtin_agent_pitch_variability",
+    "builtin_agent_audio_dropouts",
+    "builtin_pronunciation",
+    "builtin_agent_turn_duration_avg",
+    "builtin_agent_words_per_turn_avg",
+    "builtin_customer_words_per_turn_avg",
+    "builtin_agent_wpm",
+    "builtin_agent_speak_percentage",
+    "builtin_success",
+    "builtin_redundancy",
+    # evaluation quality (never goal_success / goal_reasoning)
+    "eval_sentiment_label",
+    "eval_sentiment_score",
+    "eval_hallucination",
+    "eval_redundancy",
+    "eval_pronunciation_score",
+    "eval_agent_audio_clarity",
+    "eval_user_audio_clarity",
+    "eval_agent_speak_percentage",
+    "eval_avg_agent_latency",
+    "eval_call_summary",
+    # transcript / audio
+    "transcript",
+    "transcript_url",
+    "recording_url",
+    "agent_chars",
+    "num_turns",
+]
+
+# Bluejay native outcome / goal eval — never emit these, even as extras.
+EXCLUDED_COLUMNS = frozenset({
+    "goal_success",
+    "goal_reasoning",
+    "tests_passed",
+    "judge_goal",
+    "judge_reason",
+})
+
+CANONICAL_METRICS = ("prompt_adherence", "task_completion", "premature_end")
+CANONICAL_REASONING = tuple(f"{key}_reasoning" for key in CANONICAL_METRICS)
+BUILTIN_METRICS = (
+    "duration",
+    "num_turns",
+    "interface",
+    "agent_interruption_count",
+    "customer_interruption_count",
+    "avg_agent_latency",
+    "max_agent_latency",
+    "p50_agent_latency",
+    "p90_agent_latency",
+    "p95_agent_latency",
+    "p99_agent_latency",
+    "avg_customer_latency",
+    "p50_customer_latency",
+    "p90_customer_latency",
+    "avg_punctuation_latency",
+    "p50_punctuation_latency",
+    "p90_punctuation_latency",
+    "time_to_first_agent_utterance",
+    "agent_audio_clarity",
+    "agent_perceived_loudness",
+    "agent_audio_clipping",
+    "agent_pitch_variability",
+    "agent_audio_dropouts",
+    "pronunciation",
+    "agent_turn_duration_avg",
+    "agent_words_per_turn_avg",
+    "customer_words_per_turn_avg",
+    "agent_wpm",
+    "agent_speak_percentage",
+    "success",
+    "redundancy",
+)
+EVAL_QUALITY_KEYS = (
+    "sentiment_label",
+    "sentiment_score",
+    "hallucination",
+    "redundancy",
+    "pronunciation_score",
+    "agent_audio_clarity",
+    "user_audio_clarity",
+    "agent_speak_percentage",
+    "avg_agent_latency",
+    "call_summary",
+)
+RECORDING_KEYS = (
+    "recording_url",
+    "audio_url",
+    "call_recording_url",
+    "recording",
+)
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def slug_metric(name: str) -> str:
+    return _SLUG_RE.sub("_", str(name or "").strip().lower()).strip("_")
+
+
+def canonical_metric_key(name: str) -> str | None:
+    slug = slug_metric(name)
+    if "prompt" in slug and "adherence" in slug:
+        return "prompt_adherence"
+    if "task" in slug and "completion" in slug:
+        return "task_completion"
+    if "premature" in slug:
+        return "premature_end"
+    return None
+
+
+def _bool_cell(value: Any) -> str:
+    if value is None:
+        return ""
+    return "true" if value else "false"
+
+
+def _join(names: Iterable[Any]) -> str:
+    return ";".join(str(item) for item in names if item not in (None, ""))
+
+
+def _json_cell(value: Any) -> str:
+    if value is None:
+        return ""
+    return json.dumps(value, ensure_ascii=False, default=str)
+
+
+def _eval0(result: dict[str, Any]) -> dict[str, Any]:
+    evals = result.get("evaluations") or []
+    if isinstance(evals, list) and evals and isinstance(evals[0], dict):
+        return evals[0]
+    if isinstance(evals, dict):
+        return evals
+    return {}
+
+
+def _metric_raw(entry: dict[str, Any]) -> Any:
+    if entry.get("is_not_applicable"):
+        return None
+    val = entry.get("response_value")
+    if val is None:
+        for key in (
+            "yes_no_response",
+            "quantitative_response",
+            "pass_fail_response",
+            "enum_response",
+            "qualitative_response",
+            "json_response",
+            "int_value",
+            "float_value",
+            "boolean_value",
+            "enum_value",
+            "qualitative_value",
+            "json_value",
+            "value",
+        ):
+            if entry.get(key) is not None:
+                val = entry[key]
+                break
+    return val
+
+
+def _metric_cell(entry: dict[str, Any]) -> str:
+    val = _metric_raw(entry)
+    if val is None or val == "":
+        return ""
+    kind = str(entry.get("response_type") or "").lower()
+    if kind in {"yes_no", "pass_fail"} or (
+        isinstance(val, str) and val.strip().lower() in {"yes", "no", "true", "false"}
+    ):
+        low = str(val).strip().lower()
+        if low in {"yes", "true"}:
+            return "true"
+        if low in {"no", "false"}:
+            return "false"
+    if isinstance(val, bool):
+        return "true" if val else "false"
+    return str(val).strip()
+
+
+def _metric_reasoning(entry: dict[str, Any]) -> str:
+    return str(entry.get("reasoning") or "").replace("\n", " ").strip()
+
+
+def iter_custom_metric_entries(result: dict[str, Any]) -> list[dict[str, Any]]:
+    """Prefer top-level `custom_metrics`; fall back to evaluation mirrors."""
+    top = result.get("custom_metrics")
+    if isinstance(top, list) and top:
+        return [item for item in top if isinstance(item, dict)]
+    ev = _eval0(result)
+    nested = ev.get("custom_metrics") or ev.get("custom_evals")
+    if isinstance(nested, dict):
+        results = nested.get("custom_metrics_results")
+        if isinstance(results, list):
+            return [item for item in results if isinstance(item, dict)]
+        return [
+            dict(value, name=key) if isinstance(value, dict) else {"name": key, "value": value}
+            for key, value in nested.items()
+        ]
+    if isinstance(nested, list):
+        return [item for item in nested if isinstance(item, dict)]
+    return []
+
+
+def _excluded_metric(key: str) -> bool:
+    if key in EXCLUDED_COLUMNS:
+        return True
+    if key.endswith("_reasoning") and key[: -len("_reasoning")] in EXCLUDED_COLUMNS:
+        return True
+    return False
+
+
+def custom_metric_cells(result: dict[str, Any]) -> dict[str, str]:
+    out: dict[str, str] = {key: "" for key in CANONICAL_METRICS}
+    for key in CANONICAL_METRICS:
+        out[f"{key}_reasoning"] = ""
+    for entry in iter_custom_metric_entries(result):
+        name = str(entry.get("metric_name") or entry.get("name") or "").strip()
+        if not name:
+            continue
+        key = canonical_metric_key(name) or slug_metric(name)
+        if not key or _excluded_metric(key):
+            continue
+        if key in out and out[key]:
+            continue
+        out[key] = _metric_cell(entry)
+        out[f"{key}_reasoning"] = _metric_reasoning(entry)
+    return out
+
+
+def builtin_metric(result: dict[str, Any], name: str) -> Any:
+    for item in result.get("metrics") or []:
+        if isinstance(item, dict) and item.get("name") == name:
+            return item.get("value")
+    return None
+
+
+def builtin_metric_cells(result: dict[str, Any]) -> dict[str, str]:
+    out = {f"builtin_{name}": "" for name in BUILTIN_METRICS}
+    for item in result.get("metrics") or []:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        if name not in BUILTIN_METRICS:
+            continue
+        val = item.get("value")
+        out[f"builtin_{name}"] = "" if val is None else str(val)
+    return out
+
+
+def eval_quality_cells(result: dict[str, Any]) -> dict[str, str]:
+    ev = _eval0(result)
+    out: dict[str, str] = {}
+    for key in EVAL_QUALITY_KEYS:
+        col = f"eval_{key}"
+        if _excluded_metric(col) or key in EXCLUDED_COLUMNS:
+            continue
+        val = ev.get(key)
+        if key == "call_summary" and val not in (None, ""):
+            out[col] = str(val).replace("\n", " ").strip()
+        else:
+            out[col] = "" if val is None else str(val)
+    return out
+
+
+def recording_url_of(result: dict[str, Any]) -> str:
+    for key in RECORDING_KEYS:
+        val = result.get(key)
+        if isinstance(val, str) and val.strip():
+            return val.strip()
+    return ""
+
+
+def duration_s(result: dict[str, Any]) -> str:
+    raw = result.get("duration")
+    if raw not in (None, ""):
+        return str(raw)
+    ms = builtin_metric(result, "duration")
+    if isinstance(ms, (int, float)):
+        return str(ms / 1000 if ms > 1000 else ms)
+    return ""
+
+
+def num_turns(result: dict[str, Any]) -> str:
+    turns = builtin_metric(result, "num_turns")
+    if turns is None:
+        turns = _eval0(result).get("num_turns")
+    return "" if turns is None else str(turns)
+
+
+def agent_id_of(
+    run: dict[str, Any],
+    results: list[dict[str, Any]],
+    sim_id: str,
+) -> str:
+    for key in ("agent_id",):
+        if run.get(key) not in (None, ""):
+            return str(run[key])
+    if sim_id:
+        try:
+            body = verify_run._get(f"simulation/{sim_id}")
+        except SystemExit:
+            body = {}
+        sim = body.get("simulation") or body
+        if isinstance(sim, dict) and sim.get("agent_id") not in (None, ""):
+            return str(sim["agent_id"])
+    for row in results:
+        detail = row.get("detail") or {}
+        for entry in iter_custom_metric_entries(detail):
+            if entry.get("agent_id") not in (None, ""):
+                return str(entry["agent_id"])
+    return ""
+
+
+def extra_tool_names(expected: list[str], actual: list[str]) -> list[str]:
+    want = set(expected)
+    seen: set[str] = set()
+    extra: list[str] = []
+    for name in actual:
+        if name in want or name in seen:
+            continue
+        seen.add(name)
+        extra.append(name)
+    return extra
+
+
+def transcript_text(result: dict[str, Any], lines: list[str] | None = None) -> str:
+    if lines is None:
+        lines = verify_task_run.result_transcript_lines(result)
+    return "\n".join(line.rstrip("\n") for line in lines)
+
+
+def task_link(industry: str, case_key: str, task: Any) -> tuple[str, str]:
+    """Repo-relative task.json path. Emit if the file exists or was already loaded."""
+    if not industry or not case_key:
+        return "", ""
+    rel_dir = f"industries/{industry}/tasks/{case_key}"
+    rel_file = f"{rel_dir}/task.json"
+    if task is not None or (ROOT / rel_file).is_file():
+        return rel_file, rel_dir
+    return "", ""
+
+
+def task_metadata(task: dict[str, Any] | None) -> dict[str, str]:
+    meta = (task or {}).get("metadata") if isinstance(task, dict) else None
+    if not isinstance(meta, dict):
+        meta = {}
+    return {
+        "category": "" if meta.get("category") in (None, "") else str(meta["category"]),
+        "difficulty": "" if meta.get("difficulty") in (None, "") else str(meta["difficulty"]),
+        "audio_condition": (
+            "" if meta.get("audio_condition") in (None, "") else str(meta["audio_condition"])
+        ),
+    }
+
+
+def assign_conversation_indexes(results: list[dict[str, Any]]) -> None:
+    """1..k in run order for the same digital_human_id + case_key.
+
+    Each result stays its own row. This index is only so dashboards can
+    band always/mixed/never across k conversations; it is not a rollup.
+    """
+    counts: dict[tuple[str, str], int] = {}
+    for row in results:
+        key = (str(row.get("digital_human_id") or ""), str(row.get("case_key") or ""))
+        counts[key] = counts.get(key, 0) + 1
+        row["conversation_index"] = counts[key]
+
+
+def _row_fingerprint(row: Any) -> str:
+    return json.dumps(row, sort_keys=True, default=str)
+
+
+def hangup_table_diff(
+    expected: Any,
+    actual: Any,
+    industry: str | None,
+) -> dict[str, Any]:
+    """Canonical table-level mismatch (same normalization the scorer uses)."""
+    if expected is None or actual is None:
+        return {}
+    exp = verify_task_run.office_canonical(expected, industry)
+    act = verify_task_run.office_canonical(actual, industry)
+    out: dict[str, Any] = {}
+    tables = list(dict.fromkeys([*exp.keys(), *act.keys()]))
+    for table in tables:
+        want = exp.get(table) or []
+        got = act.get(table) or []
+        if want == got:
+            continue
+        exp_fps = {_row_fingerprint(row) for row in want}
+        act_fps = {_row_fingerprint(row) for row in got}
+        out[table] = {
+            "expected_count": len(want),
+            "actual_count": len(got),
+            "only_in_expected": [row for row in want if _row_fingerprint(row) not in act_fps],
+            "only_in_actual": [row for row in got if _row_fingerprint(row) not in exp_fps],
+        }
+    return out
+
+
+def hangup_diff_cell(
+    expected: Any,
+    actual: Any,
+    state: dict[str, Any],
+    industry: str | None,
+) -> str:
+    if state.get("skipped") or state.get("passed") is not False:
+        return ""
+    diff = hangup_table_diff(expected, actual, industry)
+    return _json_cell(diff) if diff else ""
+
+
+def result_row(
+    scored: dict[str, Any],
+    *,
+    run_id: str,
+    simulation_id: str,
+    agent_id: str,
+    industry: str = "",
+    conversation_index: int | str | None = None,
+    transcript_lines: list[str] | None = None,
+) -> dict[str, str]:
+    """One CSV row for one Bluejay simulation result / conversation."""
+    detail = scored.get("detail") or {}
+    task = scored.get("task")
+    call = scored.get("call") or {}
+    handoff = scored.get("handoff") or {}
+    state = scored.get("state") or {}
+    expected_tools = verify_task_run.expected_tool_names(task)
+    actual_tools = list(scored.get("actual_tools") or [])
+    void = bool(scored.get("void_reason") or scored.get("pending"))
+    hangup = state.get("passed")
+    hangup_cell = "" if state.get("skipped") or hangup is None else _bool_cell(hangup)
+    combined = "" if void else _bool_cell(scored.get("passed"))
+    metrics = custom_metric_cells(detail)
+    builtins = builtin_metric_cells(detail)
+    evals = eval_quality_cells(detail)
+    meta = task_metadata(task if isinstance(task, dict) else None)
+    path, directory = task_link(industry, str(scored.get("case_key") or ""), task)
+    dh = scored.get("digital_human") or {}
+    task_name = ""
+    if isinstance(task, dict) and task.get("task_name"):
+        task_name = str(task["task_name"])
+    else:
+        task_name = str(dh.get("test_name") or "")
+    if conversation_index is None:
+        conversation_index = scored.get("conversation_index")
+    if transcript_lines is None:
+        transcript_lines = scored.get("transcript_lines")
+    expected_calls = list((task or {}).get("exp_tool_calls") or []) if isinstance(task, dict) else []
+    actual_calls = scored.get("actual_tool_calls")
+    if actual_calls is None:
+        actual_calls = verify_task_run.actual_tool_calls(detail)
+    expected_state = verify_task_run.expected_state(task) if isinstance(task, dict) else None
+    actual_state = scored.get("actual_state")
+    row = {
+        "run_id": str(run_id),
+        "simulation_id": str(simulation_id or ""),
+        "agent_id": str(agent_id or ""),
+        "result_id": str(scored.get("result_id") or detail.get("id") or ""),
+        "digital_human_id": "" if scored.get("digital_human_id") is None else str(scored["digital_human_id"]),
+        "industry": industry,
+        "case_key": scored.get("case_key") or "",
+        "task_path": path,
+        "task_dir": directory,
+        "task_name": task_name,
+        "dh_name": "" if dh.get("name") in (None, "") else str(dh["name"]),
+        "category": meta["category"],
+        "difficulty": meta["difficulty"],
+        "audio_condition": meta["audio_condition"],
+        "conversation_index": "" if conversation_index in (None, "") else str(conversation_index),
+        "status": scored.get("status") or "",
+        "mark": scored.get("mark") or "",
+        "pending": _bool_cell(scored.get("pending")),
+        "void_reason": scored.get("void_reason") or "",
+        "duration_s": duration_s(detail),
+        "start_time": str(detail.get("start_time") or ""),
+        "end_time": str(detail.get("end_time") or ""),
+        "combined_pass": combined,
+        "tools_pass": _bool_cell(call.get("passed")),
+        "handoff_pass": _bool_cell(handoff.get("passed")),
+        "hangup_db_pass": hangup_cell,
+        "tools_score": "" if call.get("score") is None else str(call["score"]),
+        "missing_tools": _join(call.get("missing") or []),
+        "hit_tools": _join(call.get("hit") or []),
+        "extra_tools": _join(extra_tool_names(expected_tools, actual_tools)),
+        "actual_tools": _join(actual_tools),
+        "expected_tools": _join(expected_tools),
+        "expected_tool_calls_json": _json_cell(expected_calls) if expected_calls or isinstance(task, dict) else "",
+        "actual_tool_calls_json": _json_cell(actual_calls),
+        "handoff_verdict": handoff.get("verdict") or "",
+        "handoff_score": "" if handoff.get("score") is None else str(handoff["score"]),
+        "expected_handoffs": _join(handoff.get("expected") or []),
+        "actual_handoffs": _join(handoff.get("actual") or []),
+        "hangup_expected_json": _json_cell(expected_state),
+        "hangup_actual_json": _json_cell(actual_state),
+        "hangup_diff": hangup_diff_cell(expected_state, actual_state, state, industry or None),
+        "hangup_note": "" if state.get("note") in (None, "") else str(state["note"]),
+        "prompt_adherence": metrics.get("prompt_adherence", ""),
+        "prompt_adherence_reasoning": metrics.get("prompt_adherence_reasoning", ""),
+        "task_completion": metrics.get("task_completion", ""),
+        "task_completion_reasoning": metrics.get("task_completion_reasoning", ""),
+        "premature_end": metrics.get("premature_end", ""),
+        "premature_end_reasoning": metrics.get("premature_end_reasoning", ""),
+        **builtins,
+        **evals,
+        "transcript": transcript_text(detail, transcript_lines),
+        "transcript_url": str(detail.get("transcript_url") or ""),
+        "recording_url": recording_url_of(detail),
+        "agent_chars": "" if scored.get("agent_chars") is None else str(scored["agent_chars"]),
+        "num_turns": num_turns(detail),
+    }
+    skip_metric_keys = set(CANONICAL_METRICS) | set(CANONICAL_REASONING) | EXCLUDED_COLUMNS
+    for key, value in metrics.items():
+        if key in skip_metric_keys or _excluded_metric(key) or key in row:
+            continue
+        row[key] = value
+    return {key: "" if value is None else str(value) for key, value in row.items()}
+
+
+def headers_for(rows: list[dict[str, str]]) -> list[str]:
+    extra: list[str] = []
+    for row in rows:
+        for key in row:
+            if key in HEADERS or key in EXCLUDED_COLUMNS or _excluded_metric(key) or key in extra:
+                continue
+            extra.append(key)
+    return list(HEADERS) + extra
+
+
+def write_csv(rows: list[dict[str, str]], dest: TextIO) -> list[str]:
+    fields = headers_for(rows)
+    writer = csv.DictWriter(
+        dest,
+        fieldnames=fields,
+        extrasaction="ignore",
+        lineterminator="\n",
+        quoting=csv.QUOTE_ALL,
+    )
+    writer.writeheader()
+    writer.writerows(rows)
+    return fields
+
+
+def rows_to_csv(rows: list[dict[str, str]]) -> str:
+    buf = io.StringIO()
+    write_csv(rows, buf)
+    return buf.getvalue()
+
+
+def main(argv: list[str] | None = None) -> int:
+    verify_task_run.load_dotenv()
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("run_id", nargs="?", help="Bluejay simulation run id")
+    parser.add_argument("--sim", help="Use this simulation's latest run")
+    parser.add_argument("--industry", required=True)
+    parser.add_argument("--out", help="UTF-8 CSV path (default: run_<id>.csv)")
+    parser.add_argument("--actuals-dir", type=Path, help="Local hangup dumps (skip S3)")
+    parser.add_argument("--harness", default="openai/realtime-2.1")
+    parser.add_argument("--slug", help="Override the S3 / dump slug")
+    args = parser.parse_args(argv)
+
+    run_id = args.run_id
+    if args.sim:
+        run_id = verify_run.latest_run_for_sim(args.sim)
+    if not run_id:
+        parser.error("give a run id or --sim")
+
+    scored = verify_task_run.collect_scored_results(
+        str(run_id),
+        args.industry,
+        actuals_dir=args.actuals_dir,
+        harness=args.harness,
+        slug=args.slug,
+        sim_hint=args.sim,
+    )
+    agent_id = agent_id_of(scored.get("run") or {}, scored["results"], scored.get("simulation_id") or "")
+    assign_conversation_indexes(scored["results"])
+    rows = [
+        result_row(
+            row,
+            run_id=scored["run_id"],
+            simulation_id=scored.get("simulation_id") or "",
+            agent_id=agent_id,
+            industry=args.industry,
+            conversation_index=row.get("conversation_index"),
+            transcript_lines=row.get("transcript_lines"),
+        )
+        for row in scored["results"]
+    ]
+    if not rows:
+        raise SystemExit(f"no results for run {run_id}")
+
+    out = Path(args.out) if args.out else Path(f"run_{run_id}.csv")
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("w", encoding="utf-8", newline="") as handle:
+        fields = write_csv(rows, handle)
+    print(f"wrote {out} ({len(rows)} rows × {len(fields)} columns)", file=sys.stderr)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/refresh_k5_monitor.py
+++ b/scripts/refresh_k5_monitor.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Re-inline healthcare k=5 poller snapshots into the progress-monitor canvas.
+
+Canvas runtime cannot fetch `.mivas-monitor/*.json`. This script is the Refresh
+path: read the latest poller files, rewrite the marked snapshot block in
+`healthcare-k5-progress-monitor.canvas.tsx`, and write the official
+`.canvas.data.json` sidecar so `useCanvasState("k5Monitor")` stays current.
+
+    uv run python scripts/refresh_k5_monitor.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+MONITOR_DIR = ROOT / ".mivas-monitor"
+DEFAULT_CANVAS = (
+    Path.home()
+    / ".cursor/projects/Users-farazsiddiqi-Desktop-bluejay-repos-mivas-bench"
+    / "canvases"
+    / "healthcare-k5-progress-monitor.canvas.tsx"
+)
+
+SIM_IDS = (30998, 30999, 31000, 31001, 31002, 31003, 31004)
+
+SHORT_NAMES = {
+    "openai/realtime-2.1": "realtime-2.1",
+    "openai/realtime-2.1-mini": "realtime-2.1-mini",
+    "gemini/flash-live-3.1": "flash-live-3.1",
+    "gemini/2.5-flash-native-audio": "native-audio",
+    "aws/nova-sonic-2": "nova-sonic-2",
+    "grok/voice": "grok-voice",
+    "qwen/audio-realtime": "qwen-audio",
+}
+
+MARKER_START = "/* k5-monitor-data-start */"
+MARKER_END = "/* k5-monitor-data-end */"
+STATE_KEY = "k5Monitor"
+
+
+def _f(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _i(value: Any) -> int:
+    if value is None or isinstance(value, bool):
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def parse_issues(raw: dict[str, Any]) -> dict[str, int]:
+    issues = raw.get("issues") or {}
+    return {
+        "NO_ANSWER": _i(issues.get("NO_ANSWER")),
+        "NO_CONNECTION": _i(issues.get("NO_CONNECTION")),
+        "CANCELLED": _i(issues.get("CANCELLED")),
+        "ERROR": _i(issues.get("ERROR") or issues.get("system_connection_ERROR")),
+        "SYSTEM_ERROR": _i(issues.get("SYSTEM_ERROR")),
+        "other": _i(issues.get("other")),
+    }
+
+
+def parse_latency(raw: dict[str, Any]) -> dict[str, Any]:
+    lat = raw.get("latency") or {}
+    avg: float | None = None
+    p50: float | None = None
+    p95: float | None = None
+    n = 0
+
+    if "avg_agent_latency_mean" in lat:
+        avg = _f(lat.get("avg_agent_latency_mean"))
+        p50 = _f(lat.get("p50_agent_latency_mean"))
+        p95 = _f(lat.get("p95_agent_latency_mean") or lat.get("p90_agent_latency_mean"))
+        n = _i(lat.get("n"))
+    else:
+        avg_o = lat.get("avg_agent_latency") or lat.get("avg_agent_latency_ms")
+        if isinstance(avg_o, (int, float)):
+            avg = float(avg_o)
+            n = _i(lat.get("n"))
+        elif isinstance(avg_o, dict):
+            avg = _f(avg_o.get("mean"))
+            n = _i(avg_o.get("n") or lat.get("n"))
+            p50 = _f(avg_o.get("p50"))
+
+        p50_o = lat.get("p50_agent_latency") or lat.get("p50_agent_latency_ms")
+        if isinstance(p50_o, dict):
+            p50 = _f(p50_o.get("mean"))
+            n = n or _i(p50_o.get("n"))
+        elif isinstance(p50_o, (int, float)):
+            p50 = float(p50_o)
+
+        p95_o = (
+            lat.get("p95_agent_latency")
+            or lat.get("p90_agent_latency")
+            or lat.get("p95_agent_latency_ms")
+            or lat.get("p90_agent_latency_ms")
+        )
+        if isinstance(p95_o, dict):
+            p95 = _f(p95_o.get("mean"))
+        elif isinstance(p95_o, (int, float)):
+            p95 = float(p95_o)
+
+    # grok/voice (and similar) report seconds; canvas latency columns are ms
+    if avg is not None and avg < 100:
+        avg = round(avg * 1000, 4)
+        if p50 is not None:
+            p50 = round(p50 * 1000, 4)
+        if p95 is not None:
+            p95 = round(p95 * 1000, 4)
+
+    return {"avg": avg, "p50": p50, "p95": p95, "n": n}
+
+
+def _metric_block(cm: dict[str, Any], name: str) -> tuple[float | None, int, Any]:
+    obj = cm.get(name)
+    if isinstance(obj, dict):
+        if name == "premature_end":
+            mean = _f(obj.get("rate") if obj.get("rate") is not None else obj.get("mean"))
+        else:
+            mean = _f(obj.get("mean"))
+        return mean, _i(obj.get("n")), obj.get("yes")
+    mean_key = "premature_end_rate" if name == "premature_end" else f"{name}_mean"
+    return _f(cm.get(mean_key)), _i(cm.get(f"n_{name}")), None
+
+
+def parse_metrics(raw: dict[str, Any]) -> dict[str, Any]:
+    cm = raw.get("custom_metrics") or {}
+    pa_mean, pa_n, _ = _metric_block(cm, "prompt_adherence")
+    tc_mean, tc_n, _ = _metric_block(cm, "task_completion")
+    pe_rate, pe_n, pe_yes = _metric_block(cm, "premature_end")
+    if pe_yes is None and pe_rate is not None and pe_n:
+        pe_yes = int(round(pe_rate * pe_n))
+    else:
+        pe_yes = _i(pe_yes)
+    return {
+        "prompt_adherence_mean": pa_mean,
+        "prompt_adherence_n": pa_n,
+        "task_completion_mean": tc_mean,
+        "task_completion_n": tc_n,
+        "premature_end_rate": pe_rate,
+        "premature_end_yes": pe_yes,
+        "premature_end_n": pe_n,
+    }
+
+
+def to_row(index_entry: dict[str, Any], raw: dict[str, Any]) -> dict[str, Any]:
+    harness = str(index_entry["harness"])
+    counts = raw.get("status_counts") or {}
+    status = str(raw.get("status") or raw.get("run_status") or "QUEUED").upper()
+    if status not in {"QUEUED", "RUNNING", "COMPLETED", "FAILED", "CANCELLED"}:
+        status = "RUNNING"
+    return {
+        "harness": harness,
+        "short": SHORT_NAMES.get(harness, harness.rsplit("/", 1)[-1]),
+        "agent_id": _i(raw.get("agent_id") or index_entry.get("agent_id")),
+        "simulation_id": _i(
+            raw.get("simulation_id") or raw.get("sim_id") or index_entry.get("sim_id")
+        ),
+        "run_id": _i(raw.get("run_id") or index_entry.get("run_id")),
+        "status": status,
+        "completed": _i(raw.get("completed") if raw.get("completed") is not None else counts.get("COMPLETED")),
+        "total": _i(raw.get("total") or 360),
+        "in_progress": _i(counts.get("RUNNING")),
+        "initializing": _i(counts.get("INITIALIZING")),
+        "evaluating": _i(counts.get("EVALUATING")),
+        "conversation_ended": _i(counts.get("CONVERSATION_ENDED")),
+        "queued": _i(counts.get("QUEUED")),
+        "concurrency": _i(index_entry.get("concurrency")),
+        "issues": parse_issues(raw),
+        "latency": parse_latency(raw),
+        "metrics": parse_metrics(raw),
+        "csv_path": raw.get("csv_path"),
+        "updated_at": str(raw.get("updated_at") or ""),
+    }
+
+
+def load_monitor(monitor_dir: Path) -> tuple[str, list[dict[str, Any]]]:
+    index = json.loads((monitor_dir / "index.json").read_text())
+    by_sim = {int(h["sim_id"]): h for h in index["harnesses"]}
+    rows: list[dict[str, Any]] = []
+    for sim_id in SIM_IDS:
+        path = monitor_dir / f"{sim_id}.json"
+        raw = json.loads(path.read_text())
+        rows.append(to_row(by_sim[sim_id], raw))
+    updated = [r["updated_at"] for r in rows if r["updated_at"]]
+    snapshot_at = max(updated) if updated else datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return snapshot_at, rows
+
+
+def _ts_num(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, int) and not isinstance(value, bool):
+        return str(value)
+    if isinstance(value, float):
+        return json.dumps(value)
+    return json.dumps(value)
+
+
+def emit_harness_ts(row: dict[str, Any]) -> str:
+    issues = row["issues"]
+    lat = row["latency"]
+    met = row["metrics"]
+    csv_path = "null" if row["csv_path"] is None else json.dumps(row["csv_path"])
+    return "\n".join(
+        [
+            "  {",
+            f'    harness: {json.dumps(row["harness"])},',
+            f'    short: {json.dumps(row["short"])},',
+            f'    agent_id: {row["agent_id"]},',
+            f'    simulation_id: {row["simulation_id"]},',
+            f'    run_id: {row["run_id"]},',
+            f'    status: {json.dumps(row["status"])},',
+            f'    completed: {row["completed"]},',
+            f'    total: {row["total"]},',
+            f'    in_progress: {row["in_progress"]},',
+            f'    initializing: {row["initializing"]},',
+            f'    evaluating: {row["evaluating"]},',
+            f'    conversation_ended: {row["conversation_ended"]},',
+            f'    queued: {row["queued"]},',
+            f'    concurrency: {row["concurrency"]},',
+            "    issues: {{ NO_ANSWER: {na}, NO_CONNECTION: {nc}, CANCELLED: {ca}, ERROR: {er}, SYSTEM_ERROR: {se}, other: {ot} }},".format(
+                na=issues["NO_ANSWER"],
+                nc=issues["NO_CONNECTION"],
+                ca=issues["CANCELLED"],
+                er=issues["ERROR"],
+                se=issues["SYSTEM_ERROR"],
+                ot=issues["other"],
+            ),
+            f'    latency: {{ avg: {_ts_num(lat["avg"])}, p50: {_ts_num(lat["p50"])}, p95: {_ts_num(lat["p95"])}, n: {lat["n"]} }},',
+            "    metrics: {",
+            f'      prompt_adherence_mean: {_ts_num(met["prompt_adherence_mean"])},',
+            f'      prompt_adherence_n: {met["prompt_adherence_n"]},',
+            f'      task_completion_mean: {_ts_num(met["task_completion_mean"])},',
+            f'      task_completion_n: {met["task_completion_n"]},',
+            f'      premature_end_rate: {_ts_num(met["premature_end_rate"])},',
+            f'      premature_end_yes: {met["premature_end_yes"]},',
+            f'      premature_end_n: {met["premature_end_n"]},',
+            "    },",
+            f"    csv_path: {csv_path},",
+            f'    updated_at: {json.dumps(row["updated_at"])},',
+            "  }",
+        ]
+    )
+
+
+def src_caption(snapshot_at: str) -> str:
+    clock = snapshot_at.replace("T", " ").replace("Z", " UTC")
+    return (
+        "Source: .mivas-monitor/{sim}.json · healthcare · k=5 · 72 DHs · "
+        f"snapshot {clock}"
+    )
+
+
+def emit_data_block(snapshot_at: str, rows: list[dict[str, Any]]) -> str:
+    body = ",\n".join(emit_harness_ts(row) for row in rows)
+    src = src_caption(snapshot_at).replace("\\", "\\\\").replace('"', '\\"')
+    return (
+        f"{MARKER_START}\n"
+        f'const SNAPSHOT_AT = {json.dumps(snapshot_at)};\n'
+        f"const SRC =\n"
+        f'  "{src}";\n'
+        f"\n"
+        f"const HARNESSES: HarnessRow[] = [\n"
+        f"{body},\n"
+        f"];\n"
+        f"{MARKER_END}"
+    )
+
+
+def write_canvas(canvas: Path, snapshot_at: str, rows: list[dict[str, Any]]) -> None:
+    text = canvas.read_text()
+    if MARKER_START not in text or MARKER_END not in text:
+        raise SystemExit(
+            f"{canvas} is missing {MARKER_START} / {MARKER_END} markers"
+        )
+    block = emit_data_block(snapshot_at, rows)
+    updated, n = re.subn(
+        re.escape(MARKER_START) + r"[\s\S]*?" + re.escape(MARKER_END),
+        lambda _: block,
+        text,
+        count=1,
+    )
+    if n != 1:
+        raise SystemExit(f"failed to replace snapshot block in {canvas}")
+    if "const COLORS" not in updated or "type HarnessRow" not in updated:
+        raise SystemExit(
+            f"refusing to write {canvas}: snapshot replace would drop COLORS / types"
+        )
+    canvas.write_text(updated)
+
+
+def write_sidecar(canvas: Path, snapshot_at: str, rows: list[dict[str, Any]]) -> Path:
+    sidecar = canvas.with_name(canvas.name.replace(".canvas.tsx", ".canvas.data.json"))
+    existing: dict[str, Any] = {}
+    if sidecar.is_file():
+        try:
+            loaded = json.loads(sidecar.read_text())
+            if isinstance(loaded, dict):
+                existing = loaded
+        except json.JSONDecodeError:
+            existing = {}
+    existing[STATE_KEY] = {
+        "snapshot_at": snapshot_at,
+        "source": src_caption(snapshot_at),
+        "harnesses": rows,
+    }
+    sidecar.write_text(json.dumps(existing, indent=2) + "\n")
+    return sidecar
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--monitor-dir", type=Path, default=MONITOR_DIR)
+    parser.add_argument("--canvas", type=Path, default=DEFAULT_CANVAS)
+    parser.add_argument(
+        "--print-only",
+        action="store_true",
+        help="print completed/total and skip writing files",
+    )
+    args = parser.parse_args()
+
+    snapshot_at, rows = load_monitor(args.monitor_dir)
+    if args.print_only:
+        for row in rows:
+            print(f"{row['harness']}: {row['completed']}/{row['total']} {row['status']}")
+        done = sum(r["completed"] for r in rows)
+        total = sum(r["total"] for r in rows)
+        print(f"all: {done}/{total} snapshot {snapshot_at}")
+        return 0
+
+    write_canvas(args.canvas, snapshot_at, rows)
+    sidecar = write_sidecar(args.canvas, snapshot_at, rows)
+    done = sum(r["completed"] for r in rows)
+    total = sum(r["total"] for r in rows)
+    print(f"wrote {args.canvas}")
+    print(f"wrote {sidecar}")
+    for row in rows:
+        print(f"  {row['harness']}: {row['completed']}/{row['total']} {row['status']}")
+    print(f"all: {done}/{total} snapshot {snapshot_at}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify_run.py
+++ b/scripts/verify_run.py
@@ -77,9 +77,9 @@ def latest_run_for_sim(sim_id: str) -> str:
     return str(newest.get("id") or newest.get("simulation_run_id"))
 
 
-def classify(result_id: str) -> dict:
-    body = _get(f"retrieve-simulation-result/{result_id}")
-    d = body.get("simulation_result") or {}
+def classify_detail(d: dict, result_id: str | None = None) -> dict:
+    """VOID / pending / pairing verdict from an already-fetched result body."""
+    rid = str(result_id or d.get("id") or "")
     evals = d.get("evaluations") or []
     ev = evals[0] if isinstance(evals, list) and evals else (evals if isinstance(evals, dict) else {})
     groups = d.get("tool_calls") or []
@@ -90,7 +90,7 @@ def classify(result_id: str) -> dict:
     void_reason = None
     if status in NOT_FINAL:
         return {
-            "id": result_id, "status": status, "goal": ev.get("goal_success"),
+            "id": rid, "status": status, "goal": ev.get("goal_success"),
             "expected": expected, "fired": fired, "hits": [], "missing": [],
             "void_reason": None, "pending": True,
         }
@@ -102,7 +102,7 @@ def classify(result_id: str) -> dict:
         void_reason = "tool list empty while tools were expected — extraction did not land"
 
     return {
-        "id": result_id,
+        "id": rid,
         "status": status,
         "goal": ev.get("goal_success"),
         "expected": expected,
@@ -121,6 +121,12 @@ def classify(result_id: str) -> dict:
         # is the race above, so the pairing overrides it.
         "verdict": _verdict(ev.get("goal_success"), groups),
     }
+
+
+def classify(result_id: str) -> dict:
+    body = _get(f"retrieve-simulation-result/{result_id}")
+    d = body.get("simulation_result") or {}
+    return classify_detail(d, result_id)
 
 
 def _verdict(judge_goal, groups) -> str:

--- a/scripts/verify_task_run.py
+++ b/scripts/verify_task_run.py
@@ -31,6 +31,7 @@ import json
 import os
 import re
 import sys
+import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -819,8 +820,25 @@ def handoff_adherence(expected: list[str], actual: list[str]) -> dict[str, Any]:
     }
 
 
+def _get_with_retry(path: str, attempts: int = 6) -> dict[str, Any]:
+    delay = 2.0
+    last: SystemExit | None = None
+    for i in range(attempts):
+        try:
+            return verify_run._get(path)
+        except SystemExit as exc:
+            last = exc
+            msg = str(exc)
+            retryable = any(code in msg for code in ("401", "429", "500", "502", "503"))
+            if i == attempts - 1 or not retryable:
+                raise
+            time.sleep(delay)
+            delay = min(delay * 2, 30)
+    raise last or SystemExit(f"GET {path} failed")
+
+
 def _fetch_result(result_id: str) -> dict[str, Any]:
-    body = verify_run._get(f"retrieve-simulation-result/{result_id}")
+    body = _get_with_retry(f"retrieve-simulation-result/{result_id}")
     return body.get("simulation_result") or body
 
 
@@ -905,6 +923,103 @@ def verify_result(
     }
 
 
+def collect_scored_results(
+    run_id: str,
+    industry: str,
+    *,
+    actuals_dir: Path | None = None,
+    harness: str = "openai/realtime-2.1",
+    slug: str | None = None,
+    sim_hint: str | None = None,
+) -> dict[str, Any]:
+    """Score every conversation in a run. Used by verify CLI and CSV export."""
+    slug = slug or pull.pair_slug(harness, industry)
+    schemas = load_tool_schemas(industry)
+    run_body = _get_with_retry(f"retrieve-simulation-results/{run_id}")
+    run = run_body.get("simulation_run") or {}
+    results = run_body.get("simulation_results") or run_body.get("results") or []
+    sim_id = str(run.get("simulation_id") or sim_hint or "")
+    dh_by_id = _digital_humans_by_sim(sim_id) if sim_id else {}
+
+    state_skip_note = None
+    pulled: dict[str, Any] | None = None
+    if actuals_dir is None:
+        if os.environ.get("MIVAS_SNAPSHOT_BUCKET", "").strip():
+            dest = ROOT / "actual-final-state"
+            try:
+                pulled = _pull_actuals(str(run_id), slug, dest)
+                actuals_dir = dest / slug / str(pulled.get("run_id") or run_id)
+            except SystemExit as e:
+                state_skip_note = f"S3 pull failed: {e}"
+        else:
+            state_skip_note = "MIVAS_SNAPSHOT_BUCKET not set; state compare skipped"
+    actual_by_result = _actual_by_result(actuals_dir)
+
+    rows: list[dict[str, Any]] = []
+    for summary in results:
+        result_id = str(summary.get("id") or "")
+        if not result_id:
+            continue
+        detail = _fetch_result(result_id)
+        classified = verify_run.classify_detail(detail, result_id)
+        dh = detail.get("digital_human") or dh_by_id.get(str(detail.get("digital_human_id"))) or {}
+        case_key = case_key_from_dh(dh)
+        task = load_task(industry, case_key) if case_key else None
+
+        actual_state = None
+        note = state_skip_note
+        dump = actual_by_result.get(result_id)
+        if dump and dump.get("path"):
+            actual_state = json.loads(Path(dump["path"]).read_text())
+            note = None
+        elif dump is None and actuals_dir is not None and state_skip_note is None:
+            note = "no hangup dump for this result"
+
+        check = verify_result(
+            detail, task, actual_state, state_note=note, schemas=schemas,
+            industry=industry,
+        )
+        if classified.get("pending"):
+            mark = "wait"
+        elif classified.get("void_reason"):
+            mark = "VOID"
+        elif not task:
+            mark = "MISS"
+        elif check["passed"]:
+            mark = "pass"
+        else:
+            mark = "FAIL"
+
+        lines = result_transcript_lines(detail)
+        row = {
+            "result_id": result_id,
+            "case_key": case_key,
+            "digital_human_id": detail.get("digital_human_id"),
+            "status": classified.get("status") or detail.get("status"),
+            "pending": classified.get("pending"),
+            "void_reason": classified.get("void_reason"),
+            "mark": mark,
+            "detail": detail,
+            "task": task,
+            "digital_human": dh,
+            "transcript_lines": lines,
+            "actual_state": actual_state,
+            "actual_tool_calls": actual_tool_calls(detail),
+            **check,
+        }
+        rows.append(row)
+
+    return {
+        "run_id": str(run_id),
+        "industry": industry,
+        "run": run,
+        "simulation_id": sim_id,
+        "results": rows,
+        "actuals_dir": str(actuals_dir) if actuals_dir else None,
+        "state_skip_note": state_skip_note,
+    }
+
+
 def main(argv: list[str] | None = None) -> int:
     load_dotenv()
     parser = argparse.ArgumentParser(description=__doc__)
@@ -925,93 +1040,36 @@ def main(argv: list[str] | None = None) -> int:
     if not run_id:
         parser.error("give a run id or --sim")
 
-    slug = args.slug or pull.pair_slug(args.harness, args.industry)
-    schemas = load_tool_schemas(args.industry)
-    run_body = verify_run._get(f"retrieve-simulation-results/{run_id}")
-    run = run_body.get("simulation_run") or {}
-    results = run_body.get("simulation_results") or run_body.get("results") or []
-    sim_id = str(run.get("simulation_id") or args.sim or "")
-    dh_by_id = _digital_humans_by_sim(sim_id) if sim_id else {}
-
-    actuals_dir = args.actuals_dir
-    state_skip_note = None
-    pulled: dict[str, Any] | None = None
-    if actuals_dir is None:
-        if os.environ.get("MIVAS_SNAPSHOT_BUCKET", "").strip():
-            dest = ROOT / "actual-final-state"
-            try:
-                pulled = _pull_actuals(str(run_id), slug, dest)
-                actuals_dir = dest / slug / str(pulled.get("run_id") or run_id)
-            except SystemExit as e:
-                state_skip_note = f"S3 pull failed: {e}"
-        else:
-            state_skip_note = "MIVAS_SNAPSHOT_BUCKET not set; state compare skipped"
-    actual_by_result = _actual_by_result(actuals_dir)
-
-    rows: list[dict[str, Any]] = []
-    for summary in results:
-        result_id = str(summary.get("id") or "")
-        if not result_id:
-            continue
-        classified = verify_run.classify(result_id)
-        detail = _fetch_result(result_id)
-        dh = detail.get("digital_human") or dh_by_id.get(str(detail.get("digital_human_id"))) or {}
-        case_key = case_key_from_dh(dh)
-        task = load_task(args.industry, case_key) if case_key else None
-
-        actual_state = None
-        note = state_skip_note
-        dump = actual_by_result.get(result_id)
-        if dump and dump.get("path"):
-            actual_state = json.loads(Path(dump["path"]).read_text())
-            note = None
-        elif dump is None and actuals_dir is not None and state_skip_note is None:
-            note = "no hangup dump for this result"
-
-        check = verify_result(
-            detail, task, actual_state, state_note=note, schemas=schemas,
-            industry=args.industry,
-        )
-        if classified.get("pending"):
-            mark = "wait"
-        elif classified.get("void_reason"):
-            mark = "VOID"
-        elif not task:
-            mark = "MISS"
-        elif check["passed"]:
-            mark = "pass"
-        else:
-            mark = "FAIL"
-
-        row = {
-            "result_id": result_id,
-            "case_key": case_key,
-            "digital_human_id": detail.get("digital_human_id"),
-            "status": classified.get("status"),
-            "pending": classified.get("pending"),
-            "void_reason": classified.get("void_reason"),
-            "mark": mark,
-            **check,
-        }
-        rows.append(row)
-
+    scored = collect_scored_results(
+        str(run_id),
+        args.industry,
+        actuals_dir=args.actuals_dir,
+        harness=args.harness,
+        slug=args.slug,
+        sim_hint=args.sim,
+    )
+    rows = scored["results"]
+    for row in rows:
         extra = ""
         if row["void_reason"]:
             extra = f"  ↳ {row['void_reason']}"
-        elif not task:
+        elif not row.get("task"):
             extra = "  ↳ no task.json for this digital human"
-        elif not check["call"]["passed"]:
-            extra = f"  ↳ missing tools: {check['call']['missing']}"
-        elif not check["handoff"]["passed"]:
+        elif not row["call"]["passed"]:
+            extra = f"  ↳ missing tools: {row['call']['missing']}"
+        elif not row["handoff"]["passed"]:
             extra = (
-                f"  ↳ handoff {check['handoff']['verdict']}: "
-                f"want {check['handoff']['expected']} got {check['handoff']['actual']}"
+                f"  ↳ handoff {row['handoff']['verdict']}: "
+                f"want {row['handoff']['expected']} got {row['handoff']['actual']}"
             )
-        elif check["state"].get("skipped"):
-            extra = f"  ↳ state skipped: {check['state'].get('note')}"
-        elif check["state"].get("passed") is False:
+        elif row["state"].get("skipped"):
+            extra = f"  ↳ state skipped: {row['state'].get('note')}"
+        elif row["state"].get("passed") is False:
             extra = "  ↳ exp_db_state mismatch"
-        print(f"{mark:<5} {result_id} {case_key or '?':<12} {classified.get('status') or ''}")
+        print(
+            f"{row['mark']:<5} {row['result_id']} "
+            f"{row.get('case_key') or '?':<12} {row.get('status') or ''}"
+        )
         if extra:
             print(extra)
 
@@ -1026,7 +1084,11 @@ def main(argv: list[str] | None = None) -> int:
         f"{len(skipped_state)} state-skipped"
     )
     if args.json:
-        json.dump({"run_id": run_id, "industry": args.industry, "results": rows}, sys.stdout, indent=2)
+        slim = []
+        skip = {"detail", "task", "digital_human", "transcript_lines", "actual_state", "actual_tool_calls"}
+        for row in rows:
+            slim.append({k: v for k, v in row.items() if k not in skip})
+        json.dump({"run_id": run_id, "industry": args.industry, "results": slim}, sys.stdout, indent=2)
         sys.stdout.write("\n")
 
     if pending:

--- a/tests/test_bluejay_run_to_csv.py
+++ b/tests/test_bluejay_run_to_csv.py
@@ -1,0 +1,337 @@
+"""CSV export of one simulation result / conversation — no live Bluejay, no goal-eval columns."""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import io
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+_SPEC = importlib.util.spec_from_file_location(
+    "bluejay_run_to_csv", ROOT / "scripts" / "bluejay_run_to_csv.py"
+)
+assert _SPEC is not None and _SPEC.loader is not None
+exp = importlib.util.module_from_spec(_SPEC)
+sys.modules["bluejay_run_to_csv"] = exp
+_SPEC.loader.exec_module(exp)
+
+
+def _scored_result() -> dict:
+    return {
+        "result_id": "778677",
+        "case_key": "C1-E1",
+        "digital_human_id": 537891,
+        "status": "COMPLETED",
+        "pending": False,
+        "void_reason": None,
+        "mark": "FAIL",
+        "conversation_index": 1,
+        "state": {"passed": True, "skipped": False, "note": None},
+        "call": {
+            "passed": False,
+            "score": 0.5,
+            "missing": ["transfer_to_coverage"],
+            "hit": ["check_plan_accepted"],
+        },
+        "handoff": {
+            "passed": False,
+            "verdict": "incomplete",
+            "score": 0.0,
+            "expected": ["transfer_to_coverage"],
+            "actual": [],
+        },
+        "actual_tools": ["check_plan_accepted", "end_call"],
+        "actual_tool_calls": [
+            {
+                "name": "check_plan_accepted",
+                "parameters": {"carrier": "Aetna", "start": "T09:00:00"},
+                "start_offset_ms": 4120,
+            },
+            {"name": "end_call", "parameters": {}},
+        ],
+        "passed": False,
+        "agent_chars": 179,
+        "task": {
+            "task_name": "C1-E1: Aetna coverage at Park Avenue",
+            "exp_tool_calls": [
+                {"name": "check_plan_accepted", "parameters": {"carrier": "Aetna"}},
+                {"name": "transfer_to_coverage"},
+            ],
+            "exp_handoff_path": ["transfer_to_coverage"],
+            "metadata": {
+                "category": "C1",
+                "difficulty": "easy",
+                "audio_condition": "perfect",
+            },
+            "exp_db_state": {
+                "patients": [],
+                "appointments": [{"id": 1, "start": "2026-08-20T09:00"}],
+                "waitlist": [],
+            },
+        },
+        "actual_state": {
+            "patients": [],
+            "appointments": [{"id": 1, "start": "2026-08-20T09:00:00"}],
+            "waitlist": [],
+        },
+        "digital_human": {
+            "name": "C1-E1",
+            "test_name": "C1-E1: Aetna coverage at Park Avenue",
+        },
+        "detail": {
+            "id": 778677,
+            "duration": 32,
+            "start_time": "2026-08-20T03:10:42.452000Z",
+            "end_time": "2026-08-20T03:11:15.337000Z",
+            "transcript_url": "https://example.test/transcript.json",
+            "recording_url": "https://example.test/call.wav",
+            "metrics": [
+                {"name": "num_turns", "value": 5},
+                {"name": "avg_agent_latency", "value": 410},
+                {"name": "agent_interruption_count", "value": 1},
+            ],
+            "custom_metrics": [
+                {
+                    "name": "Prompt adherence (1-5)",
+                    "response_type": "quantitative",
+                    "response_value": "1",
+                    "reasoning": "drifted from the Park Avenue script",
+                },
+                {
+                    "name": "Task completion (1-5)",
+                    "response_type": "quantitative",
+                    "response_value": "5",
+                    "reasoning": "answered the office-level coverage question",
+                },
+                {
+                    "name": "Premature call end",
+                    "response_type": "yes_no",
+                    "response_value": "no",
+                    "reasoning": "caller ended after the answer",
+                },
+            ],
+            "evaluations": [
+                {
+                    "goal_success": False,
+                    "goal_reasoning": "must never appear in the csv",
+                    "num_turns": 5,
+                    "sentiment_label": "neutral",
+                    "sentiment_score": 0.1,
+                }
+            ],
+        },
+    }
+
+
+def _row(scored: dict | None = None, **kwargs):
+    defaults = {
+        "run_id": "242261",
+        "simulation_id": "30975",
+        "agent_id": "34182",
+        "industry": "healthcare",
+        "transcript_lines": ["AGENT: Park Avenue accepts Aetna.", "USER: That's all."],
+    }
+    defaults.update(kwargs)
+    return exp.result_row(scored or _scored_result(), **defaults)
+
+
+def test_result_row_header_and_cells() -> None:
+    row = _row()
+    text = exp.rows_to_csv([row])
+    parsed = list(csv.DictReader(io.StringIO(text)))
+    assert list(csv.reader(io.StringIO(text)))[0] == exp.HEADERS
+    assert len(parsed) == 1
+    got = parsed[0]
+    assert got["run_id"] == "242261"
+    assert got["simulation_id"] == "30975"
+    assert got["agent_id"] == "34182"
+    assert got["result_id"] == "778677"
+    assert got["digital_human_id"] == "537891"
+    assert got["industry"] == "healthcare"
+    assert got["case_key"] == "C1-E1"
+    assert got["task_path"] == "industries/healthcare/tasks/C1-E1/task.json"
+    assert got["task_dir"] == "industries/healthcare/tasks/C1-E1"
+    assert got["dh_name"] == "C1-E1"
+    assert got["category"] == "C1"
+    assert got["difficulty"] == "easy"
+    assert got["audio_condition"] == "perfect"
+    assert got["conversation_index"] == "1"
+    assert got["mark"] == "FAIL"
+    assert got["pending"] == "false"
+    assert got["combined_pass"] == "false"
+    assert got["tools_pass"] == "false"
+    assert got["handoff_pass"] == "false"
+    assert got["hangup_db_pass"] == "true"
+    assert got["tools_score"] == "0.5"
+    assert got["handoff_verdict"] == "incomplete"
+    assert got["handoff_score"] == "0.0"
+    assert got["missing_tools"] == "transfer_to_coverage"
+    assert got["hit_tools"] == "check_plan_accepted"
+    assert got["extra_tools"] == "end_call"
+    assert got["actual_tools"] == "check_plan_accepted;end_call"
+    assert got["expected_tools"] == "check_plan_accepted;transfer_to_coverage"
+    assert got["prompt_adherence"] == "1"
+    assert got["task_completion"] == "5"
+    assert got["premature_end"] == "false"
+    assert got["prompt_adherence_reasoning"] == "drifted from the Park Avenue script"
+    assert got["task_completion_reasoning"] == "answered the office-level coverage question"
+    assert got["premature_end_reasoning"] == "caller ended after the answer"
+    assert got["duration_s"] == "32"
+    assert got["num_turns"] == "5"
+    assert got["builtin_num_turns"] == "5"
+    assert got["builtin_avg_agent_latency"] == "410"
+    assert got["builtin_agent_interruption_count"] == "1"
+    assert got["eval_sentiment_label"] == "neutral"
+    assert got["recording_url"] == "https://example.test/call.wav"
+    assert "Park Avenue accepts Aetna." in got["transcript"]
+    assert "That's all." in got["transcript"]
+
+
+def test_tool_call_json_keeps_args() -> None:
+    row = _row()
+    expected = json.loads(row["expected_tool_calls_json"])
+    actual = json.loads(row["actual_tool_calls_json"])
+    assert expected[0]["name"] == "check_plan_accepted"
+    assert expected[0]["parameters"]["carrier"] == "Aetna"
+    assert actual[0]["parameters"]["start"] == "T09:00:00"
+    assert actual[0]["start_offset_ms"] == 4120
+    parsed = list(csv.DictReader(io.StringIO(exp.rows_to_csv([row]))))[0]
+    assert json.loads(parsed["expected_tool_calls_json"]) == expected
+    assert json.loads(parsed["actual_tool_calls_json"]) == actual
+
+
+def test_hangup_expected_actual_round_trip() -> None:
+    scored = _scored_result()
+    row = _row(scored)
+    expected = json.loads(row["hangup_expected_json"])
+    actual = json.loads(row["hangup_actual_json"])
+    assert expected["appointments"][0]["start"] == "2026-08-20T09:00"
+    assert actual["appointments"][0]["start"] == "2026-08-20T09:00:00"
+    assert row["hangup_diff"] == ""
+    assert row["hangup_note"] == ""
+    parsed = list(csv.DictReader(io.StringIO(exp.rows_to_csv([row]))))[0]
+    assert json.loads(parsed["hangup_expected_json"]) == expected
+    assert json.loads(parsed["hangup_actual_json"]) == actual
+
+    scored["actual_state"] = {
+        "patients": [],
+        "appointments": [{"id": 1, "start": "2026-08-20T10:00:00"}],
+        "waitlist": [],
+    }
+    scored["state"] = {"passed": False, "skipped": False, "note": None}
+    failed = _row(scored)
+    diff = json.loads(failed["hangup_diff"])
+    assert "appointments" in diff
+    assert diff["appointments"]["expected_count"] == 1
+    assert diff["appointments"]["actual_count"] == 1
+
+
+def test_hangup_note_when_skipped() -> None:
+    scored = _scored_result()
+    scored["actual_state"] = None
+    scored["state"] = {"passed": None, "skipped": True, "note": "no hangup dump to compare"}
+    row = _row(scored)
+    assert row["hangup_db_pass"] == ""
+    assert row["hangup_actual_json"] == ""
+    assert row["hangup_diff"] == ""
+    assert row["hangup_note"] == "no hangup dump to compare"
+
+
+def test_excluded_goal_eval_columns_absent() -> None:
+    row = _row()
+    text = exp.rows_to_csv([row])
+    header = list(csv.reader(io.StringIO(text)))[0]
+    for name in exp.EXCLUDED_COLUMNS:
+        assert name not in header
+        assert name not in row
+    assert "goal_success" not in text
+    assert "goal_reasoning" not in text
+    assert "tests_passed" not in text
+    assert "must never appear in the csv" not in text
+
+
+def test_extra_custom_metric_value_and_reasoning() -> None:
+    scored = _scored_result()
+    scored["detail"]["custom_metrics"].append({
+        "name": "Politeness",
+        "response_type": "quantitative",
+        "response_value": "4",
+        "reasoning": "warm close",
+    })
+    scored["detail"]["custom_metrics"].append({
+        "name": "Goal success",
+        "response_type": "yes_no",
+        "response_value": "no",
+        "reasoning": "must never appear in the csv",
+    })
+    row = _row(scored)
+    text = exp.rows_to_csv([row])
+    header = list(csv.reader(io.StringIO(text)))[0]
+    assert "politeness" in header
+    assert "politeness_reasoning" in header
+    assert row["politeness"] == "4"
+    assert row["politeness_reasoning"] == "warm close"
+    assert "goal_success" not in header
+    assert "goal_success_reasoning" not in header
+    assert "must never appear in the csv" not in text
+
+
+def test_transcript_newlines_round_trip() -> None:
+    scored = _scored_result()
+    row = _row(
+        scored,
+        run_id="1",
+        simulation_id="2",
+        agent_id="3",
+        transcript_lines=["AGENT: line one", "USER: line two"],
+    )
+    assert "\n" in row["transcript"]
+    parsed = list(csv.DictReader(io.StringIO(exp.rows_to_csv([row]))))
+    assert parsed[0]["transcript"] == "AGENT: line one\nUSER: line two"
+
+
+def test_void_result_leaves_combined_pass_empty() -> None:
+    scored = _scored_result()
+    scored["void_reason"] = "no conversation (NO_ANSWER)"
+    scored["status"] = "NO_ANSWER"
+    scored["mark"] = "VOID"
+    row = _row(scored, run_id="1", simulation_id="2", agent_id="3", transcript_lines=[])
+    assert row["combined_pass"] == ""
+    assert row["void_reason"] == "no conversation (NO_ANSWER)"
+    assert row["mark"] == "VOID"
+
+
+def test_stashed_transcript_lines_skip_refetch() -> None:
+    scored = _scored_result()
+    scored["transcript_lines"] = ["AGENT: stashed once"]
+    scored["detail"]["transcript_url"] = "https://example.test/would-refetch.json"
+
+    def boom(_result):
+        raise AssertionError("should not refetch transcript_url")
+
+    original = exp.verify_task_run.result_transcript_lines
+    exp.verify_task_run.result_transcript_lines = boom
+    try:
+        row = exp.result_row(
+            scored,
+            run_id="1",
+            simulation_id="2",
+            agent_id="3",
+            industry="healthcare",
+        )
+    finally:
+        exp.verify_task_run.result_transcript_lines = original
+    assert row["transcript"] == "AGENT: stashed once"
+
+
+def test_assign_conversation_indexes_are_one_based_per_case() -> None:
+    rows = [
+        {"digital_human_id": 1, "case_key": "C1-E1"},
+        {"digital_human_id": 1, "case_key": "C1-E1"},
+        {"digital_human_id": 2, "case_key": "C1-E1-BG"},
+    ]
+    exp.assign_conversation_indexes(rows)
+    assert [row["conversation_index"] for row in rows] == [1, 2, 1]

--- a/voice-agent-harnesses/qwen/harness.py
+++ b/voice-agent-harnesses/qwen/harness.py
@@ -3,7 +3,9 @@
 Qwen-Audio Realtime (DashScope / Model Studio) is a raw WebSocket, not the
 OpenAI Agents SDK. Industry tools POST to `{TOOL_SERVER_URL}/tools/{name}`.
 Handoff tools (`handoff: true`) soft-switch the active blueprint agent on the
-same socket via `session.update`. Session tools (`session: true`) hang up.
+same socket via `session.update`. `end_call` is harness-local; other session
+tools (`escalate_to_human`, `transfer_to_human`) POST so the industry records
+the row, then the socket closes.
 
 Docs: https://help.aliyun.com/en/model-studio/qwen-audio-realtime-user-guides
 """
@@ -312,7 +314,7 @@ async def _execute_tool(
         state["agent"] = target
         return {"success": True, "role": target}, False
 
-    if name == "end_call" or is_session_tool(bp, state["agent"], name):
+    if name == "end_call":
         return {"success": True}, True
 
     async with httpx.AsyncClient(timeout=30.0) as client:
@@ -322,7 +324,9 @@ async def _execute_tool(
             headers=tool_headers(),
         )
         result = resp.json()
-        if name == "transfer_to_human":
+        # Human-transfer session tools POST (so hangup GET /state has the row)
+        # then hang up — there is no human to join.
+        if is_session_tool(bp, state["agent"], name):
             return result, True
         return result, False
 


### PR DESCRIPTION
## Summary
- Add a Bluejay run CSV exporter (`scripts/bluejay_run_to_csv.py`) plus monitor/verify helpers so local eval dumps stay on disk without being committed.
- Apply qwen harness fixes from the customer-support 72-DH suite branch.

## Test plan
- [ ] `python -m pytest tests/test_bluejay_run_to_csv.py`
- [ ] Confirm repo-root healthcare CSVs and `.mivas-monitor` remain gitignored
- [ ] Smoke the qwen harness against the control industry if a live run is available


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Exports Bluejay runs to a conversation-per-row CSV and adds a k=5 progress-monitor refresher, plus a Qwen harness fix so session tools POST before hangup. This makes local evals portable for dashboards and ensures human-transfer events are recorded, while keeping large artifacts out of Git.

- CSV exporter (`scripts/bluejay_run_to_csv.py`): stable headers; includes tool/handoff/hangup DB evals, custom metrics, builtin metrics, and transcript; excludes Bluejay goal-eval columns. Accepts a run id or `--sim` and writes a UTF‑8 CSV. Tests cover header shape, JSON round‑trip, and exclusions.
- Shared scoring (`scripts/verify_task_run.py`): new `collect_scored_results()` used by both CLI and CSV; GETs retry on 401/429/5xx; `--json` output no longer includes heavyweight fields (`detail`, `task`, `digital_human`, `transcript_lines`, `actual_state`, `actual_tool_calls`).
- Qwen harness (`voice-agent-harnesses/qwen/harness.py`): previously session tools hung up immediately; now they POST to the tool server so the industry records the row, then the socket closes. `end_call` still hangs up immediately.
- Monitor refresher (`scripts/refresh_k5_monitor.py`): reads `.mivas-monitor/*.json`, rewrites the marked snapshot block in the healthcare k=5 canvas, and writes the `.canvas.data.json` sidecar. Use `--canvas` for your local path or `--print-only` to check progress.
- Git hygiene: `.gitignore` now ignores `/eval_outputs/`, `/.mivas-monitor/`, and `/healthcare-*.csv` so local exports and monitor snapshots are not committed.

<sup>Written for commit 23a37a9327d57c45047356d0d9a6ba3b8c893938. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/44?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

