### PR TITLE
docs: clarify benchmark pull request expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,8 @@ Contributions may add harnesses, industries, policy cases, deterministic checks,
 
 New harnesses should first pass the control industry. New industry cases should state the initial fixture, caller goal, required conduct, prohibited conduct, expected tools, expected final state, and the evidence used for scoring.
 
+Keep pull requests narrow and name the affected harness, industry, and verifier behavior. Changes to a task, tool schema, prompt, seed data, or verification rule should include the corresponding deterministic check or explain why no check applies.
+
 ## Citation
 
 If you use MIVAS Bench in published work, cite the repository and the benchmark release used for the evaluation.


### PR DESCRIPTION
## Summary
- clarify what a focused MIVAS benchmark pull request should identify
- ask scoring-contract changes to include a deterministic check or state why one is not applicable

## Validation
- `git diff --check`

Authored by `chatgpt-codex-connector[bot]`; opened from a separate branch and targets `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies MIVAS benchmark contribution guidelines by requiring pull requests to stay narrow and name the affected harness, industry, and verifier behavior. Also asks that changes to task, tool schema, prompt, seed data, or verification rules include the corresponding deterministic check or explain why none applies.

<sup>Written for commit ed436cf81e2109e456b510f51b78cd2b242f8a3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/47?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

