### PR TITLE
Inject pack TODAY into every harness session

### DIFF
--- a/runtime/pack_clock.py
+++ b/runtime/pack_clock.py
@@ -1,0 +1,107 @@
+"""Industry pack calendar for harness instruction injection.
+
+Industry tool servers pin TODAY so slots, cancel windows, and deadlines stay
+deterministic. Harnesses must tell the model that date. Using the wall clock
+makes August pack slots look expired once the real calendar moves on.
+
+Resolution order:
+1. MIVAS_TODAY=wall — use date.today()
+2. MIVAS_TODAY=YYYY-MM-DD — use that date
+3. TODAY = "..." in the industry tool_server.py (date part only)
+4. date.today() if the pack has no pin (control-industry)
+
+Do not import industry tool_server modules — they start FastAPI.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import date
+from pathlib import Path
+
+_TODAY_RE = re.compile(r'^TODAY\s*=\s*["\']([^"\']+)["\']', re.MULTILINE)
+
+
+def _repo_roots() -> list[Path]:
+    roots: list[Path] = []
+    if Path("/app/industries").is_dir():
+        roots.append(Path("/app"))
+    here = Path(__file__).resolve().parents[1]
+    if (here / "industries").is_dir():
+        roots.append(here)
+    return roots
+
+
+def resolve_industry_dir(industry_dir: str | Path | None = None) -> Path | None:
+    """Resolve a pack directory from a path, industry name, or env."""
+    if industry_dir is not None:
+        path = Path(industry_dir)
+        if path.is_dir():
+            return path.resolve()
+        for root in _repo_roots():
+            candidate = root / "industries" / str(industry_dir)
+            if candidate.is_dir():
+                return candidate.resolve()
+    env_dir = os.environ.get("INDUSTRY_DIR", "").strip()
+    if env_dir and Path(env_dir).is_dir():
+        return Path(env_dir).resolve()
+    name = os.environ.get("INDUSTRY", "").strip()
+    if name:
+        for root in _repo_roots():
+            candidate = root / "industries" / name
+            if candidate.is_dir():
+                return candidate.resolve()
+    return None
+
+
+def read_pack_today(industry_dir: str | Path | None) -> date | None:
+    """Parse TODAY from tool_server.py. Healthcare pins a datetime; use the date."""
+    resolved = resolve_industry_dir(industry_dir)
+    if resolved is None:
+        return None
+    path = resolved / "tool_server.py"
+    if not path.is_file():
+        return None
+    match = _TODAY_RE.search(path.read_text())
+    if match is None:
+        return None
+    raw = match.group(1).split("T", 1)[0]
+    return date.fromisoformat(raw)
+
+
+def _wall_today() -> date:
+    return date.today()
+
+
+def pack_today(industry_dir: str | Path | None = None) -> date:
+    """The date the model should treat as today for this pack."""
+    override = os.environ.get("MIVAS_TODAY", "").strip()
+    if override == "wall":
+        return _wall_today()
+    if override:
+        return date.fromisoformat(override.split("T", 1)[0])
+    pinned = read_pack_today(industry_dir)
+    return pinned if pinned is not None else _wall_today()
+
+
+def today_clock_line(
+    industry_dir: str | Path | None = None,
+    *,
+    today: date | None = None,
+) -> str:
+    d = today if today is not None else pack_today(industry_dir)
+    return f"Today is {d.strftime('%A')}, {d.strftime('%B')} {d.day}, {d.year}."
+
+
+def with_pack_clock(
+    instructions: str,
+    industry_dir: str | Path | None = None,
+    *,
+    today: date | None = None,
+) -> str:
+    line = today_clock_line(industry_dir, today=today)
+    text = (instructions or "").rstrip()
+    if line in text:
+        return text
+    return f"{text}\n\n{line}"

--- a/tests/test_pack_clock.py
+++ b/tests/test_pack_clock.py
@@ -1,0 +1,58 @@
+"""pack_clock helper in isolation — no harness imported."""
+
+from __future__ import annotations
+
+import sys
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNTIME = ROOT / "runtime"
+if str(RUNTIME) not in sys.path:
+    sys.path.insert(0, str(RUNTIME))
+
+from pack_clock import (  # noqa: E402
+    pack_today,
+    read_pack_today,
+    today_clock_line,
+    with_pack_clock,
+)
+
+
+def test_reads_legal_and_healthcare_pins() -> None:
+    assert read_pack_today("legal") == date(2026, 8, 1)
+    assert read_pack_today("customer-support") == date(2026, 8, 1)
+    assert read_pack_today("healthcare") == date(2026, 8, 19)
+    assert read_pack_today("control-industry") is None
+
+
+def test_pack_today_uses_pin_not_wall(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MIVAS_TODAY", raising=False)
+    assert pack_today("legal") == date(2026, 8, 1)
+    assert "August 1, 2026" in today_clock_line("legal")
+    assert today_clock_line("legal").startswith("Today is Saturday")
+    assert "August 19, 2026" in today_clock_line("healthcare")
+    assert today_clock_line("healthcare").startswith("Today is Wednesday")
+
+
+def test_control_industry_falls_back_to_wall(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MIVAS_TODAY", raising=False)
+    monkeypatch.setattr("pack_clock._wall_today", lambda: date(2026, 9, 3))
+    assert pack_today("control-industry") == date(2026, 9, 3)
+
+
+def test_mivas_today_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MIVAS_TODAY", "2026-07-15")
+    assert pack_today("legal") == date(2026, 7, 15)
+    monkeypatch.setenv("MIVAS_TODAY", "wall")
+    monkeypatch.setattr("pack_clock._wall_today", lambda: date(2026, 9, 3))
+    assert pack_today("legal") == date(2026, 9, 3)
+
+
+def test_with_pack_clock_appends_once() -> None:
+    line = today_clock_line("legal")
+    first = with_pack_clock("Be helpful.", "legal")
+    assert first.endswith(line)
+    assert with_pack_clock(first, "legal") == first

--- a/voice-agent-harnesses/aws/README.md
+++ b/voice-agent-harnesses/aws/README.md
@@ -14,7 +14,7 @@ Shared builder: `harness.py`. Tracing: `report.py` (`BLUEJAY_SERVICE_NAME=mivas-
 - Speak-first: open USER audio stream, feed silent PCM keepalive, then interactive USER text (pack owns greeting text)
 - Audio: Nova PCM 16 kHz in / 24 kHz out ↔ CHIRP 16 kHz `pcm_s16le`
 - Barge-in: provider interrupted event (never mute on CHIRP VAD alone)
-- Clock: `Today is …` injected into every session instructions
+- Clock: pack `TODAY` (not the wall clock) injected as `Today is …` on every session
 - Tracing → LangSmith-shaped Bluejay OTel `realtime_session → turn → {user_message, model, execute_tool}`; the `model` span carries Nova's `usageEvent` token breakdown (speech/text, per-turn delta) + time-to-first-token. Chirp stamps `X-Simulation-Result-Id`
 - Concurrency: the CHIRP parent accepts TCP and starts one Python process per call. Amazon's Bedrock streaming library shares state across a whole process, so two calls in one interpreter cancel each other. One container still takes many calls; CPU and memory bound the count.
 

--- a/voice-agent-harnesses/aws/harness.py
+++ b/voice-agent-harnesses/aws/harness.py
@@ -37,6 +37,7 @@ for _root in (Path("/app"), *Path(__file__).resolve().parents):
             sys.path.insert(0, str(_runtime))
         break
 from call_id import headers as tool_headers, log_ws_accept, set_call_id  # noqa: E402
+from pack_clock import today_clock_line, with_pack_clock  # noqa: E402
 
 _BOOKING_CONFIRM_RE = re.compile(
     r"(?:booking\s+confirmed|appointment\s+(?:is\s+)?scheduled|"
@@ -162,17 +163,18 @@ def handoff_role(result: dict[str, Any], bp: dict[str, Any]) -> str | None:
     return role if isinstance(role, str) and role in bp["agents"] else None
 
 
-def today_context_line(today: _dt.date | None = None) -> str:
-    d = today or _dt.date.today()
-    return f"Today is {d.strftime('%A')}, {d.strftime('%B')} {d.day}, {d.year}."
+def today_context_line(
+    today: _dt.date | None = None, industry_dir: str | Path | None = None
+) -> str:
+    return today_clock_line(industry_dir, today=today)
 
 
-def with_today_context(instructions: str, today: _dt.date | None = None) -> str:
-    line = today_context_line(today)
-    text = (instructions or "").rstrip()
-    if line in text:
-        return text
-    return f"{text}\n\n{line}"
+def with_today_context(
+    instructions: str,
+    today: _dt.date | None = None,
+    industry_dir: str | Path | None = None,
+) -> str:
+    return with_pack_clock(instructions, industry_dir, today=today)
 
 
 def extract_appointment_date(text: str, *, default_year: int | None = None) -> str | None:
@@ -787,7 +789,10 @@ class SonicSession:
 
         tools = tools_for_agent(self.bp, self.agent)
         sys_id = str(uuid.uuid4())
-        instructions = with_today_context(self.bp["agents"][self.agent]["instructions"])
+        instructions = with_today_context(
+            self.bp["agents"][self.agent]["instructions"],
+            industry_dir=self.bp.get("industry_dir"),
+        )
         for payload in (
             session_start_event(),
             prompt_start_event(self.prompt_name, tools, voice=self.voice),
@@ -861,12 +866,12 @@ def demo() -> None:
     start_tools = advertised_tools("control-industry", start)
     assert tool_names(bp, start) == start_tools
     all_names = {n for a in bp["agents"] for n in tool_names(bp, a)}
-    today_line = today_context_line()
+    today_line = today_context_line(industry_dir=bp["industry_dir"])
     for agent in bp["agents"]:
         names = tool_names(bp, agent)
         specs = tools_for_agent(bp, agent)
         pack = bp["agents"][agent]["instructions"]
-        instructions = with_today_context(pack)
+        instructions = with_today_context(pack, industry_dir=bp["industry_dir"])
         assert instructions.startswith(pack.rstrip())
         assert today_line in instructions
         assert [t["toolSpec"]["name"] for t in specs] == names

--- a/voice-agent-harnesses/gemini/2.5-flash-native-audio/agent.py
+++ b/voice-agent-harnesses/gemini/2.5-flash-native-audio/agent.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
         greet_text = harness.greeting(bp)
 
         def make_llm(name: str) -> Any:
-            inst = harness.with_clock(bp["agents"][name]["instructions"])
+            inst = harness.with_clock(bp["agents"][name]["instructions"], bp.get("industry_dir"))
             if name == bp["start"]:
                 inst = harness.speak_first(inst, greet_text)
             return _llm(inst)

--- a/voice-agent-harnesses/gemini/flash-live-3.1/agent.py
+++ b/voice-agent-harnesses/gemini/flash-live-3.1/agent.py
@@ -67,7 +67,7 @@ if __name__ == "__main__":
         greet_text = harness.greeting(bp)
 
         def make_llm(name: str) -> Any:
-            inst = harness.with_clock(bp["agents"][name]["instructions"])
+            inst = harness.with_clock(bp["agents"][name]["instructions"], bp.get("industry_dir"))
             if name == bp["start"]:
                 inst = harness.speak_first(inst, greet_text)
             return _llm(inst)

--- a/voice-agent-harnesses/gemini/harness.py
+++ b/voice-agent-harnesses/gemini/harness.py
@@ -10,7 +10,6 @@ tools only). Gemini Live cannot swap tools on an open socket.
 from __future__ import annotations
 
 import asyncio
-import datetime as _dt
 import json
 import logging
 import os
@@ -39,6 +38,7 @@ for _root in (Path("/app"), *Path(__file__).resolve().parents):
             sys.path.insert(0, str(_runtime))
         break
 from call_id import begin_session, end_session, headers as tool_headers, set_call_id  # noqa: E402
+from pack_clock import with_pack_clock  # noqa: E402
 
 import report  # noqa: E402
 
@@ -127,9 +127,9 @@ def build_agents(industry_dir: str | Path) -> tuple[str, list[str]]:
     return bp["start"], list(bp["agents"])
 
 
-def with_clock(instructions: str) -> str:
-    today = _dt.date.today()
-    return instructions.rstrip() + f"\n\nToday is {today:%A, %B} {today.day}, {today.year}."
+def with_clock(instructions: str, industry_dir: str | Path | None = None) -> str:
+    """Tell the model the pack's TODAY, not the wall clock."""
+    return with_pack_clock(instructions, industry_dir)
 
 
 def greeting(bp: dict[str, Any]) -> str:
@@ -295,7 +295,7 @@ class Stage(Agent):
         chat_ctx: Any = None,
         speak_first_line: str | None = None,
     ):
-        instructions = with_clock(bp["agents"][name]["instructions"])
+        instructions = with_clock(bp["agents"][name]["instructions"], bp.get("industry_dir"))
         if speak_first_line:
             # must live on the Agent, not the RealtimeModel: livekit overrides
             # the model's instructions with the Agent's at activity start

--- a/voice-agent-harnesses/gemini/test_harness.py
+++ b/voice-agent-harnesses/gemini/test_harness.py
@@ -29,6 +29,8 @@ def test_blueprint_and_greeting() -> None:
     assert bp["catalog"]
     health = harness.load_blueprint("healthcare")
     assert "Straus" in harness.greeting(health)
+    clocked = harness.with_clock(health["agents"][health["start"]]["instructions"], health["industry_dir"])
+    assert "August 19, 2026" in clocked
 
 
 def test_agent_name() -> None:

--- a/voice-agent-harnesses/grok/README.md
+++ b/voice-agent-harnesses/grok/README.md
@@ -12,6 +12,7 @@ Shared builder: `harness.py`. Tracing/reporting: `report.py` (`BLUEJAY_SERVICE_N
 - Session tools (`session: true`, e.g. `end_call`) → harness-local + close
 - Handoffs → soft `session.update` on the same WebSocket (history stays)
 - Speak-first: bare `response.create` after `session.updated` (pack owns greeting text)
+- Clock: pack `TODAY` (not the wall clock) injected as `Today is …` on every session
 - Audio: Grok PCM 24 kHz ↔ CHIRP 16 kHz `pcm_s16le` + `speech.started` / `speech.completed`
 - Tracing → Bluejay OTel `voice.call` (`agent.speech` / `customer.speech` / `execute_tool`); Chirp stamps `X-Simulation-Result-Id` and POSTs `{trace_ids}`
 

--- a/voice-agent-harnesses/grok/harness.py
+++ b/voice-agent-harnesses/grok/harness.py
@@ -30,6 +30,7 @@ for _root in (Path("/app"), *Path(__file__).resolve().parents):
             sys.path.insert(0, str(_runtime))
         break
 from call_id import call_session, headers as tool_headers, set_call_id  # noqa: E402
+from pack_clock import today_clock_line, with_pack_clock  # noqa: E402
 
 # Verbal booking confirm without a function-call event (same failure mode as
 # hosted VoiceChat). Recover schedule_appointment for tool-server + OTel.
@@ -198,18 +199,19 @@ def _tool_decl(spec: dict) -> dict[str, Any]:
     }
 
 
-def today_context_line(today: _dt.date | None = None) -> str:
+def today_context_line(
+    today: _dt.date | None = None, industry_dir: str | Path | None = None
+) -> str:
     """Clock fact for relative dates — Grok Voice has no built-in 'today'."""
-    d = today or _dt.date.today()
-    return f"Today is {d.strftime('%A')}, {d.strftime('%B')} {d.day}, {d.year}."
+    return today_clock_line(industry_dir, today=today)
 
 
-def with_today_context(instructions: str, today: _dt.date | None = None) -> str:
-    line = today_context_line(today)
-    text = (instructions or "").rstrip()
-    if line in text:
-        return text
-    return f"{text}\n\n{line}"
+def with_today_context(
+    instructions: str,
+    today: _dt.date | None = None,
+    industry_dir: str | Path | None = None,
+) -> str:
+    return with_pack_clock(instructions, industry_dir, today=today)
 
 
 def extract_appointment_date(text: str, *, default_year: int | None = None) -> str | None:
@@ -268,7 +270,9 @@ def session_update_for_agent(
     if agent not in bp["agents"]:
         raise KeyError(f"unknown agent {agent!r}")
     tools = [_tool_decl(bp["catalog"][name]) for name in tool_names(bp, agent)]
-    instructions = with_today_context(bp["agents"][agent]["instructions"])
+    instructions = with_today_context(
+        bp["agents"][agent]["instructions"], industry_dir=bp.get("industry_dir")
+    )
     # The reception prompt assumes the branded greeting was already spoken, so a
     # bare response.create opens with "What can I help you with?" — no brand, no
     # AI disclosure. Only the pack's own greeting string fills that in.
@@ -476,7 +480,7 @@ def demo() -> None:
     start_tools = advertised_tools("control-industry", start)
     assert tool_names(bp, start) == start_tools
     all_names = {n for a in bp["agents"] for n in tool_names(bp, a)}
-    today_line = today_context_line()
+    today_line = today_context_line(industry_dir=bp["industry_dir"])
     for agent, names in ((a, tool_names(bp, a)) for a in bp["agents"]):
         update = session_update_for_agent(bp, agent)
         session = update["session"]

--- a/voice-agent-harnesses/livekit/harness.py
+++ b/voice-agent-harnesses/livekit/harness.py
@@ -26,7 +26,6 @@ the new agent's prompt and only the new agent's tools.
 from __future__ import annotations
 
 import asyncio
-import datetime as _dt
 import json
 import logging
 import os
@@ -57,6 +56,7 @@ for _root in (Path("/app"), *Path(__file__).resolve().parents):
             sys.path.insert(0, str(_runtime))
         break
 from call_id import begin_session, end_session, headers as tool_headers, set_call_id  # noqa: E402
+from pack_clock import today_clock_line, with_pack_clock  # noqa: E402
 
 logger = logging.getLogger("mivas.livekit")
 
@@ -157,17 +157,17 @@ def pack_greeting(bp: dict[str, Any] | None = None) -> str:
     return GREETING
 
 
-def today_clock() -> str:
-    d = _dt.date.today()
-    return f"Today is {d.strftime('%A')}, {d.strftime('%B')} {d.day}, {d.year}."
+def today_clock(industry_dir: str | Path | None = None) -> str:
+    return today_clock_line(industry_dir)
 
 
-def with_clock(instructions: str) -> str:
-    """gpt-4.1 (and the S2S models) have no 'today'; relative dates invent years."""
-    clock = today_clock()
-    if clock in instructions:
-        return instructions
-    return f"{instructions.rstrip()}\n\n{clock}"
+def with_clock(instructions: str, industry_dir: str | Path | None = None) -> str:
+    """gpt-4.1 (and the S2S models) have no 'today'; relative dates invent years.
+
+    Use the pack pin, not the wall clock — August slots are still open on
+    TODAY=2026-08-01 even when the real calendar has moved on.
+    """
+    return with_pack_clock(instructions, industry_dir)
 
 
 def resolve_agent_name(default: str) -> str:
@@ -333,7 +333,7 @@ class BlueprintAgent(Agent):
         scripted_opener: bool = False,
         entered_by_handoff: bool = False,
     ):
-        instructions = with_clock(bp["agents"][name]["instructions"])
+        instructions = with_clock(bp["agents"][name]["instructions"], bp.get("industry_dir"))
         llm: NotGivenOr[Any] = llm_factory(name) if llm_factory else NOT_GIVEN
         super().__init__(
             instructions=instructions,

--- a/voice-agent-harnesses/livekit/test_harness.py
+++ b/voice-agent-harnesses/livekit/test_harness.py
@@ -72,7 +72,7 @@ def test_real_handoff() -> None:
     )
     assert _tool_names(receptionist) == {"handoff_to_scheduler", "end_call"}
     assert bp["agents"]["receptionist"]["instructions"] in receptionist.instructions
-    assert harness.today_clock() in receptionist.instructions
+    assert harness.today_clock(bp["industry_dir"]) in receptionist.instructions
 
     handoff = lk_llm.ToolContext(receptionist.tools).get_function_tool("handoff_to_scheduler")
     scheduler = asyncio.run(handoff(raw_arguments={}))
@@ -80,7 +80,7 @@ def test_real_handoff() -> None:
     assert scheduler.agent_name == "scheduler"
     assert _tool_names(scheduler) == {"schedule_appointment", "end_call"}
     assert bp["agents"]["scheduler"]["instructions"] in scheduler.instructions
-    assert harness.today_clock() in scheduler.instructions
+    assert harness.today_clock(bp["industry_dir"]) in scheduler.instructions
     # scripted_opener propagates as a capability flag, but the actual spoken line is
     # derived from the *target's own* prompt, not inherited verbatim from the caller.
     assert scheduler._opener == "Hey, when do you want to schedule your repair appointment?"
@@ -99,6 +99,9 @@ def test_generic_industries() -> None:
         start = BlueprintAgent(bp, bp["start"], hangup)
         expected = {t["name"] for t in bp["agents"][bp["start"]]["tools"]}
         assert _tool_names(start) == expected, (industry, _tool_names(start) ^ expected)
+        clock = harness.today_clock(bp["industry_dir"])
+        assert clock in start.instructions
+        assert "August" in clock and "2026" in clock
 
 
 def test_pack_greeting_and_agent_name() -> None:

--- a/voice-agent-harnesses/nvidia/README.md
+++ b/voice-agent-harnesses/nvidia/README.md
@@ -8,7 +8,7 @@ Two NVIDIA runtimes over industry `agent_blueprint.json` packs, same MIVAS inter
 | `nemotron/` | Cascaded: Nemotron ASR → `nemotron-3-nano-30b-a3b` → Magpie TTS ([voice-agent blueprint](https://github.com/NVIDIA-AI-Blueprints/nemotron-voice-agent)) | Pipecat Flows (hard handoff) |
 | `nemotron-voicechat/` | Full-duplex S2S: [`nvidia/nemotron-voicechat`](https://build.nvidia.com/nvidia/nemotron-voicechat) / [HF 11B](https://huggingface.co/nvidia/NVIDIA-NemotronLabs-VoiceChat-11B) | One WS for the call; handoff = `session.update` (keeps history) |
 
-Shared: `harness.py` (blueprint + industry tools), `report.py` (OTel → Bluejay).
+Shared: `harness.py` (blueprint + industry tools), `report.py` (OTel → Bluejay). Pack `TODAY` (not the wall clock) is injected as `Today is …` on every agent.
 
 ## nemotron (cascaded)
 

--- a/voice-agent-harnesses/nvidia/harness.py
+++ b/voice-agent-harnesses/nvidia/harness.py
@@ -38,6 +38,7 @@ for _root in (Path("/app"), *Path(__file__).resolve().parents):
             sys.path.insert(0, str(_runtime))
         break
 from call_id import begin_session, end_session, headers as tool_headers, set_call_id  # noqa: E402
+from pack_clock import with_pack_clock  # noqa: E402
 
 HARNESS_DIR = Path(__file__).resolve().parent
 REPO_ROOT = HARNESS_DIR.parents[1] if len(HARNESS_DIR.parents) > 1 else HARNESS_DIR
@@ -165,7 +166,7 @@ def agent_order(bp: dict[str, Any]) -> list[str]:
 
 
 def instructions(bp: dict[str, Any], agent: str) -> str:
-    return bp["agents"][agent]["instructions"]
+    return with_pack_clock(bp["agents"][agent]["instructions"], bp.get("industry_dir"))
 
 
 def tool_names(bp: dict[str, Any], agent: str) -> list[str]:

--- a/voice-agent-harnesses/nvidia/voicechat.py
+++ b/voice-agent-harnesses/nvidia/voicechat.py
@@ -36,6 +36,7 @@ from harness import (
     tool_names,
 )
 from nvidia_fc import parse_toolcalls
+from pack_clock import with_pack_clock
 
 RUNTIME = "nemotron-voicechat"
 MODEL = "nvidia/nemotron-voicechat"
@@ -162,9 +163,9 @@ def session_update_for_agent(bp: dict[str, Any], agent: str) -> dict[str, Any]:
     for name in tool_names(bp, agent):
         tools.append(_tool_decl(bp["catalog"][name]))
     pack = _ascii(bp["agents"][agent]["instructions"])
-    instructions = pack
+    instructions = with_pack_clock(pack, bp.get("industry_dir"))
     if tools:
-        instructions = pack + _TOOLS_DECL.format(tools=_available_tools_json(tools))
+        instructions = instructions + _TOOLS_DECL.format(tools=_available_tools_json(tools))
     return {
         "type": "session.update",
         "event_id": _event_id(),

--- a/voice-agent-harnesses/openai/README.md
+++ b/voice-agent-harnesses/openai/README.md
@@ -11,6 +11,7 @@ Shared builder: `harness.py`. Tracing/reporting: `report.py`.
 
 - Industry tools → industry state API (`TOOL_SERVER_URL`)
 - Session tools (`session: true`, e.g. `end_call`) → harness-local + close realtime session
+- Clock: pack `TODAY` (not the wall clock) injected as `Today is …` on every agent
 - Handoffs → Realtime handoffs
 - Tracing → Realtime event proxy (`report.py`) parses session events into a Bluejay OTel `voice.call` tree (user/agent turns, transcripts, tools, handoffs) **plus a `chat <model>` generation span per response** carrying the full `gen_ai.usage.*` token breakdown (input/output, audio, text, cached, reasoning) and time-to-first-token (`mivas.ttft_ms` / `gen_ai.server.time_to_first_token`) — the same telemetry LangSmith/Langfuse pull, exported to Bluejay's own OTLP (no external backend). Chirp stamps `X-Simulation-Result-Id` and POSTs `{trace_ids}`. Optional Realtime API server-side traces still go to the OpenAI dashboard.
 

--- a/voice-agent-harnesses/openai/harness.py
+++ b/voice-agent-harnesses/openai/harness.py
@@ -39,6 +39,7 @@ for _root in (Path("/app"), *Path(__file__).resolve().parents):
             sys.path.insert(0, str(_runtime))
         break
 from call_id import headers as tool_headers, log_ws_accept, set_call_id  # noqa: E402
+from pack_clock import today_clock_line, with_pack_clock  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TOOL_SERVER_URL = os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
@@ -169,7 +170,9 @@ def build_agents(industry_dir: str | Path) -> tuple[RealtimeAgent, dict[str, Rea
 
     agents: dict[str, RealtimeAgent] = {}
     for entry in blueprint["agents"]:
-        instructions = (industry_dir / entry["system_prompt"]).read_text()
+        instructions = with_pack_clock(
+            (industry_dir / entry["system_prompt"]).read_text(), industry_dir
+        )
         if greeting and entry["name"] == start_name:
             instructions = (
                 instructions.rstrip()
@@ -317,6 +320,12 @@ if __name__ == "__main__":
         assert all(
             line not in a.instructions for n, a in hc_agents.items() if n != hc_start.name
         ), "greeting leaked into a downstream stage"
+        clock = today_clock_line("healthcare")
+        assert clock in hc_start.instructions, "starting agent lost the pack clock"
+        assert all(clock in a.instructions for a in hc_agents.values()), (
+            "downstream agent lost the pack clock"
+        )
+        assert "August 19, 2026" in clock
 
         # every shipped industry builds without per-tool harness handlers
         for industry in ("healthcare", "legal", "travel"):

--- a/voice-agent-harnesses/qwen/README.md
+++ b/voice-agent-harnesses/qwen/README.md
@@ -14,7 +14,7 @@ Frontend-only: no ACP coding-agent backend. Shared builder: `harness.py`. Tracin
 - Speak-first: seed a user `conversation.item.create`, then `response.create` (pack owns greeting text; Qwen rejects a bare create on an empty conversation)
 - Audio: Qwen-Audio PCM 16 kHz in / 24 kHz out ↔ CHIRP 16 kHz `pcm_s16le`
 - Barge-in: Qwen `server_vad` (never mute on CHIRP VAD alone)
-- Clock: `Today is …` injected into every session instructions
+- Clock: pack `TODAY` (not the wall clock) injected as `Today is …` on every session
 - Tools: nested `{type: function, function: {name, description, parameters}}` per Model Studio docs
 - Tracing → LangSmith-shaped Bluejay OTel `realtime_session` → `turn` → {user_message, model (gen_ai.usage.* tokens + TTFT), execute_tool}; Chirp stamps `X-Simulation-Result-Id`
 

--- a/voice-agent-harnesses/qwen/harness.py
+++ b/voice-agent-harnesses/qwen/harness.py
@@ -30,6 +30,7 @@ for _root in (Path("/app"), *Path(__file__).resolve().parents):
             sys.path.insert(0, str(_runtime))
         break
 from call_id import headers as tool_headers, log_ws_accept, set_call_id  # noqa: E402
+from pack_clock import today_clock_line, with_pack_clock  # noqa: E402
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TOOL_SERVER_URL = os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
@@ -206,17 +207,18 @@ def _tool_decl(spec: dict) -> dict[str, Any]:
     }
 
 
-def today_context_line(today: _dt.date | None = None) -> str:
-    d = today or _dt.date.today()
-    return f"Today is {d.strftime('%A')}, {d.strftime('%B')} {d.day}, {d.year}."
+def today_context_line(
+    today: _dt.date | None = None, industry_dir: str | Path | None = None
+) -> str:
+    return today_clock_line(industry_dir, today=today)
 
 
-def with_today_context(instructions: str, today: _dt.date | None = None) -> str:
-    line = today_context_line(today)
-    text = (instructions or "").rstrip()
-    if line in text:
-        return text
-    return f"{text}\n\n{line}"
+def with_today_context(
+    instructions: str,
+    today: _dt.date | None = None,
+    industry_dir: str | Path | None = None,
+) -> str:
+    return with_pack_clock(instructions, industry_dir, today=today)
 
 
 def extract_appointment_date(text: str, *, default_year: int | None = None) -> str | None:
@@ -267,7 +269,9 @@ def session_update_for_agent(
         raise KeyError(f"unknown agent {agent!r}")
     tools = [_tool_decl(bp["catalog"][name]) for name in tool_names(bp, agent)]
     session: dict[str, Any] = {
-        "instructions": with_today_context(bp["agents"][agent]["instructions"]),
+        "instructions": with_today_context(
+            bp["agents"][agent]["instructions"], industry_dir=bp.get("industry_dir")
+        ),
         "tools": tools,
     }
     # turn_detection / voice / pcm format are IDLE-only (first update).
@@ -458,7 +462,7 @@ def demo() -> None:
     start_tools = advertised_tools("control-industry", start)
     assert tool_names(bp, start) == start_tools
     all_names = {n for a in bp["agents"] for n in tool_names(bp, a)}
-    today_line = today_context_line()
+    today_line = today_context_line(industry_dir=bp["industry_dir"])
     for agent, names in ((a, tool_names(bp, a)) for a in bp["agents"]):
         update = session_update_for_agent(bp, agent)
         session = update["session"]


### PR DESCRIPTION
## Summary
- Harnesses were telling the model the **wall-clock** date (and OpenAI injected none), so August pack slots look expired once the real calendar moves on.
- Shared `runtime/pack_clock.py` reads each industry's `TODAY` pin from `tool_server.py` and injects `Today is Saturday, August 1, 2026.` (or healthcare's August 19) on every agent, including OpenAI and Nvidia.
- Override with `MIVAS_TODAY=YYYY-MM-DD` or `MIVAS_TODAY=wall`. Packs without a pin (control-industry) still fall back to the wall clock.

## Test plan
- [ ] `uv run pytest tests/test_pack_clock.py`
- [ ] Confirm legal / healthcare / customer-support OpenAI agents include the pack date (`August 1, 2026` / `August 19, 2026`)
- [ ] Grok / Qwen / AWS / Nvidia harness `demo()` self-checks still pass
- [ ] Smoke a legal booking call on OpenAI Realtime: model should treat August 11–15 slots as future, not "already passed"


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects each industry pack's pinned `TODAY` into every harness session so August booking slots no longer look expired once the real calendar moves on.

- Adds `runtime/pack_clock.py` to read `TODAY` from the industry's `tool_server.py` and append a `Today is ...` line to every agent's instructions.
- Applies the pack clock to the AWS, Gemini, Grok, LiveKit, Nvidia, OpenAI, and Qwen harnesses; OpenAI previously injected no clock at all.
- Packs without a pin (control-industry) still fall back to the wall clock.
- Override the pinned date with `MIVAS_TODAY=YYYY-MM-DD` or force the wall clock with `MIVAS_TODAY=wall`.

<sup>Written for commit 132a3a36506830a22b9138f0d1cad6a74e1762ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

