### PR TITLE
Add the GA GPT-Live 1 harness (openai/gpt-live-1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,10 +249,10 @@ Harnesses translate the MIVAS blueprint into provider-specific runtimes. Native 
 
 | Status | Runtime |
 | ------ | ------- |
-| Native S2S | [OpenAI Realtime 2.1 and 2.1 Mini](voice-agent-harnesses/openai/), [Gemini Flash Live 3.1 and 2.5 Flash Native Audio](voice-agent-harnesses/gemini/), [Amazon Nova Sonic 2](voice-agent-harnesses/aws/), [Grok Voice](voice-agent-harnesses/grok/), [Qwen Audio Realtime](voice-agent-harnesses/qwen/) |
+| Native S2S | [OpenAI GPT-Live 1](voice-agent-harnesses/openai/gpt-live-1/), [OpenAI Realtime 2.1 and 2.1 Mini](voice-agent-harnesses/openai/), [Gemini Flash Live 3.1 and 2.5 Flash Native Audio](voice-agent-harnesses/gemini/), [Amazon Nova Sonic 2](voice-agent-harnesses/aws/), [Grok Voice](voice-agent-harnesses/grok/), [Qwen Audio Realtime](voice-agent-harnesses/qwen/) |
 | Cascaded baseline | [LiveKit Cascaded](voice-agent-harnesses/livekit/) with Deepgram Flux, GPT-4.1, and ElevenLabs |
 
-The completed runtimes above account for the eight-runtime Pass<sup>5</sup> matrix. See the [harness contract](voice-agent-harnesses/README.md) for the provider adapter, tool dispatch, handoff, and session requirements.
+The eight-runtime Pass<sup>5</sup> matrix covers every runtime above except GPT-Live 1, which has landed and passes an end-to-end smoke but is not yet scored. See the [harness contract](voice-agent-harnesses/README.md) for the provider adapter, tool dispatch, handoff, and session requirements.
 
 ## Quick start
 

--- a/runtime/entrypoint.sh
+++ b/runtime/entrypoint.sh
@@ -30,6 +30,7 @@ fi
 case "${HARNESS_RUNTIME}" in
   realtime-2.1) : "${OPENAI_REALTIME_MODEL:=gpt-realtime-2.1}" ;;
   realtime-2.1-mini) : "${OPENAI_REALTIME_MODEL:=gpt-realtime-2.1-mini}" ;;
+  gpt-live-1) : "${OPENAI_REALTIME_MODEL:=gpt-live-1}" ;;
 esac
 export OPENAI_REALTIME_MODEL="${OPENAI_REALTIME_MODEL:-}"
 export HARNESS_RUNTIME

--- a/tests/test_dockerfiles.py
+++ b/tests/test_dockerfiles.py
@@ -12,8 +12,8 @@ if str(ROOT) not in sys.path:
 
 def test_dockerfiles_install_deps_before_source() -> None:
     files = sorted((ROOT / "voice-agent-harnesses").glob("*/*/Dockerfile"))
-    # one per shipped runtime: aws(1) gemini(2) grok(1) livekit(1) nvidia(2) openai(2) qwen(1)
-    assert len(files) == 10
+    # one per shipped runtime: aws(1) gemini(2) grok(1) livekit(1) nvidia(2) openai(3) qwen(1)
+    assert len(files) == 11
     for path in files:
         text = path.read_text()
         assert text.startswith("# syntax=docker/dockerfile:1"), path

--- a/voice-agent-harnesses/openai/gpt-live-1/Dockerfile
+++ b/voice-agent-harnesses/openai/gpt-live-1/Dockerfile
@@ -1,0 +1,64 @@
+# syntax=docker/dockerfile:1
+# MIVAS image for openai/gpt-live-1.
+# Build from repo root:
+#   docker build -f voice-agent-harnesses/openai/gpt-live-1/Dockerfile \
+#     --build-arg INDUSTRY=control-industry \
+#     -t mivas-bench:openai-gpt-live-1-control-industry .
+#
+# Self-contained runtime: copies only this folder (no shared openai/harness.py).
+
+FROM python:3.12-slim
+
+ARG INDUSTRY=control-industry
+
+COPY --from=ghcr.io/astral-sh/uv:0.9.26 /uv /usr/local/bin/uv
+
+ENV HARNESS=openai/gpt-live-1 \
+    INDUSTRY=${INDUSTRY} \
+    APP_ROOT=/app \
+    INDUSTRY_DIR=/app/industry \
+    HARNESS_FAMILY=openai \
+    HARNESS_RUNTIME=gpt-live-1 \
+    HARNESS_FAMILY_DIR=/app/harness \
+    HARNESS_DIR=/app/harness/gpt-live-1 \
+    PYTHONPATH=/app/harness \
+    MIVAS_DB_PATH=/data/industry.db \
+    TOOL_SERVER_PORT=8000 \
+    TOOL_SERVER_URL=http://127.0.0.1:8000 \
+    PYTHONUNBUFFERED=1 \
+    UV_SYSTEM_PYTHON=1 \
+    UV_COMPILE_BYTECODE=1 \
+    BLUEJAY_SERVICE_NAME=mivas-openai-gpt-live \
+    OPENAI_API_KEY="" \
+    OPENAI_LIVE_MODEL=gpt-live-1 \
+    GPT_LIVE_BACKEND_MODEL=gpt-5.6-terra \
+    CHIRP_PORT=8765 \
+    CHIRP_USER="" \
+    CHIRP_PASS="" \
+    BLUEJAY_API_KEY="" \
+    BLUEJAY_API_URL="" \
+    BLUEJAY_OTLP_ENDPOINT=""
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY industries/${INDUSTRY}/requirements.txt /tmp/industry-requirements.txt
+COPY voice-agent-harnesses/openai/gpt-live-1/requirements.txt /tmp/harness-requirements.txt
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv pip install --system \
+      -r /tmp/industry-requirements.txt \
+      -r /tmp/harness-requirements.txt
+
+COPY industries/${INDUSTRY}/ /app/industry/
+COPY voice-agent-harnesses/openai/gpt-live-1/ /app/harness/gpt-live-1/
+COPY runtime/ /app/runtime/
+RUN chmod +x /app/runtime/entrypoint.sh \
+    && mkdir -p /data \
+    && test -f "${HARNESS_DIR}/agent.py"
+
+EXPOSE 8000 8765
+
+CMD ["/app/runtime/entrypoint.sh"]

--- a/voice-agent-harnesses/openai/gpt-live-1/Dockerfile
+++ b/voice-agent-harnesses/openai/gpt-live-1/Dockerfile
@@ -30,7 +30,6 @@ ENV HARNESS=openai/gpt-live-1 \
     UV_COMPILE_BYTECODE=1 \
     BLUEJAY_SERVICE_NAME=mivas-openai-gpt-live \
     OPENAI_API_KEY="" \
-    OPENAI_LIVE_MODEL=gpt-live-1 \
     GPT_LIVE_BACKEND_MODEL=gpt-5.6-terra \
     CHIRP_PORT=8765 \
     CHIRP_USER="" \

--- a/voice-agent-harnesses/openai/gpt-live-1/README.md
+++ b/voice-agent-harnesses/openai/gpt-live-1/README.md
@@ -41,6 +41,14 @@ Sources: `guides/voice-websockets?api=live`, `guides/live-delegation`,
 - speak-first: one `session.instructions.append` with `delegation_id: null` after
   `session.started`. Instructions, not commentary: commentary is paraphrased and the
   pack's greeting is fixed text.
+- **`*.appended` is not a protocol ack.** It reports where the text landed on the
+  conversation timeline (`start_ms`/`end_ms`) and only fires once the timeline reaches
+  that point, which needs caller audio to be flowing. Measured 2026-09-10: with audio
+  flowing it arrives ~0.7 s after the append, and a session closed before then answers
+  `server_error / context_injection_incomplete` instead. So appends are sent and not
+  awaited — awaiting the greeting's append stalls the whole call until the caller
+  speaks first. `session.update` *is* a real ack (`session.updated` in ~50 ms with or
+  without audio) and is still awaited.
 - multi-agent = soft handoff on the one session: `session.update` swaps
   `delegation.responses.{instructions,tools}` to the target stage, then
   `session.instructions.append` (≤500 tokens, chunked) tells the live model the role

--- a/voice-agent-harnesses/openai/gpt-live-1/README.md
+++ b/voice-agent-harnesses/openai/gpt-live-1/README.md
@@ -1,0 +1,114 @@
+# OpenAI GPT-Live — `gpt-live-1`
+
+Self-contained runtime for OpenAI's GA GPT-Live model. Shares nothing with
+`openai/harness.py` / `report.py` (those are Realtime-API harnesses; GPT-Live is a
+different product and wire contract).
+
+| File | Owns |
+|---|---|
+| `pack.py` | industry pack → live prompt, per-stage backend prompt + Responses tools |
+| `live.py` | the session: `session.start`, tool loop, soft handoff, speak-first, graceful close |
+| `tools.py` | `POST {TOOL_SERVER_URL}/tools/{name}` with `X-Mivas-Call-Id` |
+| `tracing.py` | OTel `voice.call` tree → Bluejay OTLP, then one `update-simulation-result` POST |
+| `adapters/chirp.py` | Bluejay CHIRP websocket ↔ `live.py`. All Bluejay specifics live here |
+| `agent.py` | `--check`: builds every session shape offline, no network |
+
+## Contract used
+
+Sources: `guides/voice-websockets?api=live`, `guides/live-delegation`,
+`guides/live-conversations`, `guides/live-prompting`, `models/gpt-live-1`.
+
+- `wss://api.openai.com/v1/live/sessions`, `Authorization: Bearer $OPENAI_API_KEY`
+  and nothing else — GA needs no preview/alpha header.
+- first message `session.start` with the model in `session.model`; wait for
+  `session.started` before sending audio.
+- `audio.format` is one shared format for both directions and cannot change
+  mid-session. The documented default is `{audio/pcm, 24000}`; this harness picks
+  the supported `{audio/pcm, 16000}` because CHIRP is 16 kHz PCM16, so audio is
+  passed through byte-for-byte with no resampling, no gating, no mute. The model
+  is full duplex and owns barge-in.
+- Provider output is a continuous realtime stream (100 ms deltas every ~100 ms,
+  silence frames included). A 200 ms playout buffer was measured against Bluejay's
+  `agent_audio_dropouts` during the preview and did not move it, so audio is
+  forwarded as received and per-call stream gaps are logged instead
+  (`call done … gaps>250ms=…`). Remaining dropouts are the model's own
+  mid-utterance pauses while it waits on the backend.
+- Responses delegation: `session.delegation.created` → `response.event{response.created}`
+  → `response.event{response.output_item.done}` (completed `function_call`) → after
+  `response.event{response.completed}` every collected call is answered with
+  `response.item.create` then one explicit `response.create`. Deduped by `call_id`.
+  `response.completed.response.output` is empty — never use it to decide pending calls.
+- speak-first: one `session.instructions.append` with `delegation_id: null` after
+  `session.started`. Instructions, not commentary: commentary is paraphrased and the
+  pack's greeting is fixed text.
+- multi-agent = soft handoff on the one session: `session.update` swaps
+  `delegation.responses.{instructions,tools}` to the target stage, then
+  `session.instructions.append` (≤500 tokens, chunked) tells the live model the role
+  changed. Only the target stage's tools are ever registered. History is kept by
+  the service; nothing is replayed.
+- `end_call`: answered locally (never POSTed). The backend then finishes its summary
+  turn (next `response.completed` with no function calls), the live model speaks it,
+  and once that audio goes quiet the harness sends `session.close` and reads through
+  `session.closed` (which carries `usage.seconds` and a `reason`). Bounded by
+  `GPT_LIVE_END_CALL_MAX_S`.
+- Tool results and handoffs are sent from their own tasks, never from the websocket
+  read loop. Awaiting an ack (`session.updated`, `*.appended`) inside the pump blocks
+  the frame that carries the ack.
+- every command carries an `event_id`; acks and `error.client_event_id` are
+  correlated back to it.
+
+## Prompt mapping
+
+The live model gets the starting stage's system prompt verbatim plus OpenAI's
+prompting-guide delegation template. Its "Backend tools" list is built from the
+pack's own tool descriptions with **no tool names** — the prompting guide keeps
+tool names and schemas out of the live prompt. Each backend stage gets its system
+prompt verbatim inside the guide's "Voice conversation context / Task instructions /
+Return the result" wrapper. The harness adds only the pack clock (`Today is …`) and
+the wire rule that the live model delegates instead of calling tools. No pack policy
+is authored here.
+
+A pack that wants the recommended front-end/back-end prompt split can ship
+`system-prompts/<stage>.live.md`; when present it replaces the verbatim stage prompt
+in the live instructions (the backend still gets `<stage>.md`).
+
+A handoff's function result tells the backend the transfer is done and the caller's
+request is still pending. Without that the backend returns an empty final answer on a
+sizeable share of post-handoff continuations and the live model has nothing to say.
+
+## Not done on purpose
+
+- No booking-confirm inference. If the model says "booked" without calling
+  `schedule_appointment`, that is model signal and the trace shows no tool.
+- No upstream reconnect. A dropped provider socket ends the call and is logged with
+  the reason.
+- No greeting nudge, echo-mute window, or playout buffer. Anything added here has to
+  move a Bluejay metric first.
+
+## Run
+
+```bash
+uv run python voice-agent-harnesses/openai/gpt-live-1/agent.py control-industry --check
+uv run pytest voice-agent-harnesses/openai/gpt-live-1/test_gpt_live.py
+
+# local Bluejay CHIRP bridge (tool server on :8000 first)
+uv run python industries/control-industry/tool_server.py
+CHIRP_PORT=8769 CHIRP_USER=… CHIRP_PASS=… OPENAI_API_KEY=… BLUEJAY_API_KEY=… \
+  uv run python voice-agent-harnesses/openai/gpt-live-1/adapters/chirp.py --industry control-industry
+cloudflared tunnel --url http://127.0.0.1:8769 --no-autoupdate
+```
+
+Local CHIRP port: **8769**.
+
+Env: `OPENAI_API_KEY`, `CHIRP_USER`/`CHIRP_PASS`, `CHIRP_PORT`, `TOOL_SERVER_URL`,
+`BLUEJAY_API_KEY` (+ optional `BLUEJAY_OTLP_ENDPOINT`, `BLUEJAY_API_URL`, `BLUEJAY_SERVICE_NAME`),
+`GPT_LIVE_BACKEND_MODEL` (default `gpt-5.6-terra`), `GPT_LIVE_VOICE` (default `gleam`),
+`GPT_LIVE_SAMPLE_RATE` (default `16000`),
+`GPT_LIVE_END_CALL_QUIET_S` / `GPT_LIVE_END_CALL_GRACE_S` / `GPT_LIVE_END_CALL_MAX_S`,
+`GPT_LIVE_LOG_LEVEL` (`DEBUG` logs every non-audio event both ways).
+
+## Pricing
+
+$0.05 per minute of voice session, billed per second (`models/gpt-live-1`). The
+backend Responses model is billed separately on its own tokens; the tracer records
+those as `gen_ai.usage.*` on each `chat <backend model>` span.

--- a/voice-agent-harnesses/openai/gpt-live-1/adapters/chirp.py
+++ b/voice-agent-harnesses/openai/gpt-live-1/adapters/chirp.py
@@ -1,0 +1,217 @@
+"""Bluejay CHIRP ↔ GPT-Live 1. Everything Bluejay-specific lives here.
+
+CHIRP (Bluejay's websocket agent transport):
+  * upgrade headers: ``Authorization: Basic CHIRP_USER:CHIRP_PASS``,
+    ``X-Simulation-Result-Id`` (the call's Bluejay id)
+  * binary frames: caller PCM16 mono 16 kHz, both directions
+  * JSON frames: ``speech.started`` / ``speech.completed`` utterance markers.
+    Inbound ones come from Bluejay's VAD and are logged only. Outbound ones
+    bracket the agent's audible speech so Bluejay can time it.
+
+The session is opened at 16 kHz PCM — a supported format, and the one CHIRP
+carries — so audio is passed through byte-for-byte: no resampling, no pacing,
+no gating. The model is full duplex and owns barge-in.
+The provider streams a continuous realtime signal (100 ms deltas, silence
+included). A 200 ms playout buffer was measured against Bluejay's
+agent_audio_dropouts during the GPT-Live preview and moved it not at all, so
+there is none here; per-call stream gaps are logged instead
+(see _AgentSpeech.stream_report) so the finding can be re-checked per run.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import base64
+import contextlib
+import json
+import logging
+import os
+import sys
+import time
+import uuid
+from pathlib import Path
+
+from websockets.asyncio.server import serve
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+from live import LiveSession, MODEL, _peak, AUDIBLE_PEAK  # noqa: E402
+from pack import load_pack  # noqa: E402
+from tools import call_session, run_tool, set_call_id  # noqa: E402
+from tracing import Tracer, post_trace_ids, provider  # noqa: E402
+
+log = logging.getLogger("mivas.gpt-live.chirp")
+
+# Agent utterance marker closes after this much inaudible output.
+UTTERANCE_QUIET_S = float(os.environ.get("GPT_LIVE_CHIRP_UTTERANCE_QUIET_S", "0.6"))
+
+
+def _auth() -> str | None:
+    u, p = os.environ.get("CHIRP_USER", "").strip(), os.environ.get("CHIRP_PASS", "").strip()
+    return f"Basic {base64.b64encode(f'{u}:{p}'.encode()).decode()}" if u and p else None
+
+
+def _marker(kind: str, utterance_id: str) -> str:
+    return json.dumps(
+        {"type": kind, "id": str(uuid.uuid4()), "ts_ms": int(time.time() * 1000),
+         "data": {"utterance_id": utterance_id}},
+        separators=(",", ":"),
+    )
+
+
+def _simulation_result_id(ws) -> str | None:
+    headers = getattr(getattr(ws, "request", None), "headers", None)
+    val = headers.get("X-Simulation-Result-Id") if headers is not None else None
+    return str(val).strip() if val else None
+
+
+class _AgentSpeech:
+    """Outbound agent audio: pass-through + speech.started/completed markers."""
+
+    def __init__(self, ws) -> None:
+        self.ws = ws
+        self.utt: str | None = None
+        self.last_audible = 0.0
+        self.bytes_out = 0
+        # Provider stream shape, for telling jitter (mid-speech) from pauses (between turns).
+        self.in_bytes = 0
+        self.first_in = 0.0
+        self.last_in = 0.0
+        self.gaps: list[tuple[int, bool]] = []  # (gap_ms, was_speaking)
+
+    async def audio(self, pcm: bytes) -> None:
+        now = time.monotonic()
+        if self.last_in:
+            gap = int((now - self.last_in) * 1000)
+            if gap > 250:
+                self.gaps.append((gap, self.utt is not None))
+        else:
+            self.first_in = now
+        self.last_in = now
+        self.in_bytes += len(pcm)
+        await self._emit(pcm)
+
+    def stream_report(self) -> str:
+        span_ms = int((self.last_in - self.first_in) * 1000) if self.first_in else 0
+        mid = [g for g, speaking in self.gaps if speaking]
+        return (
+            f"provider_audio_ms={self.in_bytes // 32} span_ms={span_ms} "
+            f"gaps>250ms={len(self.gaps)} mid_speech={len(mid)} max_gap_ms={max((g for g, _ in self.gaps), default=0)}"
+        )
+
+    async def _emit(self, frame: bytes) -> None:
+        self.bytes_out += len(frame)
+        if _peak(frame) >= AUDIBLE_PEAK:
+            self.last_audible = time.monotonic()
+            if self.utt is None:
+                self.utt = f"u_{uuid.uuid4().hex[:12]}"
+                await self.ws.send(_marker("speech.started", self.utt))
+        await self.ws.send(frame)
+
+    async def watch(self) -> None:
+        while True:
+            await asyncio.sleep(0.1)
+            if self.utt and time.monotonic() - self.last_audible >= UTTERANCE_QUIET_S:
+                await self.end()
+
+    async def end(self) -> None:
+        if self.utt:
+            utt, self.utt = self.utt, None
+            with contextlib.suppress(Exception):
+                await self.ws.send(_marker("speech.completed", utt))
+
+
+async def _bridge(ws, industry: str) -> None:
+    sim_id = _simulation_result_id(ws)
+    set_call_id(sim_id)
+    pack = load_pack(industry)
+    tracer = Tracer(sim_id, model=MODEL, backend_model=os.environ.get("GPT_LIVE_BACKEND_MODEL", "gpt-5.6-terra")) if provider() else None
+    speech = _AgentSpeech(ws)
+    log.info("chirp accept sim=%s industry=%s", sim_id or "-", pack.industry)
+
+    if tracer:
+        tracer.open()
+    live = LiveSession(
+        pack,
+        api_key=os.environ["OPENAI_API_KEY"],
+        on_audio=speech.audio,
+        run_tool=run_tool,
+        observer=tracer,
+    )
+    bytes_in = 0
+    try:
+        async with call_session(sim_id):
+            await live.open()
+            await live.speak_first()
+            watcher = asyncio.create_task(speech.watch())
+
+            async def inbound() -> None:
+                nonlocal bytes_in
+                async for msg in ws:
+                    if isinstance(msg, bytes):
+                        bytes_in += len(msg)
+                        await live.send_audio(msg)
+                    else:
+                        with contextlib.suppress(ValueError):
+                            log.debug("chirp %s", json.loads(msg).get("type"))
+                # Bluejay hung up.
+                await live.hang_up("caller_hung_up")
+
+            in_task = asyncio.create_task(inbound())
+            await live.wait_closed()
+            await speech.end()
+            watcher.cancel()
+            in_task.cancel()
+            await asyncio.gather(watcher, in_task, return_exceptions=True)
+    finally:
+        await live.aclose()
+        with contextlib.suppress(Exception):
+            await ws.close(1000)
+        log.info(
+            "call done sim=%s session=%s reason=%s in=%dB out=%dB live_seconds=%s %s",
+            sim_id, live.session_id, live.close_reason, bytes_in, speech.bytes_out,
+            live.usage_seconds, speech.stream_report(),
+        )
+        if tracer:
+            tracer.close()
+            if sim_id and tracer.trace_id:
+                await post_trace_ids(sim_id, tracer.trace_id)
+
+
+async def _handler(ws, industry: str) -> None:
+    expected = _auth()
+    if expected and ws.request.headers.get("Authorization") != expected:
+        await ws.close(1008, "unauthorized")
+        return
+    try:
+        await _bridge(ws, industry)
+    except Exception:
+        log.exception("bridge failed")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--industry", default=os.environ.get("INDUSTRY", "control-industry"))
+    p.add_argument("--host", default=os.environ.get("CHIRP_HOST", "0.0.0.0"))
+    p.add_argument("--port", type=int, default=int(os.environ.get("CHIRP_PORT", "8769")))
+    p.add_argument("--model", default=MODEL, help="ignored unless it names this runtime's model")
+    a = p.parse_args()
+    if a.model != MODEL:
+        raise SystemExit(f"this runtime speaks {MODEL} only (got --model {a.model})")
+    if not os.environ.get("OPENAI_API_KEY"):
+        raise SystemExit("OPENAI_API_KEY required")
+    logging.basicConfig(
+        level=os.environ.get("GPT_LIVE_LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    log.info("chirp↔%s × %s :%s auth=%s", MODEL, a.industry, a.port, bool(_auth()))
+
+    async def run() -> None:
+        async with serve(lambda ws: _handler(ws, a.industry), a.host, a.port, max_size=None):
+            await asyncio.Future()
+
+    asyncio.run(run())
+
+
+if __name__ == "__main__":
+    main()

--- a/voice-agent-harnesses/openai/gpt-live-1/agent.py
+++ b/voice-agent-harnesses/openai/gpt-live-1/agent.py
@@ -1,0 +1,52 @@
+"""gpt-live-1 harness entry: offline --check of pack → session shapes."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from live import MODEL, LiveSession  # noqa: E402
+from pack import industry_path, load_pack, today_line  # noqa: E402
+
+
+async def _noop_audio(_: bytes) -> None: ...
+async def _noop_tool(_n: str, _a: dict) -> dict: return {"success": True}
+
+
+def check(industry: str | Path) -> None:
+    pack = load_pack(industry)
+    live = LiveSession(pack, api_key="check", on_audio=_noop_audio, run_tool=_noop_tool)
+    cfg = live.session_config()
+    json.dumps(cfg)  # must be wire-serialisable
+    assert cfg["model"] == MODEL
+    assert cfg["audio"]["format"] == {"type": "audio/pcm", "rate": 16000}
+    assert cfg["delegation"]["type"] == "responses"
+    start = pack.stages[pack.start]
+    names = {t["name"] for t in cfg["delegation"]["responses"]["tools"]}
+    assert names == {t.name for t in start.tools}, "start stage tools must match blueprint"
+    assert today_line() in cfg["instructions"] and today_line() in cfg["delegation"]["responses"]["instructions"]
+    assert start.prompt.strip() in cfg["instructions"]
+    for name, stage in pack.stages.items():
+        if name != pack.start:
+            assert stage.prompt.strip() not in cfg["instructions"], f"{name} prompt leaked into live prompt"
+            assert len(stage.handoff_notice()) <= 2 * 1400, f"{name} handoff notice needs >2 appends"
+    # The live model has a small context window; keep its prompt well inside 16k tokens
+    # (~3 chars/token is the conservative bound).
+    assert len(cfg["instructions"]) < 16_384 * 3, "live instructions too long for the live model"
+    print(
+        f"ok {pack.industry} × {MODEL} start={pack.start} stages={list(pack.stages)} "
+        f"backend={live.backend_model} live_prompt_chars={len(cfg['instructions'])} "
+        f"tool_server={os.environ.get('TOOL_SERVER_URL', 'http://127.0.0.1:8000')}"
+    )
+
+
+if __name__ == "__main__":
+    industry = next((a for a in sys.argv[1:] if not a.startswith("-")), "control-industry")
+    industry_dir = Path(os.environ.get("INDUSTRY_DIR") or industry_path(industry))
+    if "--check" in sys.argv:
+        check(industry_dir)
+    else:
+        raise SystemExit("run adapters/chirp.py for a live bridge; agent.py only supports --check")

--- a/voice-agent-harnesses/openai/gpt-live-1/live.py
+++ b/voice-agent-harnesses/openai/gpt-live-1/live.py
@@ -227,9 +227,10 @@ class LiveSession:
     async def speak_first(self) -> None:
         """GA guide, "Ask the model to speak first": one fresh session.instructions.append
         with ``delegation_id: null``. Not commentary — commentary is paraphrased, and the
-        pack's greeting is fixed text the benchmark compares against."""
+        pack's greeting is fixed text the benchmark compares against. Sent, not awaited
+        (see ``_post``): the caller's first audio has not arrived yet at this point."""
         for chunk in _chunks(self.pack.speak_first_prompt()):
-            await self._command(
+            await self._post(
                 {"type": "session.instructions.append", "delegation_id": None, "content": chunk},
                 ack="session.instructions.appended",
             )
@@ -279,9 +280,16 @@ class LiveSession:
         return task
 
     async def drain(self) -> None:
-        """Wait for in-flight tool/continue/hang-up tasks (tests, shutdown)."""
-        while self._tasks:
-            await asyncio.gather(*list(self._tasks), return_exceptions=True)
+        """Wait for in-flight tool/continue/hang-up tasks (tests, shutdown).
+
+        Append reports are excluded: they resolve only when the service says the
+        text was injected, which may be after the call is over.
+        """
+        while True:
+            work = [t for t in self._tasks if t.get_name() != "gpt-live-append"]
+            if not work:
+                return
+            await asyncio.gather(*work, return_exceptions=True)
 
     def _finish(self, reason: str) -> None:
         if self._closed.is_set():
@@ -300,6 +308,38 @@ class LiveSession:
             log.debug("-> %s", json.dumps(event)[:600])
         async with self._send_lock:
             await self._ws.send(json.dumps(event, separators=(",", ":")))
+
+    async def _post(self, event: dict[str, Any], *, ack: str) -> None:
+        """Send a ``*.append`` and keep going.
+
+        ``session.instructions.appended`` is not a protocol ack: it reports where the
+        text landed on the conversation timeline (``start_ms``/``end_ms``) and only
+        fires once the timeline reaches that point, which needs caller audio to be
+        flowing. Awaiting it stalls the greeting until the first caller audio and can
+        stall a handoff for as long as the caller stays silent. Measured against GA
+        on 2026-09-10: appended arrives ~0.7 s after audio starts, and a session
+        closed before then answers with ``server_error / context_injection_incomplete``.
+        Frames stay ordered on the wire, so a following ``response.create`` still
+        arrives after the append.
+        """
+        eid = event.setdefault("event_id", _eid(event["type"].replace(".", "_")))
+        fut: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
+        self._waiters[eid] = fut
+
+        async def report() -> None:
+            try:
+                ev = await fut
+            except LiveError as e:
+                log.warning("%s not applied: %s", event["type"], e)
+            except asyncio.CancelledError:
+                raise
+            else:
+                log.debug("%s at %s-%sms", ack, ev.get("start_ms"), ev.get("end_ms"))
+            finally:
+                self._waiters.pop(eid, None)
+
+        self._spawn(report(), name="gpt-live-append")
+        await self._send(event)
 
     async def _command(self, event: dict[str, Any], *, ack: str) -> dict[str, Any]:
         """Send with an event_id and wait for its acknowledgment (or correlated error)."""
@@ -535,7 +575,7 @@ class LiveSession:
             ack="session.updated",
         )
         for chunk in _chunks(stage.handoff_notice()):
-            await self._command(
+            await self._post(
                 {"type": "session.instructions.append", "delegation_id": None, "content": chunk},
                 ack="session.instructions.appended",
             )

--- a/voice-agent-harnesses/openai/gpt-live-1/live.py
+++ b/voice-agent-harnesses/openai/gpt-live-1/live.py
@@ -1,0 +1,566 @@
+"""GPT-Live (`gpt-live-1`) WebSocket session.
+
+Wire contract: the GA guides — "Connect over WebSockets" (voice-websockets),
+"Delegation and tools" (live-delegation), "Usage and graceful close"
+(live-conversations). Transport-neutral: audio in and out are raw PCM bytes at the
+session's sample rate; whoever owns the caller leg (CHIRP, SIP, a test) plugs in.
+
+One session per call. Multi-agent packs are soft handoffs on that session: the
+backend (Responses) stage is swapped with ``session.update`` and the live model
+gets a ``session.instructions.append`` role-change notice. History is kept by
+the service; nothing is replayed.
+
+Tool loop (Responses delegation):
+  session.delegation.created ─┐
+  response.event{response.created}          → open delegation
+  response.event{response.output_item.done} → collect completed function_call
+  response.event{response.completed}        → run collected calls, then
+      response.item.create(function_call_output) × n,
+      [session.update + session.instructions.append if a call was a handoff],
+      then response.create
+
+Full duplex: the model handles barge-in itself. This client never mutes,
+cancels, or gates audio in either direction.
+"""
+
+from __future__ import annotations
+
+import array
+import asyncio
+import base64
+import contextlib
+import json
+import logging
+import os
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable
+
+from websockets.asyncio.client import connect
+from websockets.exceptions import ConnectionClosed
+
+from pack import Pack, Stage, today_line
+
+log = logging.getLogger("mivas.gpt-live")
+
+MODEL = "gpt-live-1"
+LIVE_URL = os.environ.get("GPT_LIVE_URL", "wss://api.openai.com/v1/live/sessions")
+BACKEND_MODEL = os.environ.get("GPT_LIVE_BACKEND_MODEL", "gpt-5.6-terra")
+VOICE = os.environ.get("GPT_LIVE_VOICE", "gleam")
+# 24 kHz is the documented default; 16 kHz PCM is a supported format and is what
+# CHIRP carries, so picking it keeps the caller leg resample-free in both directions.
+SAMPLE_RATE = int(os.environ.get("GPT_LIVE_SAMPLE_RATE", "16000"))
+
+ACK_TIMEOUT_S = float(os.environ.get("GPT_LIVE_ACK_TIMEOUT_S", "15"))
+# After end_call: hang up once the agent has been quiet this long (farewell done), bounded.
+END_CALL_QUIET_S = float(os.environ.get("GPT_LIVE_END_CALL_QUIET_S", "1.5"))
+END_CALL_MAX_S = float(os.environ.get("GPT_LIVE_END_CALL_MAX_S", "20"))
+# ...and if no farewell audio starts at all within this window, hang up anyway.
+END_CALL_GRACE_S = float(os.environ.get("GPT_LIVE_END_CALL_GRACE_S", "4"))
+CLOSED_TIMEOUT_S = float(os.environ.get("GPT_LIVE_CLOSED_TIMEOUT_S", "6"))
+# Appends are capped at 500 tokens; ~3 chars/token keeps a safe margin.
+APPEND_MAX_CHARS = 1400
+AUDIBLE_PEAK = 300  # int16 peak below this is silence for hang-up timing only
+
+_QUIET_EVENTS = {"session.output_audio.delta", "session.input_transcript.delta", "session.output_transcript.delta"}
+
+ToolRunner = Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]]
+AudioSink = Callable[[bytes], Awaitable[None]]
+
+
+class LiveError(RuntimeError):
+    pass
+
+
+@dataclass
+class FunctionCall:
+    call_id: str
+    name: str
+    arguments: dict[str, Any]
+    response_id: str | None
+    delegation_id: str | None
+
+
+@dataclass
+class Delegation:
+    delegation_id: str | None
+    response_id: str | None
+    pending: dict[str, asyncio.Task[dict[str, Any]]] = field(default_factory=dict)
+    after_handoff: bool = False
+    said_something: bool = False
+
+
+class Observer:
+    """No-op hooks. tracing.Tracer implements them; tests may too."""
+
+    def session_started(self, session: dict[str, Any]) -> None: ...
+    def transcript(self, role: str, delta: str, start_ms: int, end_ms: int) -> None: ...
+    def delegation_created(self, delegation: dict[str, Any], offset_ms: int) -> None: ...
+    def response_created(self, response_id: str, delegation_id: str | None) -> None: ...
+    def response_done(self, response: dict[str, Any], delegation_id: str | None) -> None: ...
+    def backend_text(self, response_id: str | None, text: str) -> None: ...
+    def tool_start(self, call: FunctionCall) -> None: ...
+    def tool_end(self, call: FunctionCall, result: dict[str, Any]) -> None: ...
+    def handoff(self, from_stage: str, to_stage: str) -> None: ...
+    def usage(self, seconds: float | None, usage_ratio: float | None) -> None: ...
+    def error(self, error: dict[str, Any]) -> None: ...
+    def closed(self, reason: str, usage_seconds: float | None) -> None: ...
+
+
+def _eid(prefix: str) -> str:
+    return f"{prefix}_{uuid.uuid4().hex[:12]}"
+
+
+def _chunks(text: str, limit: int = APPEND_MAX_CHARS) -> list[str]:
+    out: list[str] = []
+    cur = ""
+    for line in text.splitlines(keepends=True):
+        if cur and len(cur) + len(line) > limit:
+            out.append(cur)
+            cur = ""
+        cur += line
+    if cur:
+        out.append(cur)
+    return out or [""]
+
+
+def _peak(pcm: bytes) -> int:
+    if len(pcm) < 2:
+        return 0
+    samples = array.array("h")
+    samples.frombytes(pcm[: len(pcm) - len(pcm) % 2])
+    return max(abs(min(samples)), abs(max(samples)))
+
+
+class LiveSession:
+    def __init__(
+        self,
+        pack: Pack,
+        *,
+        api_key: str,
+        on_audio: AudioSink,
+        run_tool: ToolRunner,
+        observer: Observer | None = None,
+        model: str = MODEL,
+        backend_model: str = BACKEND_MODEL,
+        voice: str = VOICE,
+        sample_rate: int = SAMPLE_RATE,
+        clock: str | None = None,
+    ) -> None:
+        self.pack = pack
+        self.stage: Stage = pack.stages[pack.start]
+        self.model = model
+        self.backend_model = backend_model
+        self.voice = voice
+        self.sample_rate = sample_rate
+        self.clock = clock or today_line()
+        self.on_audio = on_audio
+        self.run_tool = run_tool
+        self.obs = observer or Observer()
+        self._api_key = api_key
+        self._ws: Any = None
+        self._send_lock = asyncio.Lock()
+        self._waiters: dict[str, asyncio.Future[dict[str, Any]]] = {}
+        self._delegations: dict[str, Delegation] = {}  # keyed by delegation_id or response_id
+        self._latest_delegation: Delegation | None = None
+        self._answered: set[str] = set()
+        self._handoff_target: str | None = None
+        self._tasks: set[asyncio.Task[Any]] = set()
+        self._last_audible_mono = 0.0
+        self._ending: asyncio.Event = asyncio.Event()
+        # Set when the backend finishes a turn with no function calls after end_call:
+        # that turn is the summary the live model will speak as the farewell.
+        self._backend_done: asyncio.Event = asyncio.Event()
+        self._hangup_started = False
+        self._closed: asyncio.Event = asyncio.Event()
+        self._close_sent = False
+        self.session_id: str | None = None
+        self.usage_seconds: float | None = None
+        self.close_reason: str | None = None
+
+    # ---- lifecycle ---------------------------------------------------------
+
+    def session_config(self) -> dict[str, Any]:
+        start = self.stage
+        return {
+            "model": self.model,
+            "instructions": self.pack.live_instructions(self.clock),
+            "audio": {
+                "format": {"type": "audio/pcm", "rate": self.sample_rate},
+                "output": {"voice": self.voice},
+            },
+            "delegation": {
+                "type": "responses",
+                "responses": {
+                    "model": self.backend_model,
+                    "instructions": start.backend_instructions(self.clock),
+                    "tools": start.responses_tools(),
+                    "tool_choice": "auto",
+                    "parallel_tool_calls": False,
+                },
+            },
+        }
+
+    async def open(self) -> None:
+        """Connect, ``session.start``, wait for ``session.started``."""
+        self._ws = await connect(
+            LIVE_URL,
+            additional_headers={"Authorization": f"Bearer {self._api_key}"},
+            max_size=None,
+            ping_interval=20,
+            ping_timeout=20,
+        )
+        self._pump = asyncio.create_task(self._pump_events(), name="gpt-live-pump")
+        started = await self._command(
+            {"type": "session.start", "session": self.session_config()},
+            ack="session.started",
+        )
+        session = started.get("session") or {}
+        self.session_id = session.get("id")
+        self.obs.session_started(session)
+        log.info(
+            "session.started id=%s stage=%s backend=%s rate=%s",
+            self.session_id, self.stage.name, self.backend_model, self.sample_rate,
+        )
+
+    async def speak_first(self) -> None:
+        """GA guide, "Ask the model to speak first": one fresh session.instructions.append
+        with ``delegation_id: null``. Not commentary — commentary is paraphrased, and the
+        pack's greeting is fixed text the benchmark compares against."""
+        for chunk in _chunks(self.pack.speak_first_prompt()):
+            await self._command(
+                {"type": "session.instructions.append", "delegation_id": None, "content": chunk},
+                ack="session.instructions.appended",
+            )
+
+    async def send_audio(self, pcm: bytes) -> None:
+        if not pcm or self._closed.is_set():
+            return
+        await self._send(
+            {"type": "session.input_audio.append", "audio": base64.b64encode(pcm).decode("ascii")}
+        )
+
+    async def wait_closed(self) -> None:
+        await self._closed.wait()
+
+    async def hang_up(self, reason: str = "harness") -> None:
+        """Graceful close: ``session.close`` then read through ``session.closed``."""
+        if self._close_sent or self._ws is None:
+            return
+        self._close_sent = True
+        log.info("session.close reason=%s", reason)
+        with contextlib.suppress(Exception):
+            await self._send({"type": "session.close", "event_id": _eid("close")})
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(self._closed.wait(), CLOSED_TIMEOUT_S)
+        if not self._closed.is_set():
+            log.warning("no session.closed within %.0fs; closing transport", CLOSED_TIMEOUT_S)
+            self._finish("transport_timeout")
+
+    async def aclose(self) -> None:
+        self._finish(self.close_reason or "harness")
+        if self._ws is not None:
+            with contextlib.suppress(Exception):
+                await self._ws.close()
+        for task in list(self._tasks):
+            task.cancel()
+        pump = getattr(self, "_pump", None)
+        if pump is not None:
+            pump.cancel()
+            with contextlib.suppress(BaseException):
+                await pump
+
+    def _spawn(self, coro: Awaitable[Any], *, name: str) -> asyncio.Task[Any]:
+        task = asyncio.ensure_future(coro)
+        task.set_name(name)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        return task
+
+    async def drain(self) -> None:
+        """Wait for in-flight tool/continue/hang-up tasks (tests, shutdown)."""
+        while self._tasks:
+            await asyncio.gather(*list(self._tasks), return_exceptions=True)
+
+    def _finish(self, reason: str) -> None:
+        if self._closed.is_set():
+            return
+        self.close_reason = self.close_reason or reason
+        self._closed.set()
+        for fut in self._waiters.values():
+            if not fut.done():
+                fut.set_exception(LiveError(f"session closed ({reason})"))
+        self._waiters.clear()
+
+    # ---- sending -----------------------------------------------------------
+
+    async def _send(self, event: dict[str, Any]) -> None:
+        if event.get("type") != "session.input_audio.append" and log.isEnabledFor(logging.DEBUG):
+            log.debug("-> %s", json.dumps(event)[:600])
+        async with self._send_lock:
+            await self._ws.send(json.dumps(event, separators=(",", ":")))
+
+    async def _command(self, event: dict[str, Any], *, ack: str) -> dict[str, Any]:
+        """Send with an event_id and wait for its acknowledgment (or correlated error)."""
+        eid = event.setdefault("event_id", _eid(event["type"].replace(".", "_")))
+        fut: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
+        self._waiters[eid] = fut
+        await self._send(event)
+        try:
+            return await asyncio.wait_for(fut, ACK_TIMEOUT_S)
+        except asyncio.TimeoutError as e:
+            raise LiveError(f"no {ack} for {event['type']} within {ACK_TIMEOUT_S}s") from e
+        finally:
+            self._waiters.pop(eid, None)
+
+    # ---- receiving ---------------------------------------------------------
+
+    async def _pump_events(self) -> None:
+        try:
+            async for raw in self._ws:
+                if isinstance(raw, bytes):
+                    continue
+                try:
+                    await self._handle(json.loads(raw))
+                except Exception:
+                    log.exception("event handler failed")
+        except ConnectionClosed as e:
+            log.info("transport closed: %s", e)
+            self._finish("transport_closed")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            log.exception("event pump crashed")
+            self._finish("pump_error")
+        else:
+            self._finish("transport_closed")
+
+    async def _handle(self, ev: dict[str, Any]) -> None:
+        t = ev.get("type")
+        if t not in _QUIET_EVENTS and log.isEnabledFor(logging.DEBUG):
+            log.debug("<- %s", json.dumps(ev)[:1500])
+        if t == "session.output_audio.delta":
+            pcm = base64.b64decode(ev["delta"])
+            if _peak(pcm) >= AUDIBLE_PEAK:
+                self._last_audible_mono = time.monotonic()
+            await self.on_audio(pcm)
+        elif t == "session.output_transcript.delta":
+            self.obs.transcript("assistant", ev.get("delta", ""), ev.get("start_ms", 0), ev.get("end_ms", 0))
+        elif t == "session.input_transcript.delta":
+            self.obs.transcript("user", ev.get("delta", ""), ev.get("start_ms", 0), ev.get("end_ms", 0))
+        elif t == "session.delegation.created":
+            d = ev.get("delegation") or {}
+            self._delegation_for(d.get("id"), d.get("response_id"))
+            self.obs.delegation_created(d, int(ev.get("offset_ms") or 0))
+        elif t == "response.event":
+            await self._responses_event(ev.get("delegation_id"), ev.get("event") or {})
+        elif t == "session.usage.updated":
+            self.usage_seconds = (ev.get("usage") or {}).get("seconds", self.usage_seconds)
+            self.obs.usage(self.usage_seconds, (ev.get("context_window") or {}).get("usage_ratio"))
+        elif t == "session.closed":
+            self.usage_seconds = (ev.get("usage") or {}).get("seconds", self.usage_seconds)
+            self.close_reason = str(ev.get("reason") or "closed")
+            self.obs.closed(self.close_reason, self.usage_seconds)
+            self._finish(self.close_reason)
+        elif t == "error":
+            err = ev.get("error") or {}
+            self.obs.error(err)
+            cid = err.get("client_event_id")
+            fut = self._waiters.get(cid) if cid else None
+            if fut is not None and not fut.done():
+                fut.set_exception(LiveError(f"{err.get('code')}: {err.get('message')}"))
+            else:
+                log.error("live error %s: %s (param=%s)", err.get("code"), err.get("message"), err.get("param"))
+        else:
+            cid = ev.get("client_event_id")
+            fut = self._waiters.get(cid) if cid else None
+            if fut is not None and not fut.done():
+                fut.set_result(ev)
+
+    def _delegation_for(self, delegation_id: str | None, response_id: str | None) -> Delegation:
+        for key in (delegation_id, response_id):
+            if key and key in self._delegations:
+                d = self._delegations[key]
+                d.response_id = response_id or d.response_id
+                d.delegation_id = delegation_id or d.delegation_id
+                break
+        else:
+            if delegation_id is None and response_id is None and self._latest_delegation is not None:
+                return self._latest_delegation
+            d = Delegation(delegation_id=delegation_id, response_id=response_id)
+        for key in (d.delegation_id, d.response_id):
+            if key:
+                self._delegations[key] = d
+        self._latest_delegation = d
+        return d
+
+    async def _responses_event(self, delegation_id: str | None, inner: dict[str, Any]) -> None:
+        it = inner.get("type") or ""
+        if it == "response.created":
+            rid = (inner.get("response") or {}).get("id")
+            self._delegation_for(delegation_id, rid)
+            self.obs.response_created(rid or "", delegation_id)
+        elif it == "response.output_item.done":
+            item = inner.get("item") or {}
+            if item.get("type") == "message":
+                text = " ".join(
+                    c.get("text", "") for c in item.get("content") or [] if isinstance(c, dict)
+                ).strip()
+                d = self._delegation_for(delegation_id, None)
+                if text:
+                    d.said_something = True
+                    self.obs.backend_text(d.response_id, text)
+                return
+            if item.get("type") != "function_call":
+                return
+            if item.get("status") not in (None, "completed"):
+                return
+            call_id = item.get("call_id")
+            if not call_id or call_id in self._answered:
+                return
+            self._answered.add(call_id)
+            d = self._delegation_for(delegation_id, None)
+            try:
+                args = json.loads(item.get("arguments") or "{}")
+            except json.JSONDecodeError:
+                args = {}
+            call = FunctionCall(call_id, item.get("name") or "", args, d.response_id, d.delegation_id)
+            d.pending[call_id] = self._spawn(self._execute(call), name=f"tool-{call.name}")
+        elif it in ("response.completed", "response.incomplete", "response.failed"):
+            resp = inner.get("response") or {}
+            d = self._delegation_for(delegation_id, resp.get("id"))
+            self.obs.response_done(resp, delegation_id)
+            if d.pending or d.said_something:
+                d.said_something = False
+            elif d.after_handoff:
+                log.warning(
+                    "backend returned no text and no calls after handoff (response=%s status=%s "
+                    "output_tokens=%s); live model has nothing to relay",
+                    resp.get("id"), resp.get("status"), (resp.get("usage") or {}).get("output_tokens"),
+                )
+            d.after_handoff = False
+            if it == "response.failed":
+                log.error("backend response failed: %s", resp.get("error"))
+            if d.pending:
+                # Own task: the pump must keep reading, or the acks _continue waits
+                # for (session.updated, *.appended) are never read.
+                self._spawn(self._continue(d), name="gpt-live-continue")
+            elif self._ending.is_set():
+                self._backend_done.set()
+
+    async def _continue(self, d: Delegation) -> None:
+        """All outputs for this response, then one explicit response.create."""
+        pending, d.pending = d.pending, {}
+        results = await asyncio.gather(*pending.values())
+        for call_id, result in zip(pending, results):
+            await self._send(
+                {
+                    "type": "response.item.create",
+                    "event_id": _eid("tool_result"),
+                    "item": {
+                        "type": "function_call_output",
+                        "call_id": call_id,
+                        "output": json.dumps(result),
+                    },
+                }
+            )
+        if self._handoff_target:
+            target, self._handoff_target = self._handoff_target, None
+            d.after_handoff = True
+            try:
+                await self._handoff(target)
+            except LiveError:
+                log.exception("handoff to %s failed; backend keeps stage %s", target, self.stage.name)
+        await self._send({"type": "response.create", "event_id": _eid("continue")})
+        if self._ending.is_set() and not self._hangup_started:
+            self._hangup_started = True
+            self._spawn(self._hang_up_after_farewell(), name="gpt-live-hangup")
+
+    # ---- tools -------------------------------------------------------------
+
+    async def _execute(self, call: FunctionCall) -> dict[str, Any]:
+        tool = self.stage.tool(call.name) or next(
+            (t for st in self.pack.stages.values() for t in st.tools if t.name == call.name), None
+        )
+        self.obs.tool_start(call)
+        log.info("tool %s(%s) stage=%s", call.name, json.dumps(call.arguments), self.stage.name)
+        try:
+            if tool is None:
+                result: dict[str, Any] = {"success": False, "error": f"unknown tool: {call.name}"}
+            elif tool.is_handoff:
+                # Applied in _continue: the service queues session.update behind the
+                # response that is awaiting this call's output, so awaiting the ack
+                # here deadlocks until timeout. Output first, then update, then continue.
+                self._handoff_target = tool.handoff_to or ""
+                # The continuation resumes under the target stage's instructions; say so
+                # in the result so the backend answers the caller's pending request
+                # instead of treating the transfer itself as the outcome.
+                result = {
+                    "success": True,
+                    "to_agent": self._handoff_target,
+                    "note": (
+                        f"Transfer complete. You are now the {self._handoff_target} stage and "
+                        "your instructions have been replaced. The caller is still on the line "
+                        "with the same request; continue it per your new instructions and "
+                        "return what the voice assistant should say next."
+                    ),
+                }
+            elif tool.session:
+                result = {"success": True} if call.name == "end_call" else await self.run_tool(call.name, call.arguments)
+                self._ending.set()
+            else:
+                result = await self.run_tool(call.name, call.arguments)
+        except Exception as e:  # never leave a function call unanswered
+            log.exception("tool %s failed", call.name)
+            result = {"success": False, "error": f"{type(e).__name__}: {e}"}
+        self.obs.tool_end(call, result)
+        return result
+
+    async def _handoff(self, target: str) -> dict[str, Any]:
+        stage = self.pack.stages[target]
+        await self._command(
+            {
+                "type": "session.update",
+                "session": {
+                    "delegation": {
+                        "type": "responses",
+                        "responses": {
+                            "instructions": stage.backend_instructions(self.clock),
+                            "tools": stage.responses_tools(),
+                        },
+                    }
+                },
+            },
+            ack="session.updated",
+        )
+        for chunk in _chunks(stage.handoff_notice()):
+            await self._command(
+                {"type": "session.instructions.append", "delegation_id": None, "content": chunk},
+                ack="session.instructions.appended",
+            )
+        prev, self.stage = self.stage, stage
+        self.obs.handoff(prev.name, target)
+        log.info("handoff %s → %s", prev.name, target)
+        return {"success": True, "to_agent": target}
+
+    async def _hang_up_after_farewell(self) -> None:
+        """end_call → backend finishes its summary turn → live model speaks it → close.
+
+        There is no output-audio-done event, so the spoken part is bounded by audio
+        activity: wait for speech to start (grace), then for it to go quiet.
+        """
+        t0 = time.monotonic()
+        deadline = t0 + END_CALL_MAX_S
+        with contextlib.suppress(asyncio.TimeoutError):
+            await asyncio.wait_for(self._backend_done.wait(), max(0.0, deadline - time.monotonic()))
+        t1 = time.monotonic()
+        while time.monotonic() < deadline and not self._closed.is_set():
+            now = time.monotonic()
+            spoke = self._last_audible_mono >= t0
+            if spoke and now - self._last_audible_mono >= END_CALL_QUIET_S:
+                break
+            if not spoke and now - t1 >= END_CALL_GRACE_S:
+                break
+            await asyncio.sleep(0.1)
+        await self.hang_up("end_call")

--- a/voice-agent-harnesses/openai/gpt-live-1/pack.py
+++ b/voice-agent-harnesses/openai/gpt-live-1/pack.py
@@ -1,0 +1,227 @@
+"""Industry pack → GPT-Live session shapes.
+
+GPT-Live is two models behind one session (guide, "How GPT-Live works"):
+
+  * the **live** model speaks and decides when to delegate. Its prompt is
+    ``session.instructions`` — immutable after ``session.start``, later guidance
+    arrives via ``session.instructions.append`` (≤500 tokens each).
+  * the **backend** Responses model owns tools and business rules. Its prompt and
+    tools live under ``delegation.responses`` and can be swapped wholesale with
+    ``session.update`` mid-call.
+
+A MIVAS pack has one prompt per blueprint agent. Mapping:
+
+  * backend instructions for stage S = S's system prompt verbatim, wrapped in
+    OpenAI's recommended voice header/footer ("Backend prompt and setup").
+    Tools = S's tools only (archive isolation), in Responses function format.
+  * live instructions = the starting stage's prompt verbatim (or the pack's
+    optional ``<stage>.live.md`` FEM prompt when it ships one) + OpenAI's
+    prompting-guide delegation template, filled from the pack's own tool
+    descriptions (no tool names). Nothing pack-specific is authored here.
+  * a handoff = ``session.update`` to the target stage's backend + a short
+    ``session.instructions.append`` role-change notice for the live model.
+
+The harness adds exactly two things the pack cannot know: the wall clock (the
+model has none) and the wire-level rule that the live model never calls tools.
+"""
+
+from __future__ import annotations
+
+import json
+import sys as _sys
+from pathlib import Path as _Path
+
+_runtime = _Path(__file__).resolve().parents[3] / "runtime"
+if _runtime.is_dir() and str(_runtime) not in _sys.path:
+    _sys.path.insert(0, str(_runtime))
+from pack_clock import today_clock_line  # noqa: E402
+import os
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# --- OpenAI's own prompt scaffolding (live-prompting guide), verbatim ---------
+
+BACKEND_HEADER = """## Voice conversation context
+You are helping an assistant in a live voice conversation. Transcripts
+can contain mistakes, unfinished phrases, and later corrections. Use
+the latest context and verified records. If a needed detail is still
+unclear, ask for that detail instead of guessing.
+
+## Task instructions
+"""
+
+BACKEND_FOOTER = """
+## Return the result
+Return a short, clear plain-text answer for the voice assistant.
+Say what happened, whether the task is complete, and what comes next.
+Use confirmed values. Do not invent a successful action.
+Keep raw tool output, JSON, and Markdown out of the spoken summary."""
+
+LIVE_TEMPLATE = """Backchannel policy: Use moderate backchannels. Acknowledge naturally without competing with the main response.
+
+Interruption policy: Stop speaking when the user interrupts. Listen to what they say.
+
+Delegation policy:
+You do not call tools yourself; the backend does. Wherever the instructions above say to call or use a tool, delegate that request to the backend instead.
+Backend tools:
+{capabilities}
+
+Delegate to the backend when:
+- The request needs a backend capability or careful reasoning.
+- A correction changes the work already requested.
+- The instructions above say to call, use, or hand off to a tool.
+
+Do not delegate to the backend when:
+- You can answer from the conversation or a still-current result.
+- You need a brief clarification to understand the request.
+
+Delegate before giving an answer that depends on backend work.
+Do not guess the result while waiting."""
+
+HANDOFF_NOTICE = """Role change: the backend now handles the "{target}" stage of this call.
+Backend tools:
+{capabilities}
+Continue the conversation from where it is. The caller already spoke with the previous stage; do not greet again or restart."""
+
+
+def _first_sentence(text: str, limit: int = 160) -> str:
+    head = text.strip().split("\n", 1)[0]
+    for sep in (". ", "; "):
+        if sep in head:
+            head = head.split(sep, 1)[0] + "."
+            break
+    return head if len(head) <= limit else head[: limit - 1].rstrip() + "…"
+
+
+def today_line(day: date | None = None) -> str:
+    # Pack clock, not wall clock: seeds and deadlines pin the industry TODAY.
+    return today_clock_line(today=day)
+
+
+def industry_path(name: str | Path) -> Path:
+    path = Path(name)
+    if path.is_dir():
+        return path.resolve()
+    env_dir = os.environ.get("INDUSTRY_DIR", "").strip()
+    if env_dir and Path(env_dir).is_dir():
+        return Path(env_dir).resolve()
+    return (REPO_ROOT / "industries" / name).resolve()
+
+
+@dataclass(frozen=True)
+class Tool:
+    name: str
+    description: str
+    parameters: dict[str, Any]
+    handoff_to: str | None = None
+    session: bool = False
+
+    @property
+    def is_handoff(self) -> bool:
+        return self.handoff_to is not None
+
+    def responses_function(self) -> dict[str, Any]:
+        params = dict(self.parameters or {"type": "object"})
+        params.setdefault("type", "object")
+        params.setdefault("properties", {})
+        return {
+            "type": "function",
+            "name": self.name,
+            "description": self.description,
+            "parameters": params,
+        }
+
+
+@dataclass(frozen=True)
+class Stage:
+    name: str
+    prompt: str
+    tools: tuple[Tool, ...]
+    # Optional pack-authored live (FEM) prompt for this stage: system-prompts/<name>.live.md.
+    # When present it replaces the verbatim stage prompt in the live instructions.
+    live_prompt: str | None = None
+
+    def tool(self, name: str) -> Tool | None:
+        return next((t for t in self.tools if t.name == name), None)
+
+    def capabilities(self) -> str:
+        """One capability per tool, described in the pack's own words. No tool names:
+        OpenAI's prompting guide and FEM/BEM skill keep names and schemas out of
+        the live prompt; it only needs to know what the backend can do."""
+        return "\n".join(f"- {_first_sentence(t.description)}" for t in self.tools) or "- (none)"
+
+    def backend_instructions(self, clock: str) -> str:
+        return f"{BACKEND_HEADER}{self.prompt.strip()}\n\n{clock}\n{BACKEND_FOOTER}"
+
+    def responses_tools(self) -> list[dict[str, Any]]:
+        return [t.responses_function() for t in self.tools]
+
+    def handoff_notice(self) -> str:
+        return HANDOFF_NOTICE.format(target=self.name, capabilities=self.capabilities())
+
+
+@dataclass(frozen=True)
+class Pack:
+    industry: str
+    start: str
+    greeting: str
+    stages: dict[str, Stage] = field(default_factory=dict)
+
+    def live_instructions(self, clock: str) -> str:
+        start = self.stages[self.start]
+        template = LIVE_TEMPLATE.format(capabilities=start.capabilities())
+        return f"{(start.live_prompt or start.prompt).strip()}\n\n{template}\n\n{clock}"
+
+    def speak_first_prompt(self) -> str:
+        # Delivered as session.instructions.append, which the guide says is the
+        # channel for wording that must be said as written.
+        text = (
+            "The call has just connected and the caller has not spoken yet. "
+            "Greet the caller in English now, without waiting for them to speak, "
+            "then pause and listen."
+        )
+        if self.greeting:
+            text += f"\n\nSay this welcome verbatim: {self.greeting}"
+        return text
+
+
+def load_pack(industry: str | Path) -> Pack:
+    industry_dir = industry_path(industry)
+    blueprint = json.loads((industry_dir / "agent_blueprint.json").read_text())
+    catalog = {
+        t["name"]: t for t in json.loads((industry_dir / "tools.json").read_text())["tools"]
+    }
+    stages: dict[str, Stage] = {}
+    for entry in blueprint["agents"]:
+        tools: list[Tool] = []
+        for ref in entry["tools"]:
+            spec = catalog.get(ref["name"])
+            if spec is None:
+                raise KeyError(f"{industry_dir.name}: tool {ref['name']!r} missing from tools.json")
+            tools.append(
+                Tool(
+                    name=spec["name"],
+                    description=spec.get("description", spec["name"]),
+                    parameters=spec.get("inputSchema") or {"type": "object"},
+                    handoff_to=ref.get("handoff_to") if ref.get("handoff") else None,
+                    session=bool(ref.get("session")),
+                )
+            )
+        prompt_path = industry_dir / entry["system_prompt"]
+        live_path = prompt_path.with_suffix(".live.md")
+        stages[entry["name"]] = Stage(
+            name=entry["name"],
+            prompt=prompt_path.read_text(),
+            tools=tuple(tools),
+            live_prompt=live_path.read_text() if live_path.is_file() else None,
+        )
+    return Pack(
+        industry=industry_dir.name,
+        start=blueprint["agents"][0]["name"],
+        greeting=str(blueprint.get("greeting") or "").strip(),
+        stages=stages,
+    )

--- a/voice-agent-harnesses/openai/gpt-live-1/requirements.txt
+++ b/voice-agent-harnesses/openai/gpt-live-1/requirements.txt
@@ -1,0 +1,7 @@
+# Docker deps for this runtime (`uv pip install -r`). Local root uses `uv sync`.
+websockets>=14.0
+httpx>=0.27.0
+opentelemetry-api>=1.27.0
+opentelemetry-sdk>=1.27.0
+opentelemetry-exporter-otlp-proto-http>=1.27.0
+boto3>=1.35.0

--- a/voice-agent-harnesses/openai/gpt-live-1/test_gpt_live.py
+++ b/voice-agent-harnesses/openai/gpt-live-1/test_gpt_live.py
@@ -61,14 +61,17 @@ def _completed(rid: str, delegation="item_1") -> dict:
 
 
 async def _ack_commands(live: LiveSession, ws: FakeWS, ack_for: dict[str, str]) -> None:
-    """Acknowledge every pending command the way the server would."""
+    """Acknowledge the listed pending commands the way the server would. Anything
+    not listed (the fire-and-forget appends) is left unanswered on purpose."""
     for _ in range(50):
         await asyncio.sleep(0)
         for eid, fut in list(live._waiters.items()):
             if fut.done():
                 continue
             sent = next(e for e in ws.sent if e.get("event_id") == eid)
-            await live._handle({"type": ack_for[sent["type"]], "client_event_id": eid, "session": {}})
+            ack = ack_for.get(sent["type"])
+            if ack:
+                await live._handle({"type": ack, "client_event_id": eid, "session": {}})
 
 
 def test_session_start_shape() -> None:
@@ -113,10 +116,7 @@ def test_handoff_answers_call_then_swaps_backend_then_continues() -> None:
     async def go() -> None:
         live, ws = _session([])
         await live._handle(_fc("call_h", "handoff_to_scheduler", {}))
-        acks = asyncio.create_task(_ack_commands(live, ws, {
-            "session.update": "session.updated",
-            "session.instructions.append": "session.instructions.appended",
-        }))
+        acks = asyncio.create_task(_ack_commands(live, ws, {"session.update": "session.updated"}))
         await live._handle(_completed("resp_h"))
         await acks
         await live.drain()
@@ -158,12 +158,13 @@ def test_end_call_closes_after_grace(monkeypatch: pytest.MonkeyPatch) -> None:
     asyncio.run(go())
 
 
-def test_speak_first_uses_instructions_append() -> None:
+def test_speak_first_appends_instructions_without_awaiting_the_report() -> None:
+    """session.instructions.appended only fires once caller audio advances the
+    timeline, so the greeting must not block on it."""
+
     async def go() -> None:
         live, ws = _session([])
-        task = asyncio.create_task(live.speak_first())
-        await _ack_commands(live, ws, {"session.instructions.append": "session.instructions.appended"})
-        await task
+        await asyncio.wait_for(live.speak_first(), 0.5)  # no ack is ever delivered
         sent = ws.of("session.instructions.append")
         assert sent and not ws.of("session.commentary.append")
         assert all(e["delegation_id"] is None for e in sent)

--- a/voice-agent-harnesses/openai/gpt-live-1/test_gpt_live.py
+++ b/voice-agent-harnesses/openai/gpt-live-1/test_gpt_live.py
@@ -1,0 +1,196 @@
+"""Wire-level checks for the GPT-Live client against a fake socket (no network)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import live as live_mod  # noqa: E402
+from live import LiveSession  # noqa: E402
+from pack import REPO_ROOT, load_pack  # noqa: E402
+
+CONTROL = REPO_ROOT / "industries" / "control-industry"
+
+
+class FakeWS:
+    def __init__(self) -> None:
+        self.sent: list[dict] = []
+
+    async def send(self, raw: str) -> None:
+        self.sent.append(json.loads(raw))
+
+    async def close(self) -> None: ...
+
+    def of(self, kind: str) -> list[dict]:
+        return [e for e in self.sent if e["type"] == kind]
+
+
+def _session(tool_log: list) -> tuple[LiveSession, FakeWS]:
+    async def audio(_: bytes) -> None: ...
+
+    async def run_tool(name: str, args: dict) -> dict:
+        tool_log.append((name, args))
+        return {"success": True, "date": args.get("date")}
+
+    live = LiveSession(load_pack(CONTROL), api_key="k", on_audio=audio, run_tool=run_tool)
+    ws = FakeWS()
+    live._ws = ws
+    return live, ws
+
+
+def _fc(call_id: str, name: str, args: dict, delegation="item_1") -> dict:
+    return {
+        "type": "response.event",
+        "delegation_id": delegation,
+        "event": {
+            "type": "response.output_item.done",
+            "item": {"type": "function_call", "status": "completed", "call_id": call_id,
+                     "name": name, "arguments": json.dumps(args)},
+        },
+    }
+
+
+def _completed(rid: str, delegation="item_1") -> dict:
+    return {"type": "response.event", "delegation_id": delegation,
+            "event": {"type": "response.completed", "response": {"id": rid, "usage": {"input_tokens": 3, "output_tokens": 2}}}}
+
+
+async def _ack_commands(live: LiveSession, ws: FakeWS, ack_for: dict[str, str]) -> None:
+    """Acknowledge every pending command the way the server would."""
+    for _ in range(50):
+        await asyncio.sleep(0)
+        for eid, fut in list(live._waiters.items()):
+            if fut.done():
+                continue
+            sent = next(e for e in ws.sent if e.get("event_id") == eid)
+            await live._handle({"type": ack_for[sent["type"]], "client_event_id": eid, "session": {}})
+
+
+def test_session_start_shape() -> None:
+    live, _ = _session([])
+    cfg = live.session_config()
+    assert cfg["model"] == "gpt-live-1"
+    assert cfg["audio"]["format"] == {"type": "audio/pcm", "rate": 16000}
+    assert cfg["audio"]["output"]["voice"] == live_mod.VOICE
+    tools = {t["name"]: t for t in cfg["delegation"]["responses"]["tools"]}
+    assert set(tools) == {"handoff_to_scheduler", "end_call"}  # receptionist only
+    assert tools["end_call"]["type"] == "function" and "parameters" in tools["end_call"]
+    assert "Delegation policy" in cfg["instructions"]
+    tail = cfg["instructions"].split("Backend tools:", 1)[1]
+    assert "handoff_to_scheduler" not in tail and "end_call" not in tail  # capabilities, not tool names
+    assert "Today is" in cfg["delegation"]["responses"]["instructions"]
+
+
+def test_function_call_then_completed_submits_output_and_continues() -> None:
+    log: list = []
+
+    async def go() -> None:
+        live, ws = _session(log)
+        await live._handle({"type": "response.event", "delegation_id": "item_1",
+                            "event": {"type": "response.created", "response": {"id": "resp_1"}}})
+        # arrive at the scheduler stage first so schedule_appointment is a known tool
+        live.stage = live.pack.stages["scheduler"]
+        await live._handle(_fc("call_1", "schedule_appointment", {"date": "09/08/2026"}))
+        await live._handle(_fc("call_1", "schedule_appointment", {"date": "09/08/2026"}))  # duplicate
+        await live._handle(_completed("resp_1"))
+        await live.drain()
+        outputs = ws.of("response.item.create")
+        assert len(outputs) == 1 and outputs[0]["item"]["call_id"] == "call_1"
+        assert json.loads(outputs[0]["item"]["output"]) == {"success": True, "date": "09/08/2026"}
+        assert len(ws.of("response.create")) == 1
+        assert ws.sent.index(outputs[0]) < ws.sent.index(ws.of("response.create")[0])
+        assert log == [("schedule_appointment", {"date": "09/08/2026"})]
+
+    asyncio.run(go())
+
+
+def test_handoff_answers_call_then_swaps_backend_then_continues() -> None:
+    async def go() -> None:
+        live, ws = _session([])
+        await live._handle(_fc("call_h", "handoff_to_scheduler", {}))
+        acks = asyncio.create_task(_ack_commands(live, ws, {
+            "session.update": "session.updated",
+            "session.instructions.append": "session.instructions.appended",
+        }))
+        await live._handle(_completed("resp_h"))
+        await acks
+        await live.drain()
+        upd = ws.of("session.update")
+        assert len(upd) == 1
+        resp = upd[0]["session"]["delegation"]["responses"]
+        assert {t["name"] for t in resp["tools"]} == {"schedule_appointment", "end_call"}
+        assert "scheduler" in resp["instructions"].lower()
+        notice = ws.of("session.instructions.append")
+        assert notice and notice[0]["delegation_id"] is None
+        assert "scheduler" in notice[0]["content"]
+        # output first (the service queues session.update behind the pending call), then update, notice, continue
+        out_i = ws.sent.index(ws.of("response.item.create")[0])
+        assert out_i < ws.sent.index(upd[0]) < ws.sent.index(notice[0]) < ws.sent.index(ws.of("response.create")[0])
+        assert live.stage.name == "scheduler"
+        out = json.loads(ws.of("response.item.create")[0]["item"]["output"])
+        assert out["success"] is True and out["to_agent"] == "scheduler" and "scheduler" in out["note"]
+
+    asyncio.run(go())
+
+
+def test_end_call_closes_after_grace(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(live_mod, "END_CALL_GRACE_S", 0.2)
+    monkeypatch.setattr(live_mod, "CLOSED_TIMEOUT_S", 0.2)
+
+    async def go() -> None:
+        live, ws = _session([])
+        await live._handle(_fc("call_e", "end_call", {"reason": "done"}))
+        await live._handle(_completed("resp_e"))
+        await asyncio.sleep(0.05)
+        assert ws.of("response.item.create")  # end_call is answered, never POSTed
+        assert not ws.of("session.close"), "must wait for the backend's summary turn"
+        await live._handle(_completed("resp_e2"))  # backend summary, no function calls
+        await asyncio.sleep(0.5)
+        assert ws.of("session.close"), "no session.close after end_call"
+        await live._handle({"type": "session.closed", "reason": "client_request", "usage": {"seconds": 4.2}})
+        assert live.close_reason == "client_request" and live.usage_seconds == 4.2
+
+    asyncio.run(go())
+
+
+def test_speak_first_uses_instructions_append() -> None:
+    async def go() -> None:
+        live, ws = _session([])
+        task = asyncio.create_task(live.speak_first())
+        await _ack_commands(live, ws, {"session.instructions.append": "session.instructions.appended"})
+        await task
+        sent = ws.of("session.instructions.append")
+        assert sent and not ws.of("session.commentary.append")
+        assert all(e["delegation_id"] is None for e in sent)
+        content = "".join(e["content"] for e in sent)
+        assert "without waiting" in content
+        if live.pack.greeting:
+            assert live.pack.greeting in content
+
+    asyncio.run(go())
+
+
+def test_error_correlates_to_command() -> None:
+    async def go() -> None:
+        live, ws = _session([])
+        task = asyncio.create_task(live._command({"type": "session.instructions.append", "delegation_id": None, "content": "hi"}, ack="session.instructions.appended"))
+        await asyncio.sleep(0)
+        eid = ws.sent[-1]["event_id"]
+        await live._handle({"type": "error", "error": {"code": "bad", "message": "nope", "client_event_id": eid}})
+        with pytest.raises(live_mod.LiveError, match="bad"):
+            await task
+
+    asyncio.run(go())
+
+
+def test_append_chunks_respect_cap() -> None:
+    text = "\n".join(f"line {i} " + "x" * 80 for i in range(60))
+    chunks = live_mod._chunks(text)
+    assert "".join(chunks) == text
+    assert all(len(c) <= live_mod.APPEND_MAX_CHARS for c in chunks)
+

--- a/voice-agent-harnesses/openai/gpt-live-1/tools.py
+++ b/voice-agent-harnesses/openai/gpt-live-1/tools.py
@@ -1,0 +1,39 @@
+"""Industry tool dispatch: POST {TOOL_SERVER_URL}/tools/{name} with the call id header.
+
+Handoffs and ``end_call`` never reach the tool server (see live.py). Every other
+blueprint tool, including human-transfer session tools, is a dumb-pipe POST and
+the server's JSON envelope is returned to the backend model verbatim.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+for _root in (Path("/app"), *Path(__file__).resolve().parents):
+    _runtime = _root / "runtime"
+    if (_runtime / "call_id.py").is_file():
+        if str(_runtime) not in sys.path:
+            sys.path.insert(0, str(_runtime))
+        break
+from call_id import call_session, headers as call_headers, set_call_id  # noqa: E402,F401
+
+TOOL_SERVER_URL = os.environ.get("TOOL_SERVER_URL", "http://127.0.0.1:8000").rstrip("/")
+
+
+async def run_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        resp = await client.post(
+            f"{TOOL_SERVER_URL}/tools/{name}",
+            json={"arguments": arguments},
+            headers=call_headers(),
+        )
+    try:
+        body = resp.json()
+    except ValueError:
+        body = {"success": False, "error": f"tool server {resp.status_code}: {resp.text[:200]}"}
+    return body if isinstance(body, dict) else {"result": body}

--- a/voice-agent-harnesses/openai/gpt-live-1/tracing.py
+++ b/voice-agent-harnesses/openai/gpt-live-1/tracing.py
@@ -1,0 +1,299 @@
+"""GPT-Live session → Bluejay OTel ``voice.call`` trace.
+
+  voice.call (SERVER)                      bluejay.simulation_result_id, gen_ai.*
+    ├── customer.speech / agent.speech     transcript fragments grouped by gap
+    ├── chat <backend model> (CLIENT)      one per delegated Responses invocation,
+    │                                      gen_ai.usage.* from response.completed
+    └── execute_tool <name>                every backend function call, incl.
+                                           handoffs and end_call (Bluejay reads these)
+
+After the call: force_flush, settle, then one ``update-simulation-result`` POST
+with ``trace_ids`` so Bluejay extracts tool actuals from the spans.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+from typing import Any
+
+import httpx
+from opentelemetry import trace as otel
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.trace import Span, SpanKind, Status, StatusCode
+
+from live import FunctionCall, Observer
+
+log = logging.getLogger("mivas.gpt-live.otel")
+
+OTLP_ENDPOINT = os.environ.get("BLUEJAY_OTLP_ENDPOINT") or "https://otlp.getbluejay.ai/v1/traces"
+API_URL = (os.environ.get("BLUEJAY_API_URL") or "https://api.getbluejay.ai/v1").rstrip("/")
+SERVICE = os.environ.get("BLUEJAY_SERVICE_NAME", "mivas-openai-gpt-live")
+SETTLE_S = float(os.environ.get("MIVAS_UPSERT_SETTLE_SECONDS", "10"))
+# Transcript fragments from one speaker closer than this are one utterance
+# (guide "Estimate conversation turns": start at 1.5 s and tune).
+UTTERANCE_GAP_MS = int(os.environ.get("GPT_LIVE_UTTERANCE_GAP_MS", "1500"))
+_MAX_ATTR = 4000
+
+_provider: TracerProvider | None = None
+
+
+def api_key() -> str | None:
+    return os.environ.get("BLUEJAY_API_KEY") or None
+
+
+def provider() -> TracerProvider | None:
+    global _provider
+    key = api_key()
+    if not key:
+        return None
+    if _provider is None:
+        p = TracerProvider(resource=Resource.create({SERVICE_NAME: SERVICE}))
+        p.add_span_processor(
+            BatchSpanProcessor(
+                OTLPSpanExporter(OTLP_ENDPOINT, headers={"X-API-KEY": key}),
+                max_queue_size=int(os.environ.get("MIVAS_OTEL_QUEUE", "32768")),
+                max_export_batch_size=512,
+                schedule_delay_millis=1000,
+            )
+        )
+        otel.set_tracer_provider(p)
+        _provider = p
+        log.info("otel → %s service=%s", OTLP_ENDPOINT, SERVICE)
+    return _provider
+
+
+def cur_start(span: Span) -> int:
+    attrs = getattr(span, "attributes", None) or {}
+    return int(attrs.get("mivas.start_ms", 0))
+
+
+def _clip(v: Any) -> str:
+    s = v if isinstance(v, str) else json.dumps(v, default=str)
+    return s if len(s) <= _MAX_ATTR else s[: _MAX_ATTR - 3] + "..."
+
+
+class Tracer(Observer):
+    """One instance per call. ``open()`` before the session, ``close()`` after."""
+
+    def __init__(self, simulation_result_id: str | None, *, model: str, backend_model: str) -> None:
+        self.sim_id = simulation_result_id
+        self.model = model
+        self.backend_model = backend_model
+        self._tracer = otel.get_tracer("mivas.openai.gpt-live")
+        self.root: Span | None = None
+        self.trace_id: str | None = None
+        self._t0_ns = time.time_ns()  # session timeline zero ≈ session.started
+        self._utt: dict[str, tuple[Span, list[str], int]] = {}  # role → (span, text, end_ms)
+        self._tools: dict[str, Span] = {}
+        self._chats: dict[str, Span] = {}
+        self._backend_tokens = {"in": 0, "out": 0}
+
+    # ---- lifecycle ---------------------------------------------------------
+
+    def open(self) -> None:
+        attrs = {
+            "gen_ai.operation.name": "voice.call",
+            "gen_ai.system": "openai",
+            "gen_ai.request.model": self.model,
+            "mivas.backend.model": self.backend_model,
+        }
+        if self.sim_id:
+            attrs["bluejay.simulation_result_id"] = self.sim_id
+        self.root = self._tracer.start_span("voice.call", kind=SpanKind.SERVER, attributes=attrs)
+        ctx = self.root.get_span_context()
+        if ctx.is_valid:
+            self.trace_id = format(ctx.trace_id, "032x")
+        log.info("trace_id=%s sim=%s", self.trace_id, self.sim_id)
+
+    def close(self) -> None:
+        for role in list(self._utt):
+            self._end_utterance(role)
+        for span in list(self._tools.values()) + list(self._chats.values()):
+            span.set_status(Status(StatusCode.OK))
+            span.end()
+        self._tools.clear()
+        self._chats.clear()
+        if self.root is not None:
+            self.root.set_attribute("gen_ai.usage.input_tokens", self._backend_tokens["in"])
+            self.root.set_attribute("gen_ai.usage.output_tokens", self._backend_tokens["out"])
+            self.root.set_status(Status(StatusCode.OK))
+            self.root.end()
+
+    def _ctx(self):
+        return otel.set_span_in_context(self.root) if self.root is not None else None
+
+    def _wall_ns(self, session_ms: int) -> int:
+        return self._t0_ns + int(session_ms) * 1_000_000
+
+    # ---- Observer ----------------------------------------------------------
+
+    def session_started(self, session: dict[str, Any]) -> None:
+        self._t0_ns = time.time_ns()
+        if self.root is not None and session.get("id"):
+            self.root.set_attribute("gen_ai.session.id", str(session["id"]))
+
+    def transcript(self, role: str, delta: str, start_ms: int, end_ms: int) -> None:
+        if not delta:
+            return
+        cur = self._utt.get(role)
+        if cur is not None and start_ms - cur[2] > UTTERANCE_GAP_MS:
+            self._end_utterance(role)
+            cur = None
+        if cur is None:
+            name = "customer.speech" if role == "user" else "agent.speech"
+            span = self._tracer.start_span(
+                name,
+                context=self._ctx(),
+                kind=SpanKind.INTERNAL,
+                start_time=self._wall_ns(start_ms),
+                attributes={"mivas.role": role, "mivas.start_ms": start_ms},
+            )
+            cur = (span, [], end_ms)
+        span, parts, _ = cur
+        parts.append(delta)
+        self._utt[role] = (span, parts, max(end_ms, cur[2]))
+
+    def _end_utterance(self, role: str) -> None:
+        cur = self._utt.pop(role, None)
+        if cur is None:
+            return
+        span, parts, end_ms = cur
+        text = "".join(parts).strip()
+        log.info("%s [%d-%dms] %s", "CALLER" if role == "user" else "AGENT ", cur_start(span), end_ms, text)
+        span.set_attribute("mivas.transcript", _clip(text))
+        span.set_attribute("mivas.end_ms", end_ms)
+        span.set_status(Status(StatusCode.OK))
+        span.end(end_time=self._wall_ns(end_ms))
+
+    def response_created(self, response_id: str, delegation_id: str | None) -> None:
+        if not response_id or response_id in self._chats:
+            return
+        attrs: dict[str, Any] = {
+            "gen_ai.operation.name": "chat",
+            "gen_ai.system": "openai",
+            "gen_ai.request.model": self.backend_model,
+            "gen_ai.response.id": response_id,
+        }
+        if delegation_id:
+            attrs["mivas.delegation_id"] = delegation_id
+        self._chats[response_id] = self._tracer.start_span(
+            f"chat {self.backend_model}", context=self._ctx(), kind=SpanKind.CLIENT, attributes=attrs
+        )
+
+    def backend_text(self, response_id: str | None, text: str) -> None:
+        log.info("BACKEND [%s] %s", response_id, text)
+        span = self._chats.get(response_id or "")
+        if span is not None:
+            span.set_attribute("gen_ai.output.messages", _clip([{"role": "assistant", "content": text}]))
+
+    def response_done(self, response: dict[str, Any], delegation_id: str | None) -> None:
+        rid = response.get("id") or ""
+        span = self._chats.pop(rid, None)
+        if span is None:
+            return
+        usage = response.get("usage") or {}
+        for key, path in (
+            ("gen_ai.usage.input_tokens", ("input_tokens",)),
+            ("gen_ai.usage.output_tokens", ("output_tokens",)),
+            ("gen_ai.usage.total_tokens", ("total_tokens",)),
+            ("gen_ai.usage.cached_tokens", ("input_tokens_details", "cached_tokens")),
+            ("gen_ai.usage.output_reasoning_tokens", ("output_tokens_details", "reasoning_tokens")),
+        ):
+            v: Any = usage
+            for k in path:
+                v = v.get(k) if isinstance(v, dict) else None
+            if isinstance(v, int):
+                span.set_attribute(key, v)
+        self._backend_tokens["in"] += int(usage.get("input_tokens") or 0)
+        self._backend_tokens["out"] += int(usage.get("output_tokens") or 0)
+        if response.get("model"):
+            span.set_attribute("gen_ai.response.model", str(response["model"]))
+        status = response.get("status")
+        if status == "failed":
+            span.set_status(Status(StatusCode.ERROR, _clip(response.get("error") or "failed")))
+        else:
+            span.set_status(Status(StatusCode.OK))
+        span.end()
+
+    def tool_start(self, call: FunctionCall) -> None:
+        attrs: dict[str, Any] = {
+            "gen_ai.operation.name": "execute_tool",
+            "gen_ai.tool.name": call.name,
+            "gen_ai.tool.call.arguments": _clip(call.arguments),
+            "mivas.tool.call_id": call.call_id,
+        }
+        if call.response_id:
+            attrs["gen_ai.response.id"] = call.response_id
+        self._tools[call.call_id] = self._tracer.start_span(
+            f"execute_tool {call.name}", context=self._ctx(), kind=SpanKind.INTERNAL, attributes=attrs
+        )
+
+    def tool_end(self, call: FunctionCall, result: dict[str, Any]) -> None:
+        span = self._tools.pop(call.call_id, None)
+        if span is None:
+            return
+        span.set_attribute("gen_ai.tool.call.result", _clip(result))
+        ok = result.get("success", result.get("ok", True)) is not False
+        span.set_status(Status(StatusCode.OK) if ok else Status(StatusCode.ERROR, _clip(result.get("error") or "")))
+        span.end()
+
+    def handoff(self, from_stage: str, to_stage: str) -> None:
+        if self.root is not None:
+            self.root.add_event("handoff", {"from": from_stage, "to": to_stage})
+
+    def usage(self, seconds: float | None, usage_ratio: float | None) -> None:
+        if self.root is None:
+            return
+        if seconds is not None:
+            self.root.set_attribute("mivas.live.usage_seconds", float(seconds))
+        if usage_ratio is not None:
+            self.root.set_attribute("mivas.live.context_usage_ratio", float(usage_ratio))
+
+    def error(self, error: dict[str, Any]) -> None:
+        if self.root is not None:
+            self.root.add_event("live.error", {k: _clip(v) for k, v in error.items() if v is not None})
+
+    def closed(self, reason: str, usage_seconds: float | None) -> None:
+        if self.root is not None:
+            self.root.set_attribute("mivas.close_reason", reason)
+            if usage_seconds is not None:
+                self.root.set_attribute("mivas.live.usage_seconds", float(usage_seconds))
+
+
+# ---- Bluejay link -----------------------------------------------------------
+
+async def post_trace_ids(simulation_result_id: str, trace_id: str) -> None:
+    """Link once, after flush + settle. Relinking re-extracts spans and doubles tool rows."""
+    key = api_key()
+    if not key:
+        return
+    if _provider is not None:
+        _provider.force_flush()
+    await asyncio.sleep(SETTLE_S)
+    body = {"simulation_result_id": str(simulation_result_id), "trace_ids": [trace_id]}
+    async with httpx.AsyncClient(timeout=20) as client:
+        for attempt in range(4):
+            try:
+                r = await client.post(
+                    f"{API_URL}/update-simulation-result",
+                    json=body,
+                    headers={"X-API-Key": key, "Content-Type": "application/json"},
+                )
+            except httpx.TransportError as e:
+                log.warning("update-simulation-result transport error (%s/4): %s", attempt + 1, e)
+                await asyncio.sleep(2**attempt)
+                continue
+            if r.status_code < 400:
+                log.info("update-simulation-result ok sim=%s trace=%s", simulation_result_id, trace_id)
+                return
+            if r.status_code not in (429, 500, 502, 503, 504):
+                break
+            await asyncio.sleep(2**attempt)
+        log.error("update-simulation-result FAILED %s %s", r.status_code, r.text[:300])

--- a/voice-agent-harnesses/s2s-model-pricing.json
+++ b/voice-agent-harnesses/s2s-model-pricing.json
@@ -39,6 +39,8 @@
   "_note_grok_text_input": "xAI also charges $0.004 per text input on top of the audio minute (https://docs.x.ai/docs/models). Not modelled — the grok harness emits no text-input count. Understates grok by a few tenths of a cent per call.",
   "per_minute_pricing": {
     "_note_": "grok-voice-latest is an alias of grok-voice-think-fast-2.0 (verified 2026-08-22, https://docs.x.ai/docs/models: '$0.08 / min ($4.80 / hr) audio'). xAI meters the speech-to-speech model as ONE per-minute charge, not as separate STT/LLM/TTS legs — grok-stt ($0.10/hr REST, $0.20/hr streaming) and grok-tts ($15.00/1M chars) are separate products that a cascaded pipeline would pay for instead. Duration minutes are the right billing basis. Add $0.01/min if xAI PSTN telephony is used (we use CHIRP, so no).",
+    "_note_gpt-live-1": "GPT-Live meters the voice session per minute, billed per second ($0.05/min, https://developers.openai.com/api/docs/models/gpt-live-1, checked 2026-09-10). The backend Responses model is billed separately on its own tokens — price those from the chat spans, not from this row.",
+    "gpt-live-1":                    0.05,
     "grok-voice-latest":             0.08,
     "grok-voice-think-fast-2.0":     0.08,
     "grok-voice-think-fast-1.0":     0.05


### PR DESCRIPTION
Adds `voice-agent-harnesses/openai/gpt-live-1/`, a self-contained runtime for OpenAI's GPT-Live 1, now GA in the API. It shares nothing with `openai/harness.py` / `report.py` — those are Realtime-API harnesses and GPT-Live is a different product and wire contract.

Same two-model shape the product describes: the live model speaks and decides when to delegate, a Responses backend owns the industry pack's tools and business rules, and a multi-agent pack is a soft handoff on the one session (`session.update` swaps `delegation.responses`, an instructions append tells the live model its role changed). Only the current stage's tools are ever registered.

## Contract

Built against `guides/voice-websockets?api=live`, `guides/live-delegation`, `guides/live-conversations`, `guides/live-prompting`, and `models/gpt-live-1`.

- `wss://api.openai.com/v1/live/sessions`, `Authorization` and nothing else
- `session.start` with the model in `session.model`, then wait for `session.started`
- `audio.format` is `{audio/pcm, 16000}`. 24 kHz is the documented default, but 16 kHz is supported and is what Bluejay's CHIRP transport carries, so audio passes through byte-for-byte in both directions — no resampling, no gating, no mute. The model is full duplex and owns barge-in.
- the live prompt carries capability descriptions, never tool names or schemas, per the prompting guide
- `end_call` is answered locally, the backend finishes its summary turn, the live model speaks it, and the harness closes once that audio goes quiet

## Two findings worth calling out

**`*.appended` is not a protocol acknowledgment.** It reports where injected text landed on the conversation timeline (`start_ms`/`end_ms`) and only fires once the timeline reaches that point, which requires caller audio to be flowing. The speak-first append happens before any caller audio exists, so awaiting it hung every call for the full ack timeout and the session then died with `server_error / context_injection_incomplete`. Measured against `gpt-live-1`:

| event | no audio flowing | audio flowing |
| --- | --- | --- |
| `session.instructions.append` | no report; `context_injection_incomplete` at close | `session.instructions.appended {start_ms: 600, end_ms: 800}` ~0.7 s later |
| `session.update` | `session.updated` in ~50 ms | `session.updated` in ~50 ms |

Appends are now sent and not awaited, ordered on the wire ahead of the `response.create` that follows, with a background task that logs if the service rejects one. `session.update` keeps its blocking ack.

**Entrypoint model default.** The shared `runtime/entrypoint.sh` passes `--model $OPENAI_REALTIME_MODEL` for every `openai` runtime and exits when it is empty, so the pod crash-looped. `gpt-live-1` now gets its default in the same case block as the realtime runtimes rather than through a second variable.

## Verification

Offline: `agent.py --check` builds every session shape for control-industry; 7 wire-level tests against a fake socket cover the session shape, the tool loop, the handoff ordering, the `end_call` close, error correlation, append chunking, and the fire-and-forget greeting.

Live, against the real API: `session.started` in 0.51 s, greeting audio at 1.18 s, graceful close reporting usage seconds.

End to end on Kubernetes, healthcare pack, six task digital humans over Bluejay CHIRP — 6/6 goal success, no warnings and no errors in any pod:

| turns | tool calls recovered from traces | p50 agent latency | close reason |
| --- | --- | --- | --- |
| 10 | 0 (none expected) | 1340 ms | close_requested |
| 12 | 4 | 1260 ms | close_requested |
| 12 | 7 | 1340 ms | close_requested |
| 43 | 10 | 1290 ms | close_requested |
| 37 | 7 | 1310 ms | close_requested |
| 46 | 12 | 1460 ms | close_requested |

The 46-turn case is the eleven-tool cosmetic consult; every expected tool appears in the trace, including `book_cosmetic_consult`, `offer_financing`, and `send_payment_link`, so the OTel `execute_tool` spans are reaching Bluejay as tool actuals.

Provider stream gaps were logged per call rather than smoothed: 1-4 gaps over 250 ms per call, 549 ms maximum, and mid-speech gaps on only one call. Consistent with the gaps being the model pausing while it waits on the backend rather than transport jitter, which is why there is no playout buffer here.

## Not in this PR

Only the healthcare pack is deployed. No scored suite yet, so the README marks GPT-Live 1 as landed but outside the eight-runtime Pass^5 matrix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the self-contained OpenAI GPT-Live 1 harness (`voice-agent-harnesses/openai/gpt-live-1/`) for the GA API, using a two-model delegation pattern (live model + Responses backend) and passing 16 kHz PCM audio through CHIRP byte-for-byte. Also fixes the entrypoint model default so the pod no longer crash-loops, and updates the runtime table, pricing, and Dockerfile count.

**Implementation notes**
- `session.instructions.append` is sent without awaiting its report because `.appended` only fires once caller audio flows; awaiting it stalls the greeting. `session.update` remains a blocking ack.
- Handoffs swap the backend stage with `session.update` plus an instructions append; only the current stage's tools are registered.
- `end_call` is handled locally, the backend finishes its summary turn, and the session closes after the farewell audio goes quiet.

<sup>Written for commit 6b89f02987640afd2a7679051dbe2e6fa54b7176. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/56?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

