### PR TITLE
Add the mivas-run skill; cluster-agnostic deployment

### DIFF
--- a/.claude/skills/mivas-run/BLUEJAY.md
+++ b/.claude/skills/mivas-run/BLUEJAY.md
@@ -1,0 +1,81 @@
+# Bluejay from the consumer side
+
+Base URL `https://api.getbluejay.ai/v1` (`BLUEJAY_API_URL` overrides). Auth header
+`X-API-Key: $BLUEJAY_API_KEY`. Public reference: https://docs.getbluejay.ai/api-reference/introduction.
+The app is `https://app.getbluejay.ai`; a run lives at `/simulations/{sim}/runs/{run}`.
+
+## Objects
+
+| Object | Meaning here |
+|---|---|
+| Agent | the system under test: `connection_type=WEBSOCKET`, `websocket_url=wss://…`, `websocket_username/password` = CHIRP basic auth. Scripts key it by `external_agent_id=mivas:<slug>`. |
+| Simulation | settings for a batch: `max_call_duration`, `max_concurrent`, `runs_per_digital_human`. Smoke: 4 min, concurrency 1. Full: 8 min. |
+| Digital human | one test case: `intent`, `traits`, `expected_tool_calls`, `success_criteria`, `scripted_responses`, `speaks_first_config`. Generated from `industries/<I>/tasks/*/task.json` by `scripts/tasks_to_digital_humans.py`. |
+| Run / result | one queue = one run; one result per conversation. `retrieve-simulation-result/{id}` carries `status`, `transcript_url`, `tool_calls[].actual`, `trace_ids`, `metrics[]`, `goal_success`. |
+
+## Endpoints the scripts call
+
+| Call | Path |
+|---|---|
+| find agent | `GET agent-by-external-id/{external_id}` |
+| create / repoint agent | `POST add-agent` · `POST update-agent {agent_id, …}` |
+| create simulation | `POST create-simulation {agent_id, name, max_concurrent, max_call_duration, max_call_duration_units, runs_per_digital_human, hangup_on_transfer}` |
+| read / fix simulation | `GET simulation/{id}` · `PUT simulation/{id}` |
+| digital humans | `GET digital-human-by-test-name/{title}` · `POST create-digital-humans {simulation_ids, digital_humans}` · `PUT update-digital-human/{id} {simulation_ids}` · `GET digital-humans-by-simulation/{sim}` |
+| queue | `POST queue-simulation-run {simulation_id, digital_human_ids, runs_per_digital_human}` → `simulation_run_id` |
+| poll | `GET retrieve-simulation-results/{run}` → `simulation_run`, `simulation_results[]` |
+| one result | `GET retrieve-simulation-result/{result}` |
+| trace | `GET traces/{trace_id}` |
+
+## Quirks the scripts already handle
+
+- `create-simulation` has stored `max_call_duration=4, units=minutes` as **4 seconds… or 7200**. Always GET and PUT until it reads back `minutes × 60`.
+- `add-agent` may return no id: re-read via `agent-by-external-id`.
+- `create-digital-humans` takes **unwrapped** digital humans plus top-level `simulation_ids`; wrapping each as `{digital_human: …}` is a 422.
+- `test_name` is unique per org: the scripts look up by test name and re-attach instead of duplicating.
+- Setting a digital human's `simulation_ids` **replaces** its memberships: merge, never overwrite.
+- A result is not final until its status leaves `RUNNING / QUEUED / EVALUATING / CONVERSATION_ENDED`; tools are extracted after the harness posts `trace_ids`, so scoring `CONVERSATION_ENDED` undercounts.
+- `NO_ANSWER` / `NO_CONNECTION` = Bluejay could not reach your `wss://` (DNS, TLS, auth, no Ready pod). Not a model failure.
+
+## Rubric
+
+Per call, all six required. Thresholds live in `scripts/score_rubric.py` (`--self-test`).
+
+| # | Check | Passes when | Fails usually because |
+|---|---|---|---|
+| 1 | utterances | `num_turns > 0`, `transcript_url` set | socket never connected / auth |
+| 2 | tool calls | some `tool_calls[].actual` non-empty | no spans, `BLUEJAY_API_KEY` missing in pod, tool wiring |
+| 3 | traces | `trace_ids` non-empty | OTLP export / update-simulation-result failed |
+| 4 | dead air | `max_punctuation_latency ≤ 25 s`, no "are you still there", no user→agent gap > 8 s | inbound audio gated, tool wait blocks speech |
+| 5 | audio continuity | `agent_audio_dropouts == 0`, clipping ≈ 0 | sample-rate / pacing bugs, muting on echo |
+| 6 | opening silence | `time_to_first_agent_utterance ≤ 3 s` | provider session created on accept instead of at boot |
+
+`goal_success` is the LLM judge's opinion of the transcript. It passes calls that never
+called the tool and fails calls that did; the scripts print it but never gate on it.
+
+## Reading a result
+
+```bash
+uv run python .claude/skills/mivas-run/scripts/bluejay.py results --run RUN --out verify-out/smoke/RUN
+uv run python .claude/skills/mivas-run/scripts/bluejay.py score verify-out/smoke/RUN
+curl -s "$(jq -r .simulation_result.transcript_url verify-out/smoke/RUN/<id>.json)" | jq '.[] | {speaker, start_offset_ms, text}'
+```
+
+Transcript gate (read at least one per smoke): greeting is a full sentence; the agent
+answers what the caller actually said; after a handoff the specialist continues (no cold
+re-ask); dates are this year; the call ends with `end_call`, not a cut.
+
+## Full-run scoring
+
+Bluejay's judge is not the benchmark score. After a full run:
+
+```bash
+uv run python verifiers/verify_run.py RUN                                    # exit 1 = void results, rerun those
+uv run python verifiers/verify_task_run.py RUN --industry $I --harness $H     # tools ∧ handoff ∧ final DB state
+uv run python scripts/bluejay_run_to_csv.py RUN --industry $I --harness $H    # one row per conversation
+```
+
+`verify_task_run.py` pulls `<result_id>.final.json` from the snapshot store
+(`MIVAS_SNAPSHOT_BUCKET`, `AWS_ENDPOINT_URL_S3` for S3-compatible) and diffs the
+write-bearing tables against each task's `exp_db_state`. Without a store it prints a skip
+note and scores tools + handoffs only.

--- a/.claude/skills/mivas-run/DEPLOY.md
+++ b/.claude/skills/mivas-run/DEPLOY.md
@@ -1,0 +1,194 @@
+# Deploying a MIVAS pair
+
+One **pair** = one harness (`family/runtime`) × one industry pack, built into one image,
+run as one Deployment. The container runs the industry tool server on `:8000` and the
+CHIRP WebSocket bridge on `:8765` in the same pod. Bluejay dials the CHIRP port over
+`wss://` with basic auth (`CHIRP_USER` / `CHIRP_PASS`, default `mivas`/`mivas`).
+
+`run.py` renders `k8s/*.yaml` from `.env` and applies it. It also creates or refreshes
+the `mivas-secrets` Secret from whichever provider / Bluejay keys are in your `.env`.
+
+```
+Bluejay ──wss──▶ ingress / LB / tunnel ──▶ Service mivas-<slug>:8765 ──▶ pod
+                                                                          ├─ CHIRP bridge (harness)
+                                                                          ├─ tool server :8000 (industry)
+                                                                          └─ /data/calls/<result_id>.db → snapshot store
+```
+
+slug = `family-runtime-industry` lowercased with `/`, `.`, `_` → `-`
+(`openai/realtime-2.1` × `healthcare` → `openai-realtime-2-1-healthcare`).
+
+## Storage
+
+Every Bluejay conversation gets its **own SQLite file**, created from the pack's
+`schema.sql` + `seed.sql` on first tool call and keyed by the Bluejay simulation result id
+(`X-Simulation-Result-Id` → `X-Mivas-Call-Id`). It lives in the pod's `emptyDir` at
+`/data/calls/<id>.db`. At hangup the harness freezes `GET /state` to
+`<id>.final.json` and, when `MIVAS_SNAPSHOT_BUCKET` is set, PUTs both files to
+`s3://$MIVAS_SNAPSHOT_BUCKET/$MIVAS_SNAPSHOT_PREFIX/<slug>/<id>.final.json`.
+
+The verifiers read **that object**, never the pod, because with replicas > 1 the
+public hostname lands on a random pod. Pick one:
+
+| Store | Pod env | Laptop env for verifiers | Notes |
+|---|---|---|---|
+| AWS S3 | `MIVAS_SNAPSHOT_BUCKET`, `AWS_DEFAULT_REGION`; creds via EKS Pod Identity / IRSA (`MIVAS_IRSA_ROLE_ARN`) or `AWS_ACCESS_KEY_ID`+`AWS_SECRET_ACCESS_KEY` in `.env` | same bucket, your AWS creds | the reference setup |
+| Any S3-compatible (MinIO, Cloudflare R2, GCS interop, DO Spaces) | same plus `AWS_ENDPOINT_URL_S3=https://…` and that store's key pair | `AWS_ENDPOINT_URL_S3` pointing at the same store (for in-cluster MinIO: `kubectl port-forward svc/minio 9000:9000` → `http://127.0.0.1:9000`) | boto3 honours `AWS_ENDPOINT_URL_S3`; no code change |
+| None | leave `MIVAS_SNAPSHOT_BUCKET` unset | – | `.final.json` stays in the pod; rung 3 checks it via `kubectl exec`; rung 4 state scoring is skipped |
+
+In-cluster MinIO for local / own clusters: `kubectl apply -f .claude/skills/mivas-run/assets/minio.yaml`
+(20 Gi PVC, bucket `mivas` created by a Job, root creds `mivas`/`mivasmivas` — change them),
+then in `.env`:
+
+```dotenv
+MIVAS_SNAPSHOT_BUCKET=mivas
+AWS_ENDPOINT_URL_S3=http://minio:9000
+AWS_ACCESS_KEY_ID=mivas
+AWS_SECRET_ACCESS_KEY=mivasmivas
+AWS_DEFAULT_REGION=us-east-1
+```
+
+`run.py --apply` copies those into `mivas-secrets`. Run verifiers on the laptop with the
+port-forward URL exported instead. All pods must be able to reach the store: the entrypoint
+runs `snapshot.preflight()` and logs `NO AWS CREDENTIALS` if not.
+
+## Images and registry
+
+| Target | Build | `.env` |
+|---|---|---|
+| Docker Desktop k8s | `run.py --build` (host arch) | no prefix; `imagePullPolicy: IfNotPresent` |
+| kind / minikube | `run.py --build` then `kind load docker-image mivas-bench:<slug>` (`minikube image load …`) | no prefix |
+| Any registry | `MIVAS_IMAGE_PREFIX=ghcr.io/you/mivas-bench` (or ECR, Docker Hub, GAR) → `run.py --build` does `buildx --platform linux/amd64 --push`; `docker login` first (ECR login is automatic) | `MIVAS_IMAGE_PLATFORMS` to override arch |
+| Private registry pull | `kubectl create secret docker-registry regcred …` then `kubectl patch serviceaccount mivas-bench -p '{"imagePullSecrets":[{"name":"regcred"}]}'` | – |
+| AWS CodeBuild fleet | `run.py --codebuild` builds one image per `AGENTS` pair in your AWS account (creates ECR repo, S3 source bucket, CodeBuild project + roles) | `MIVAS_IMAGE_PREFIX` = your ECR |
+
+The image copies `industries/<I>/`, `voice-agent-harnesses/<family>/` and `runtime/`.
+Rebuild after touching any of those.
+
+## Target: local Kubernetes (+ tunnel)
+
+Bluejay dials from the internet, so a local cluster needs a public `wss://` in front.
+
+```bash
+# .env: HARNESS, INDUSTRY, provider key, BLUEJAY_API_KEY; leave MIVAS_BASE_DOMAIN empty
+MIVAS_SERVICE_TYPE=LoadBalancer uv run python run.py --build --apply --no-logs   # Docker Desktop: localhost:8765
+# kind/minikube: kind load docker-image mivas-bench:<slug>; MIVAS_SERVICE_TYPE=NodePort MIVAS_NODE_HOST=127.0.0.1
+kubectl port-forward svc/mivas-<slug> 8765:8765        # if the LB has no address
+cloudflared tunnel --url http://127.0.0.1:8765 --no-autoupdate   # prints https://xxx.trycloudflare.com
+```
+
+Use `wss://xxx.trycloudflare.com` as `--url` for preflight and `bluejay.py smoke`. The quick
+tunnel URL changes on every restart; rerun `bluejay.py ensure-agent --url …`. A named
+Cloudflare tunnel or ngrok domain gives a stable one. Snapshot store: MinIO above, or none.
+
+No cluster at all? `uv run python run.py` runs the tool server + CHIRP locally on `:8765`;
+the same tunnel makes it dialable. Good for harness development, not for a full run.
+
+## Target: EKS
+
+**Auto Mode (reference).** `k8s/ingressclass.yaml` + `k8s/ingress.yaml` create one shared
+internet-facing ALB (group `mivas-chirp`, idle timeout 3600 s, least-outstanding-requests).
+
+```dotenv
+MIVAS_BASE_DOMAIN=mivas.example.com           # wildcard you control
+MIVAS_ACM_CERTIFICATE_ARN=arn:aws:acm:…       # *.mivas.example.com, status ISSUED
+MIVAS_IMAGE_PREFIX=<acct>.dkr.ecr.<region>.amazonaws.com/mivas-bench
+AWS_DEFAULT_REGION=<region>
+MIVAS_SNAPSHOT_BUCKET=<your-bucket>
+```
+
+1. `aws eks update-kubeconfig --name <cluster>`; make sure the cluster can create ALBs (Auto Mode does).
+2. S3 access for pods: `aws eks create-pod-identity-association --cluster-name <c> --namespace default --service-account mivas-bench --role-arn <role with s3:PutObject/GetObject on the bucket>`; or IRSA with `MIVAS_IRSA_ROLE_ARN` (renders the annotation).
+3. `uv run python run.py --build --apply --no-logs` (or `--codebuild --apply --no-logs`).
+4. DNS: `kubectl get ingress -l app=mivas-bench -o jsonpath='{.items[0].status.loadBalancer.ingress[0].hostname}'` → wildcard `*.mivas.example.com` CNAME to it, **DNS-only** (a proxying CDN idle-times the sockets).
+5. `preflight.py --k8s` must show `wss probe … 101`.
+
+Pods set `karpenter.sh/do-not-disrupt` and roll with `maxUnavailable: 0` so consolidation
+does not kill live calls. Scale with `MIVAS_REPLICAS=3` and re-apply (default 1).
+
+**Classic EKS (AWS Load Balancer Controller, or no ALB controller).** The Auto Mode
+`IngressClassParams` CRD does not exist there. Use the any-cluster path below with
+`ingress-nginx` + `cert-manager` (works on EKS too), keeping Pod Identity / IRSA for S3.
+
+## Target: Baseten
+
+Baseten runs the same image as a **Custom Server** with a WebSocket transport. Two gaps
+to bridge:
+
+1. **Auth.** Baseten expects `Authorization: Bearer <BASETEN_API_KEY>`; Bluejay sends
+   basic auth. Put `assets/baseten/auth-proxy-worker.js` in front (a Cloudflare Worker:
+   checks `CHIRP_USER`/`CHIRP_PASS` basic auth, forwards the upgrade to Baseten with the
+   bearer header, passes `X-Simulation-Result-Id` through). Bluejay dials the Worker URL.
+   On Baseten leave `CHIRP_USER`/`CHIRP_PASS` empty so the bridge accepts the proxied socket.
+2. **Health.** Baseten probes the port the socket listens on. The CHIRP bridges answer
+   `GET /health` on `:8765` (`runtime/chirp_health.py`), so `readiness_endpoint: /health`
+   works on `server_port: 8765`.
+
+```bash
+MIVAS_IMAGE_PREFIX=docker.io/<you>/mivas-bench uv run python run.py --build   # amd64 push
+cp .claude/skills/mivas-run/assets/baseten/config.yaml ./baseten-config.yaml    # edit image, slug, env
+pip install truss && truss push baseten-config.yaml --publish
+```
+
+Secrets arrive as files under `/secrets/<name>`; the template's `start_command` exports
+them as env before `runtime/entrypoint.sh`. Snapshot store must be external (S3 / R2) with
+static keys. One replica ≈ 2–4 concurrent calls; set Baseten `predict_concurrency`
+accordingly. Worker families (`livekit`, `gemini`) do not apply here: they need SIP, not a
+WebSocket ingress.
+
+## Target: any Kubernetes (k3s, GKE, AKS, DOKS, on-prem)
+
+Needs an ingress controller with WebSocket support and TLS. Set `MIVAS_INGRESS_CLASS` and
+`run.py` renders `k8s/ingress-generic.yaml` (one Ingress per pair, 3600 s proxy timeouts)
+instead of the EKS ALB pair; no ACM.
+
+```bash
+helm upgrade -i ingress-nginx ingress-nginx --repo https://kubernetes.github.io/ingress-nginx -n ingress-nginx --create-namespace
+helm upgrade -i cert-manager cert-manager --repo https://charts.jetstack.io -n cert-manager --create-namespace --set crds.enabled=true
+kubectl apply -f - <<'Y'
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata: {name: letsencrypt-prod}
+spec:
+  acme:
+    server: https://acme-v02.api.letsencrypt.org/directory
+    email: you@example.com
+    privateKeySecretRef: {name: letsencrypt-prod}
+    solvers: [{http01: {ingress: {class: nginx}}}]
+Y
+```
+
+```dotenv
+MIVAS_BASE_DOMAIN=mivas.example.com
+MIVAS_INGRESS_CLASS=nginx
+MIVAS_CLUSTER_ISSUER=letsencrypt-prod      # or MIVAS_TLS_SECRET=<your wildcard TLS secret>
+MIVAS_IMAGE_PREFIX=ghcr.io/you/mivas-bench
+MIVAS_SNAPSHOT_BUCKET=mivas + AWS_ENDPOINT_URL_S3=http://minio:9000 (see Storage)
+```
+
+Then `run.py --build --apply --no-logs`, point wildcard DNS `*.mivas.example.com` at the
+controller's external IP (`kubectl get svc -n ingress-nginx`), wait for the certificate
+(`kubectl get certificate`), and `preflight.py --k8s`. HTTP-01 needs the DNS live before
+the Ingress exists; otherwise use a DNS-01 solver or a bought wildcard cert via
+`MIVAS_TLS_SECRET`.
+
+Storage: MinIO from `assets/minio.yaml`, or an external S3-compatible bucket.
+
+## After apply, before smoke
+
+```bash
+kubectl rollout status deployment/mivas-<slug> --timeout=180s
+kubectl logs deployment/mivas-<slug> --tail=50      # "snapshot: preflight ok" and the CHIRP bind line ("ws↔…")
+uv run python .claude/skills/mivas-run/scripts/preflight.py --harness $H --industry $I --k8s
+```
+
+Readiness probes `:8000/health` (tools), so a pod can be Ready a few seconds before CHIRP
+listens; the preflight checks the log line. If `kubectl apply` says `unchanged` after a new
+push on a mutable tag, `kubectl rollout restart deployment/mivas-<slug>`.
+
+## Worker families (LiveKit SIP)
+
+`livekit/*` and `gemini/*` register with a LiveKit Cloud project and take Bluejay SIP
+inbound; they have no CHIRP ingress. Their Bluejay agent is `connection_type=LIVEKIT`, and
+`bluejay.py ensure-agent` does not cover them: follow `voice-agent-harnesses/gemini/README.md`
+and create the agent in the Bluejay app, then use `bluejay.py smoke --agent-id …`.

--- a/.claude/skills/mivas-run/HARNESS.md
+++ b/.claude/skills/mivas-run/HARNESS.md
@@ -1,0 +1,102 @@
+# Harnesses
+
+A harness turns the industry pack (`agent_blueprint.json`, `tools.json`, prompts) into a
+live multi-agent voice runtime for one provider, and bridges Bluejay's CHIRP audio to it.
+You need **full control** of the harness you run: its Dockerfile, its adapter, its keys.
+
+## Existing harnesses
+
+| `family/runtime` | Model | Env keys | Local CHIRP port |
+|---|---|---|---|
+| `openai/realtime-2.1`, `openai/realtime-2.1-mini` | gpt-realtime-2.1 (mini) | `OPENAI_API_KEY` | 8765 / 8766 |
+| `gemini/flash-live-3.1`, `gemini/2.5-flash-native-audio` | Gemini Live (LiveKit SIP worker) | `GOOGLE_API_KEY`, `LIVEKIT_URL/API_KEY/API_SECRET`, `LIVEKIT_SIP_HOST` | – (SIP) |
+| `aws/nova-sonic-2` | Amazon Nova 2 Sonic | `AWS_ACCESS_KEY_ID`/`SECRET` (+`AWS_SESSION_TOKEN`), `NOVA_SONIC_REGION` | 8774 |
+| `grok/voice` | xAI Grok voice | `GROK_API_KEY` (or `XAI_API_KEY`) | 8768 |
+| `qwen/audio-realtime` | Qwen Audio Realtime | `DASHSCOPE_API_KEY`, `QWEN_WORKSPACE_ID`, `QWEN_REGION` | 8769 |
+| `nvidia/nemotron`, `nvidia/nemotron-voicechat` | cascaded Nemotron / VoiceChat NIM | `NVIDIA_API_KEY` (or NIM `NEMOTRON_*` / `VOICECHAT_*` URLs) | 8766 |
+| `livekit/cascaded` | Deepgram Flux → GPT-4.1 → ElevenLabs (LiveKit SIP worker) | `LIVEKIT_*`, `OPENAI_API_KEY`, `DEEPGRAM_API_KEY`, `ELEVENLABS_API_KEY` | – (SIP) |
+
+Each family README documents its wire contract and gotchas. Every pod also needs
+`BLUEJAY_API_KEY` (trace upload + result relink) and `CHIRP_USER`/`CHIRP_PASS`.
+
+Offline gate for any pair: `uv run python run.py --harness $H --industry $I --check`
+(builds the agents from the blueprint, no call). Talk to it locally:
+`uv run python tests/converse.py --harness $H` (mic; OpenAI only) or `--text`.
+
+## Build your own
+
+Layout (copy the closest family; `openai/` for a soft-handoff realtime API, `grok/`
+for a raw WebSocket provider, `nvidia/nemotron-voicechat` for hard dual-session):
+
+```
+voice-agent-harnesses/<family>/
+  README.md            # wire contract, env keys, local port; never Bluejay ids or hosts
+  requirements.txt     # pip deps for the image
+  harness.py           # blueprint → provider sessions; industry tools → POST /tools/{name}
+  report.py            # OTel voice.call tree → Bluejay OTLP; POST update-simulation-result {trace_ids}
+  <runtime>/
+    agent.py           # `python agent.py <industry> --check` must build all agents offline
+    Dockerfile         # copy openai/realtime-2.1/Dockerfile; change family/runtime names
+    adapters/chirp.py  # Bluejay CHIRP bridge (16 kHz pcm_s16le in/out, speech.* JSON events)
+```
+
+### Contract (what the verifiers assume)
+
+1. **Blueprint first.** Load `agent_blueprint.json` + `tools.json` + `system-prompts/`. The first
+   agent starts. Each provider session advertises only that agent's tools.
+2. **Tools are a dumb pipe.** Every non-handoff, non-session tool → `POST {TOOL_SERVER_URL}/tools/{name}`
+   with `{"arguments": {...}}` and header `X-Mivas-Call-Id: <simulation result id>`
+   (`runtime/call_id.py`: `set_call_id`, `headers()`); return the JSON verbatim. No per-tool code.
+3. **Handoffs are provider-native** (`handoff: true`): swap instructions/tools on the live
+   session when the provider can (`session.update`), or open the next session and seed it
+   with the prior user turns. Never hit the tool server.
+4. **`end_call` is harness-native** (`session: true`): let the farewell audio drain, then close.
+5. **CHIRP.** On upgrade read `Authorization: Basic` and `X-Simulation-Result-Id`. Binary
+   frames are caller PCM16 @16 kHz; JSON `speech.started`/`speech.completed` are Bluejay's
+   VAD. Always forward inbound audio to the provider; never mute the agent on Bluejay VAD alone
+   (it fires on agent echo). Resample with kept state. Speak first: DHs are `speaks_first: false`.
+6. **Clock.** Inject the pack's date line (`runtime/pack_clock.py`) into every agent's
+   instructions; realtime models otherwise book in the wrong year.
+7. **Tracing.** One `voice.call` root span per conversation with turn / tool spans and
+   `gen_ai.usage.*`; export to `BLUEJAY_OTLP_ENDPOINT` with `X-API-Key`; POST
+   `update-simulation-result {simulation_result_id, trace_ids}` (retry 429/5xx). Bluejay's
+   `actual` tool calls come from these spans: no spans, no tool credit.
+8. **Hangup snapshot.** Call `snapshot.capture_final(call_id)` (`runtime/snapshot.py`) when the
+   socket closes; it freezes `GET /state` and uploads to the snapshot store.
+9. **Health.** Pass `process_request=chirp_health.process_request` to `websockets.serve` so
+   `GET /health` on the CHIRP port answers 200 (Baseten probes it).
+
+### Register it in the repo
+
+- `tests/test_dockerfiles.py` asserts the Dockerfile count: bump it.
+- New provider env var: add to `k8s/deployment.yaml` (secretKeyRef, `optional: true`),
+  `run.py` `_SECRET_ENV_KEYS` (+ `_redact_cmd`), `k8s/secret.example.yaml`, `.env.example`.
+- Heavy runtimes (local VAD, cascaded STT/TTS): `run.py` `pair_resources()`.
+- SIP worker instead of CHIRP: add the family to `LIVEKIT_WORKER_FAMILIES` in `run.py`
+  and the `entrypoint.sh` worker branch.
+- `tests/test_harness_tool_headers.py` greps every tool POST for `X-Mivas-Call-Id`.
+
+### Local loop
+
+```bash
+uv run python run.py --harness <family>/<runtime> --industry control-industry --check
+uv run python run.py --harness <family>/<runtime> --industry control-industry      # tools :8000 + CHIRP
+cloudflared tunnel --url http://127.0.0.1:8765 --no-autoupdate
+uv run python .claude/skills/mivas-run/scripts/bluejay.py smoke --harness <family>/<runtime> --industry control-industry --url wss://<tunnel>
+```
+
+Done only when three consecutive control-industry smoke calls pass the rubric **and** a
+read transcript shows: full greeting, scheduler continues with the date the caller already
+gave, `schedule_appointment` actual with a plausible `MM/DD/YYYY`, clean `end_call`.
+
+### Fix loop (symptom → layer)
+
+| Symptom | Layer | Look at |
+|---|---|---|
+| "Hey," then silence; dropouts | audio bridge | muting on Bluejay `speech.started`; echo window |
+| agent re-asks what caller said | inbound path / handoff seed | forward-always; USER ASR log |
+| booking said, no `schedule_appointment` actual | tool wiring / spans | tool POST + `execute_tool` span |
+| wrong year | clock | pack date injection |
+| `trace_ids` empty | report | `BLUEJAY_API_KEY` in pod; update-simulation-result 5xx retry |
+| first agent audio > 3 s | accept path | create provider sessions at boot, not on accept |
+| 401 on wss probe | creds | Bluejay agent username/password vs `CHIRP_USER`/`CHIRP_PASS` |

--- a/.claude/skills/mivas-run/SKILL.md
+++ b/.claude/skills/mivas-run/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: mivas-run
+description: >-
+  Runs MIVAS Bench end to end from a consumer seat: prerequisites (Bluejay API key,
+  provider key), a harness (existing or self-built), a Kubernetes deployment (local,
+  EKS, Baseten, or any cluster), then a gated ladder of smoke tests, three Bluejay
+  smoke calls, harness + benchmark integrity, and finally a full industry run.
+  Use when someone says /mivas-run, "run MIVAS myself", "set up mivas-bench",
+  "deploy a harness for MIVAS", "smoke my harness on Bluejay", "benchmark my voice
+  model on healthcare/legal/customer-support", or asks how to plug their own voice
+  agent into MIVAS.
+argument-hint: "family/runtime industry [target: local|eks|baseten|k8s]"
+---
+
+# MIVAS run (consumer)
+
+Everything here uses the public Bluejay REST API with **your** `BLUEJAY_API_KEY`
+and **your** cluster. No Bluejay internals, no shared infrastructure.
+
+## Prerequisites (stop if any is missing)
+
+1. Bluejay account + API key (Bluejay app → API Keys) → `BLUEJAY_API_KEY` in `.env`.
+2. Provider key for the harness (`OPENAI_API_KEY`, `GOOGLE_API_KEY`, …). Table: [HARNESS.md](HARNESS.md#existing-harnesses).
+3. A harness you fully control: an existing `voice-agent-harnesses/<family>/<runtime>/`, or your own built per [HARNESS.md](HARNESS.md#build-your-own).
+4. Somewhere to run it that Bluejay can dial over public `wss://`: [DEPLOY.md](DEPLOY.md) (local + tunnel, EKS, Baseten, any Kubernetes).
+5. A snapshot store for per-call final state, or accept that state scoring is skipped: [DEPLOY.md → Storage](DEPLOY.md#storage).
+
+```bash
+git clone https://github.com/bluejay-ai-dev/mivas-bench && cd mivas-bench && uv sync && cp .env.example .env
+```
+
+## Ladder (each rung gates the next)
+
+Track it:
+
+```
+- [ ] 0 preflight      scripts/preflight.py            (keys, pair on disk, --check, store)
+- [ ] 1 deploy         DEPLOY.md target → pods Ready → preflight --k8s / --url (wss 101)
+- [ ] 2 smoke calls    scripts/bluejay.py smoke  → 3 calls, rubric PASS each
+- [ ] 3 integrity      scripts/verify_integrity.py → INTEGRITY PASS
+- [ ] 4 full industry  scripts/bluejay.py full   → verify_task_run + CSV
+```
+
+Commands (from the repo root; `H=family/runtime`, `I=industry`):
+
+```bash
+uv run python .claude/skills/mivas-run/scripts/preflight.py --harness $H --industry $I
+uv run python run.py --harness $H --industry $I --build --apply --no-logs   # or per DEPLOY.md
+uv run python .claude/skills/mivas-run/scripts/preflight.py --harness $H --industry $I --k8s   # or --url wss://…
+uv run python .claude/skills/mivas-run/scripts/bluejay.py smoke --harness $H --industry $I --url wss://HOST
+uv run python .claude/skills/mivas-run/scripts/verify_integrity.py --harness $H --industry $I --smoke-dir verify-out/smoke/<slug>/<run> --k8s
+uv run python .claude/skills/mivas-run/scripts/bluejay.py full --harness $H --industry healthcare --runs 5
+```
+
+## Rules
+
+- **Rung 0 first, always.** Never `--apply` with a missing provider key or `BLUEJAY_API_KEY`: the pod syncs `mivas-secrets` from `.env`, and a missing Bluejay key means no traces, which fails the rubric.
+- **Start with `control-industry`.** It is the wiring smoke (reception → scheduler → `schedule_appointment`). Only when it passes rung 2 do you point the same harness at `healthcare`, `legal`, or `customer-support`.
+- **Rubric, not `goal_success`.** A call passes when all six checks pass: utterances, actual tool calls, trace ids, dead air ≤ 25 s, zero dropouts/clipping, first agent audio ≤ 3 s. `goal_success` is informational. Details and the fix loop: [BLUEJAY.md → Rubric](BLUEJAY.md#rubric).
+- **Read one transcript** per smoke even when the rubric passes (greeting complete, handoff continues the intent, booking date plausible).
+- **Never redeploy mid-run.** In-flight CHIRP sockets die on pod restart. Wait for the run to be final.
+- **Concurrency** is `max_concurrent ≤ MIVAS_REPLICAS × 2–4` for CHIRP families. Smoke defaults to 1.
+- **Storage before rung 4.** Without `MIVAS_SNAPSHOT_BUCKET` (AWS S3 or any S3-compatible endpoint), `verify_task_run.py` skips the final-state check and Pass@1 / Pass^k are not reportable.
+- **Secrets stay out of the tree.** Report ids and URLs in chat; never commit `.env`, hostnames, or keys.
+
+## Rung 4: full industry
+
+`bluejay.py full` converts `industries/<I>/tasks/*/task.json` to digital humans on a fresh
+simulation (via `scripts/tasks_to_digital_humans.py --push`), queues `k` runs per task, and
+prints the verifier + CSV commands. Budget: 72 tasks × k calls of up to 8 minutes; with
+`--max-concurrent 3` and `k=5` expect several hours. `--no-wait` returns the run id;
+resume with `bluejay.py poll --run RUN`. Score with `verifiers/verify_task_run.py` (tools ∧
+handoff ∧ final state), export with `scripts/bluejay_run_to_csv.py`. Do not quote a number
+from a run with void results (`verifiers/verify_run.py` exit 1).
+
+## Files
+
+| File | When |
+|---|---|
+| [DEPLOY.md](DEPLOY.md) | rung 1: storage model, registry, local/EKS/Baseten/any-k8s recipes, DNS+TLS |
+| [HARNESS.md](HARNESS.md) | picking a harness, env keys, building and registering your own |
+| [BLUEJAY.md](BLUEJAY.md) | REST calls the scripts make, API quirks, rubric, reading results, fix loop |
+| `scripts/preflight.py` | rung 0/1 gate |
+| `scripts/bluejay.py` | `ensure-agent` · `smoke` · `queue` · `poll` · `results` · `score` · `full` |
+| `scripts/verify_integrity.py` | rung 3 |
+| `scripts/score_rubric.py` | six-check rubric (stdlib; `--self-test`) |
+| `assets/` | `minio.yaml` (in-cluster S3), `baseten/config.yaml`, `baseten/auth-proxy-worker.js` |

--- a/.claude/skills/mivas-run/assets/baseten/auth-proxy-worker.js
+++ b/.claude/skills/mivas-run/assets/baseten/auth-proxy-worker.js
@@ -1,0 +1,28 @@
+// Cloudflare Worker: Bluejay (basic auth) → Baseten WebSocket model (bearer auth).
+//
+// Bluejay's WEBSOCKET agent can only send `Authorization: Basic user:pass`; Baseten's
+// WebSocket endpoint wants `Authorization: Bearer <BASETEN_API_KEY>`. This Worker checks the
+// basic credentials, swaps the header and proxies the upgrade. Everything else, including
+// X-Simulation-Result-Id, passes through untouched.
+//
+// Vars (wrangler secret put …): CHIRP_USER, CHIRP_PASS, BASETEN_API_KEY,
+//   BASETEN_WS_URL = wss://model-<id>.api.baseten.co/environments/production/websocket
+// Bluejay agent: websocket_url = wss://<worker>.workers.dev, username/password = CHIRP_USER/PASS.
+
+export default {
+  async fetch(request, env) {
+    if (request.headers.get("Upgrade")?.toLowerCase() !== "websocket") {
+      return new Response("mivas baseten proxy\n", { status: 200 });
+    }
+    const expected = "Basic " + btoa(`${env.CHIRP_USER}:${env.CHIRP_PASS}`);
+    if (request.headers.get("Authorization") !== expected) {
+      return new Response("unauthorized\n", { status: 401 });
+    }
+    const upstream = new URL(env.BASETEN_WS_URL);
+    const headers = new Headers(request.headers);
+    headers.set("Authorization", `Bearer ${env.BASETEN_API_KEY}`);
+    headers.set("Host", upstream.host);
+    // A 101 response carries the upstream socket; returning it hands the pipe to Bluejay.
+    return fetch(upstream.toString(), { method: "GET", headers });
+  },
+};

--- a/.claude/skills/mivas-run/assets/baseten/config.yaml
+++ b/.claude/skills/mivas-run/assets/baseten/config.yaml
@@ -1,0 +1,46 @@
+# Truss config for one MIVAS pair on Baseten as a Custom Server (WebSocket transport).
+# 1. Build + push the pair image to a registry Baseten can pull:
+#      MIVAS_IMAGE_PREFIX=docker.io/<you>/mivas-bench uv run python run.py --harness openai/realtime-2.1 --industry control-industry --build
+# 2. Create Baseten secrets (Workspace → Secrets) named below; they mount at /secrets/<name>.
+# 3. truss push config.yaml --publish
+# 4. Front the model URL with assets/baseten/auth-proxy-worker.js (Bluejay sends basic auth, Baseten wants a bearer).
+model_name: mivas-openai-realtime-2-1-control-industry
+base_image:
+  image: docker.io/<you>/mivas-bench:openai-realtime-2-1-control-industry
+docker_server:
+  # secrets → env, then the normal combined entrypoint (tool server :8000 + CHIRP :8765)
+  start_command: >-
+    /bin/sh -c 'for s in /secrets/*; do [ -f "$s" ] && export "$(basename "$s")=$(cat "$s")"; done;
+    exec /app/runtime/entrypoint.sh'
+  server_port: 8765
+  predict_endpoint: /v1/websocket
+  readiness_endpoint: /health
+  liveness_endpoint: /health
+runtime:
+  transport:
+    kind: websocket
+  predict_concurrency: 3          # ≈ concurrent calls per replica; keep 2–4 for CHIRP families
+resources:
+  cpu: "1"
+  memory: 2Gi
+  use_gpu: false
+environment_variables:
+  HARNESS: openai/realtime-2.1
+  INDUSTRY: control-industry
+  MIVAS_MODE: chirp
+  MIVAS_SLUG: openai-realtime-2-1-control-industry   # snapshot key prefix; k8s sets this from the Deployment
+  CHIRP_USER: ""                                     # auth is the proxy's job; leave both empty
+  CHIRP_PASS: ""
+  MIVAS_SNAPSHOT_BUCKET: ""                          # external S3 / R2 bucket; empty = pod-local only
+  MIVAS_SNAPSHOT_PREFIX: mivas
+  AWS_DEFAULT_REGION: us-east-1
+  AWS_ENDPOINT_URL_S3: ""                            # set for R2 / MinIO / GCS interop
+  BLUEJAY_API_URL: https://api.getbluejay.ai/v1
+  BLUEJAY_OTLP_ENDPOINT: https://otlp.getbluejay.ai/v1/traces
+  BLUEJAY_SERVICE_NAME: mivas-openai
+  PYTHONUNBUFFERED: "1"
+secrets:
+  OPENAI_API_KEY: null        # provider key for this family
+  BLUEJAY_API_KEY: null       # traces + result relink
+  AWS_ACCESS_KEY_ID: null     # snapshot store (optional)
+  AWS_SECRET_ACCESS_KEY: null

--- a/.claude/skills/mivas-run/assets/minio.yaml
+++ b/.claude/skills/mivas-run/assets/minio.yaml
@@ -1,0 +1,85 @@
+# Single-node MinIO as the MIVAS snapshot store for local / self-managed clusters.
+# kubectl apply -f .claude/skills/mivas-run/assets/minio.yaml
+# Pods:    AWS_ENDPOINT_URL_S3=http://minio:9000   MIVAS_SNAPSHOT_BUCKET=mivas
+# Laptop:  kubectl port-forward svc/minio 9000:9000 ; AWS_ENDPOINT_URL_S3=http://127.0.0.1:9000
+# Change the root credentials before exposing this anywhere.
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-root
+type: Opaque
+stringData:
+  MINIO_ROOT_USER: mivas
+  MINIO_ROOT_PASSWORD: mivasmivas
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: minio-data
+spec:
+  accessModes: [ReadWriteOnce]
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  labels: {app: minio}
+spec:
+  replicas: 1
+  strategy: {type: Recreate}
+  selector:
+    matchLabels: {app: minio}
+  template:
+    metadata:
+      labels: {app: minio}
+    spec:
+      containers:
+        - name: minio
+          image: quay.io/minio/minio:RELEASE.2025-04-22T22-12-26Z
+          args: ["server", "/data", "--console-address", ":9001"]
+          envFrom:
+            - secretRef: {name: minio-root}
+          ports:
+            - {containerPort: 9000, name: s3}
+            - {containerPort: 9001, name: console}
+          readinessProbe:
+            httpGet: {path: /minio/health/ready, port: 9000}
+          volumeMounts:
+            - {name: data, mountPath: /data}
+      volumes:
+        - name: data
+          persistentVolumeClaim: {claimName: minio-data}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+spec:
+  selector: {app: minio}
+  ports:
+    - {name: s3, port: 9000, targetPort: 9000}
+    - {name: console, port: 9001, targetPort: 9001}
+---
+# Creates the `mivas` bucket once MinIO is up.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: minio-make-bucket
+spec:
+  backoffLimit: 10
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: mc
+          image: quay.io/minio/mc:RELEASE.2025-04-16T18-13-26Z
+          envFrom:
+            - secretRef: {name: minio-root}
+          command: ["/bin/sh", "-c"]
+          args:
+            - >
+              until mc alias set local http://minio:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"; do sleep 3; done;
+              mc mb --ignore-existing local/mivas

--- a/.claude/skills/mivas-run/scripts/bluejay.py
+++ b/.claude/skills/mivas-run/scripts/bluejay.py
@@ -1,0 +1,575 @@
+#!/usr/bin/env python3
+"""Drive Bluejay from the consumer side for one MIVAS harness × industry pair.
+
+Everything goes through the public REST API with your own BLUEJAY_API_KEY
+(X-API-Key). No Bluejay internals, no MCP.
+
+    uv run python .claude/skills/mivas-run/scripts/bluejay.py ensure-agent --harness openai/realtime-2.1 --industry control-industry --url wss://HOST
+    uv run python .claude/skills/mivas-run/scripts/bluejay.py smoke        --harness openai/realtime-2.1 --industry control-industry --url wss://HOST
+    uv run python .claude/skills/mivas-run/scripts/bluejay.py full         --harness openai/realtime-2.1 --industry healthcare --runs 5
+    uv run python .claude/skills/mivas-run/scripts/bluejay.py poll  --run RUN_ID
+    uv run python .claude/skills/mivas-run/scripts/bluejay.py results --run RUN_ID --out verify-out/smoke/RUN_ID
+    uv run python .claude/skills/mivas-run/scripts/bluejay.py score verify-out/smoke/RUN_ID
+
+`smoke` = ensure agent → dedicated smoke simulation → smoke digital humans →
+queue → poll → dump results → rubric. Exit 0 only when every call passes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[3]
+for extra in (HERE, ROOT / "scripts", ROOT / "runtime"):
+    if str(extra) not in sys.path:
+        sys.path.insert(0, str(extra))
+
+import score_rubric  # noqa: E402
+
+DEFAULT_API = "https://api.getbluejay.ai/v1"
+# tools are extracted after the harness posts trace ids, so these are unfinished
+NOT_FINAL = {"RUNNING", "IN_PROGRESS", "QUEUED", "PENDING", "EVALUATING", "CONVERSATION_ENDED"}
+NO_CONVERSATION = {"NO_ANSWER", "NO_CONNECTION", "CANCELLED", "SYSTEM_ERROR", "ERROR"}
+
+
+def load_dotenv() -> None:
+    path = ROOT / ".env"
+    if not path.is_file():
+        return
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        os.environ.setdefault(key.strip(), value.strip().strip("'").strip('"'))
+
+
+def api_url() -> str:
+    return os.environ.get("BLUEJAY_API_URL", DEFAULT_API).rstrip("/")
+
+
+def app_url() -> str:
+    return os.environ.get("BLUEJAY_APP_URL", "https://app.getbluejay.ai").rstrip("/")
+
+
+def _key() -> str:
+    key = os.environ.get("BLUEJAY_API_KEY", "").strip()
+    if not key:
+        raise SystemExit("BLUEJAY_API_KEY is not set (create one under API Keys in the Bluejay app)")
+    return key
+
+
+def req(method: str, path: str, payload: dict[str, Any] | None = None, *, not_found_ok: bool = False) -> dict[str, Any]:
+    data = json.dumps(payload).encode() if payload is not None else None
+    r = urllib.request.Request(
+        f"{api_url()}/{path}", data=data, method=method,
+        headers={"X-API-Key": _key(), "Content-Type": "application/json"},
+    )
+    for attempt in range(4):
+        try:
+            with urllib.request.urlopen(r, timeout=120) as resp:
+                raw = resp.read()
+                return json.loads(raw) if raw.strip() else {}
+        except urllib.error.HTTPError as e:
+            if not_found_ok and e.code == 404:
+                return {}
+            body = e.read()[:600].decode(errors="replace")
+            if e.code in (429, 502, 503, 504) and attempt < 3:
+                time.sleep(2 * (attempt + 1))
+                continue
+            raise SystemExit(f"{method} {path} → {e.code} {body}") from e
+        except urllib.error.URLError as e:
+            if attempt < 3:
+                time.sleep(2 * (attempt + 1))
+                continue
+            raise SystemExit(f"{method} {path} → {e}") from e
+    raise SystemExit(f"{method} {path} → gave up")
+
+
+def slug(harness: str, industry: str) -> str:
+    return f"{harness.replace('/', '-')}-{industry}".replace("_", "-").replace(".", "-").lower()
+
+
+def default_url(harness: str, industry: str) -> str | None:
+    base = os.environ.get("MIVAS_BASE_DOMAIN", "").strip().lower().strip(".")
+    return f"wss://{slug(harness, industry)}.{base}" if base else None
+
+
+# ---------------------------------------------------------------- agent
+
+def _unwrap(body: dict[str, Any], *keys: str) -> dict[str, Any]:
+    for k in keys:
+        inner = body.get(k)
+        if isinstance(inner, dict):
+            return inner
+    return body
+
+
+def _id(obj: dict[str, Any], *keys: str) -> int | None:
+    for k in keys:
+        v = obj.get(k)
+        if v not in (None, ""):
+            try:
+                return int(v)
+            except (TypeError, ValueError):
+                continue
+    return None
+
+
+def get_agent_by_external_id(external_id: str) -> dict[str, Any] | None:
+    body = req("GET", f"agent-by-external-id/{urllib.parse.quote(external_id, safe='')}", not_found_ok=True)
+    if not body:
+        return None
+    agent = _unwrap(body, "agent", "data")
+    return agent if _id(agent, "id", "agent_id") is not None else None
+
+
+def ensure_agent(harness: str, industry: str, url: str, user: str, password: str, name: str | None) -> int:
+    external_id = f"mivas:{slug(harness, industry)}"
+    ws = {
+        "connection_type": "WEBSOCKET",
+        "mode": "VOICE",
+        "websocket_url": url,
+        "websocket_username": user,
+        "websocket_password": password,
+    }
+    existing = get_agent_by_external_id(external_id)
+    if existing:
+        agent_id = _id(existing, "id", "agent_id")
+        req("POST", "update-agent", {"agent_id": str(agent_id), **ws})
+        print(f"agent {agent_id} ({external_id}) → {url}", flush=True)
+        return int(agent_id)  # type: ignore[arg-type]
+    title = name or f"MIVAS {harness} × {industry}"
+    req("POST", "add-agent", {
+        "name": title,
+        # Prompts and tools live in the industry pack on the harness; Bluejay only dials.
+        "system_prompt": f"MIVAS harness {harness} running the {industry} pack. Prompts live in the pack.",
+        "knowledge_base": "Not used. The harness owns prompts, tools and state.",
+        "goals": ["Complete the caller's request using the industry's agents and tools."],
+        "type": "INBOUND",
+        "external_agent_id": external_id,
+        **ws,
+    })
+    created = get_agent_by_external_id(external_id)
+    if not created:
+        raise SystemExit("add-agent succeeded but agent-by-external-id cannot find it; check the Bluejay app")
+    agent_id = _id(created, "id", "agent_id")
+    print(f"agent {agent_id} created ({external_id}) → {url}", flush=True)
+    return int(agent_id)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------- simulation
+
+def _sim(body: dict[str, Any]) -> dict[str, Any]:
+    return _unwrap(body, "simulation", "data")
+
+
+def _duration_seconds(sim: dict[str, Any]) -> int | None:
+    settings = sim.get("settings") or {}
+    raw = sim.get("max_call_duration") or settings.get("max_call_duration")
+    if raw is None:
+        return None
+    units = str(sim.get("max_call_duration_units") or settings.get("max_call_duration_units") or "seconds").lower()
+    return int(raw) * 60 if units.startswith("min") else int(raw)
+
+
+def create_simulation(agent_id: int, name: str, *, minutes: int, max_concurrent: int, runs: int = 1) -> int:
+    payload = {
+        "agent_id": str(agent_id),
+        "name": name,
+        "max_concurrent": max_concurrent,
+        "max_call_duration": minutes,
+        "max_call_duration_units": "minutes",
+        "runs_per_digital_human": runs,
+        "hangup_on_transfer": False,
+    }
+    created = req("POST", "create-simulation", payload)
+    sim_id = _id(created, "simulation_id", "id") or _id(_sim(created), "id")
+    if sim_id is None:
+        raise SystemExit(f"create-simulation returned no id: {json.dumps(created)[:300]}")
+    # the API has stored minutes as seconds on create; re-PUT until it reads back right
+    for _ in range(2):
+        fetched = _sim(req("GET", f"simulation/{sim_id}"))
+        if _duration_seconds(fetched) == minutes * 60:
+            break
+        req("PUT", f"simulation/{sim_id}", {"max_call_duration": minutes, "max_call_duration_units": "minutes"})
+    else:
+        print(f"warning: simulation {sim_id} max_call_duration stored as {_duration_seconds(fetched)}s", flush=True)
+    print(f"simulation {sim_id}: {name} ({minutes} min cap, max_concurrent={max_concurrent})", flush=True)
+    return int(sim_id)
+
+
+def update_simulation(sim_id: int, **fields: Any) -> None:
+    req("PUT", f"simulation/{sim_id}", fields)
+
+
+# ---------------------------------------------------------------- digital humans
+
+CONTROL_BOOKER = {
+    "name": "Riley Booker",
+    "test_name": "MIVAS smoke · control-industry · repair booking",
+    "intent": (
+        "You are calling Bluejay's Repair Services to schedule a repair appointment for next "
+        "Tuesday afternoon. Wait for the receptionist to greet you, then say you need to book a "
+        "repair. When asked for a date, say next Tuesday afternoon; if they ask for a specific "
+        "date, give the calendar date of next Tuesday. Once the appointment is confirmed, thank "
+        "them and end the call. Do not ask for anything else."
+    ),
+    "success_criteria": "Success requires handoff_to_scheduler and schedule_appointment to have been called.",
+    "expected_tool_calls": [{"name": "handoff_to_scheduler"}, {"name": "schedule_appointment"}],
+    "tags": ["mivas_smoke", "mivas_control_industry"],
+    "speaks_first_config": {"speaks_first": False},
+    "creativity": 0,
+    "language": "en",
+    "accent": "american",
+    "gender": "female",
+    "fluency": "native",
+    "voice_speed": "normal",
+    "verbosity": "medium",
+    "interruptions": {"type": "none"},
+    "allow_end_call_tool": True,
+    "allow_silence_tool": True,
+    "allow_dtmf_tool": False,
+    "num_runs": 1,
+    "background_noise": "none",
+    "background_noise_volume": 0.0,
+    "audio_quality": "high",
+}
+
+
+def smoke_humans(industry: str, n: int) -> list[dict[str, Any]]:
+    """n digital humans for a smoke: the control booker, or n easy/perfect tasks of the pack."""
+    import tasks_to_digital_humans as t2d  # repo script; source of truth for DH shape
+
+    if industry == "control-industry" or not (ROOT / "industries" / industry / "tasks").is_dir():
+        dh = dict(CONTROL_BOOKER)
+        dh["intent"] = t2d.with_scenario_clock(dh["intent"], industry)
+        return [dh]  # one DH, repeated by runs_per_digital_human
+    humans = t2d.build(industry)
+
+    def trait(h: dict[str, Any], name: str) -> str:
+        return str(t2d.trait_value(h, name) or "")
+
+    # one easy, clean-audio task per call area, so a 3-call smoke crosses three specialists
+    picked: list[dict[str, Any]] = []
+    seen_areas: set[str] = set()
+    for h in humans:
+        if trait(h, "difficulty") != "easy" or trait(h, "audio_condition") != "perfect":
+            continue
+        area = trait(h, "call_area")
+        if area in seen_areas:
+            continue
+        seen_areas.add(area)
+        picked.append(h)
+        if len(picked) == n:
+            break
+    if len(picked) < n:
+        picked += [h for h in humans if h not in picked][: n - len(picked)]
+    for h in picked:
+        h["test_name"] = f"MIVAS smoke · {h['test_name']}"
+        h["tags"] = list(h.get("tags") or []) + ["mivas_smoke"]
+    return picked
+
+
+def find_dh_by_test_name(title: str) -> dict[str, Any] | None:
+    body = req("GET", f"digital-human-by-test-name/{urllib.parse.quote(title, safe='')}", not_found_ok=True)
+    dh = _unwrap(body, "digital_human", "data") if body else {}
+    if isinstance(dh, dict) and dh.get("digital_human"):
+        dh = dh["digital_human"]
+    return dh if isinstance(dh, dict) and dh.get("id") else None
+
+
+def ensure_humans(humans: list[dict[str, Any]], sim_id: int) -> list[int]:
+    ids: list[int] = []
+    to_create: list[dict[str, Any]] = []
+    for dh in humans:
+        live = find_dh_by_test_name(dh["test_name"])
+        if live:
+            sims = {int(s) for s in (live.get("simulation_ids") or []) if str(s).isdigit()}
+            sims.add(sim_id)
+            req("PUT", f"update-digital-human/{live['id']}", {"simulation_ids": sorted(sims)})
+            ids.append(int(live["id"]))
+        else:
+            to_create.append(dh)
+    if to_create:
+        resp = req("POST", "create-digital-humans", {"simulation_ids": [sim_id], "digital_humans": to_create})
+        rows = resp.get("digital_humans") or resp.get("created") or resp.get("created_digital_humans") or []
+        if not rows and isinstance(resp.get("data"), list):
+            rows = resp["data"]
+        errs = resp.get("errors") or []
+        if errs:
+            raise SystemExit(f"create-digital-humans errors: {json.dumps(errs[:3])[:600]}")
+        for row in rows:
+            row = row.get("digital_human", row) if isinstance(row, dict) else row
+            if isinstance(row, dict) and row.get("id"):
+                ids.append(int(row["id"]))
+    if len(ids) != len(humans):
+        raise SystemExit(f"expected {len(humans)} digital humans on simulation {sim_id}, have {len(ids)}")
+    print(f"digital humans on simulation {sim_id}: {ids}", flush=True)
+    return ids
+
+
+def humans_on_simulation(sim_id: int) -> list[int]:
+    body = req("GET", f"digital-humans-by-simulation/{sim_id}")
+    rows = body.get("digital_humans") or body.get("data") or []
+    return [int(r["id"]) for r in rows if isinstance(r, dict) and r.get("id")]
+
+
+# ---------------------------------------------------------------- runs
+
+def queue(sim_id: int, dh_ids: list[int], runs: int) -> int:
+    body = req("POST", "queue-simulation-run", {
+        "simulation_id": str(sim_id),
+        "digital_human_ids": [str(i) for i in dh_ids],
+        "runs_per_digital_human": runs,
+    })
+    run_id = _id(body, "simulation_run_id", "run_id", "id")
+    if run_id is None:
+        raise SystemExit(f"queue-simulation-run returned no run id: {json.dumps(body)[:300]}")
+    print(f"queued run {run_id}: {len(dh_ids)} digital humans × {runs}", flush=True)
+    return int(run_id)
+
+
+def run_results(run_id: int) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+    body = req("GET", f"retrieve-simulation-results/{run_id}")
+    run = body.get("simulation_run") or {}
+    results = body.get("simulation_results") or body.get("results") or []
+    return run, results
+
+
+def poll(run_id: int, *, interval: int, timeout_min: int, sim_id: int | None = None) -> list[dict[str, Any]]:
+    deadline = time.monotonic() + timeout_min * 60
+    while True:
+        run, results = run_results(run_id)
+        counts: dict[str, int] = {}
+        for r in results:
+            counts[str(r.get("status"))] = counts.get(str(r.get("status")), 0) + 1
+        run_status = str(run.get("status") or "?")
+        settled = bool(results) and all(str(r.get("status")) not in NOT_FINAL for r in results)
+        print(f"run {run_id} {run_status}: {counts}", flush=True)
+        if settled and run_status.upper() not in NOT_FINAL:
+            return results
+        if time.monotonic() > deadline:
+            raise SystemExit(f"run {run_id} still not final after {timeout_min} min")
+        time.sleep(interval)
+
+
+def dump_results(run_id: int, out: Path) -> list[Path]:
+    out.mkdir(parents=True, exist_ok=True)
+    _, results = run_results(run_id)
+    paths: list[Path] = []
+    for r in results:
+        rid = r.get("id")
+        if rid is None:
+            continue
+        full = req("GET", f"retrieve-simulation-result/{rid}")
+        path = out / f"{rid}.json"
+        path.write_text(json.dumps(full, indent=2))
+        paths.append(path)
+    print(f"wrote {len(paths)} results → {out}", flush=True)
+    return paths
+
+
+def score_dir(out: Path, *, in_pod_tools: bool = False) -> bool:
+    paths = sorted(out.glob("*.json"))
+    if not paths:
+        raise SystemExit(f"no result JSON in {out}")
+    all_ok = True
+    print(f"{'result':>8} {'dh':>7} {'status':<20} {'goal':<5} rubric")
+    for path in paths:
+        result = score_rubric._unwrap(json.loads(path.read_text()))
+        status = str(result.get("status") or "?")
+        if status in NO_CONVERSATION:
+            print(f"{result.get('id')!s:>8} {result.get('digital_human_id')!s:>7} {status:<20} {'-':<5} FAIL (no conversation)")
+            all_ok = False
+            continue
+        transcript = score_rubric._fetch_transcript(str(result["transcript_url"])) if result.get("transcript_url") else None
+        score = score_rubric.score_call(result, transcript=transcript, in_pod_tools=in_pod_tools)
+        flags = " ".join(f"{k}={'ok' if score['checks'][k]['pass'] else 'FAIL'}" for k in score_rubric.CHECKS)
+        goal = result.get("goal_success")
+        goal_s = "-" if goal is None else ("yes" if goal else "no")
+        print(f"{result.get('id')!s:>8} {result.get('digital_human_id')!s:>7} {status:<20} {goal_s:<5} {'PASS' if score['pass'] else 'FAIL'} {flags}")
+        all_ok = all_ok and score["pass"]
+    print("goal_success is informational only; the rubric is the gate (see BLUEJAY.md).", flush=True)
+    return all_ok
+
+
+# ---------------------------------------------------------------- commands
+
+def cmd_ensure_agent(a: argparse.Namespace) -> int:
+    url = a.url or default_url(a.harness, a.industry)
+    if not url:
+        raise SystemExit("pass --url wss://… or set MIVAS_BASE_DOMAIN")
+    ensure_agent(a.harness, a.industry, url, a.user, a.password, a.name)
+    return 0
+
+
+def cmd_smoke(a: argparse.Namespace) -> int:
+    url = a.url or default_url(a.harness, a.industry)
+    if not url:
+        raise SystemExit("pass --url wss://… or set MIVAS_BASE_DOMAIN")
+    if url.startswith("ws://") or "localhost" in url or "127.0.0.1" in url:
+        raise SystemExit("Bluejay dials from the internet: use a public wss:// URL (ingress or a tunnel)")
+    agent_id = a.agent_id or ensure_agent(a.harness, a.industry, url, a.user, a.password, None)
+    pair = slug(a.harness, a.industry)
+    sim_id = create_simulation(
+        agent_id, f"MIVAS smoke · {pair}", minutes=a.minutes, max_concurrent=a.max_concurrent,
+    )
+    humans = smoke_humans(a.industry, a.calls)
+    dh_ids = ensure_humans(humans, sim_id)
+    runs = a.calls if len(dh_ids) == 1 else 1
+    run_id = queue(sim_id, dh_ids, runs)
+    print(f"{app_url()}/simulations/{sim_id}/runs/{run_id}", flush=True)
+    poll(run_id, interval=a.interval, timeout_min=a.timeout_min)
+    out = Path(a.out) if a.out else ROOT / "verify-out" / "smoke" / pair / str(run_id)
+    dump_results(run_id, out)
+    ok = score_dir(out, in_pod_tools=a.in_pod_tools)
+    summary = {"harness": a.harness, "industry": a.industry, "slug": pair, "agent_id": agent_id,
+               "simulation_id": sim_id, "run_id": run_id, "results_dir": str(out), "pass": ok,
+               "run_url": f"{app_url()}/simulations/{sim_id}/runs/{run_id}"}
+    (out / "smoke.json").write_text(json.dumps(summary, indent=2))
+    print(json.dumps(summary, indent=2), flush=True)
+    print("SMOKE PASS" if ok else "SMOKE FAIL — see HARNESS.md → fix loop", flush=True)
+    return 0 if ok else 1
+
+
+def cmd_queue(a: argparse.Namespace) -> int:
+    dh_ids = [int(x) for x in a.dh_ids] if a.dh_ids else humans_on_simulation(a.sim)
+    if not dh_ids:
+        raise SystemExit(f"simulation {a.sim} has no digital humans")
+    run_id = queue(a.sim, dh_ids, a.runs)
+    print(f"{app_url()}/simulations/{a.sim}/runs/{run_id}", flush=True)
+    return 0
+
+
+def cmd_poll(a: argparse.Namespace) -> int:
+    poll(a.run, interval=a.interval, timeout_min=a.timeout_min)
+    return 0
+
+
+def cmd_results(a: argparse.Namespace) -> int:
+    dump_results(a.run, Path(a.out))
+    return 0
+
+
+def cmd_score(a: argparse.Namespace) -> int:
+    return 0 if score_dir(Path(a.dir), in_pod_tools=a.in_pod_tools) else 1
+
+
+def cmd_full(a: argparse.Namespace) -> int:
+    """Whole industry: pack tasks → digital humans on a fresh simulation → queue k runs each."""
+    if not (ROOT / "industries" / a.industry / "tasks").is_dir():
+        raise SystemExit(f"{a.industry} has no scored task suite (control-industry is smoke-only)")
+    url = a.url or default_url(a.harness, a.industry)
+    agent_id = a.agent_id
+    if agent_id is None:
+        if not url:
+            raise SystemExit("pass --agent-id, or --url / MIVAS_BASE_DOMAIN so the agent can be ensured")
+        agent_id = ensure_agent(a.harness, a.industry, url, a.user, a.password, None)
+    pair = slug(a.harness, a.industry)
+    cmd = [sys.executable, str(ROOT / "scripts" / "tasks_to_digital_humans.py"),
+           "--industry", a.industry, "--push", "--agent-id", str(agent_id),
+           "--name", f"MIVAS {a.industry} · {a.harness} · k={a.runs}"]
+    print("+", " ".join(cmd), flush=True)
+    proc = subprocess.run(cmd, cwd=str(ROOT), capture_output=True, text=True)
+    sys.stdout.write(proc.stdout)
+    sys.stderr.write(proc.stderr)
+    if proc.returncode != 0:
+        return proc.returncode
+    sim_id = None
+    for line in proc.stdout.splitlines():
+        if line.startswith("simulation ") and " on agent " in line:
+            sim_id = int(line.split()[1])
+    if sim_id is None:
+        raise SystemExit("could not read the simulation id from tasks_to_digital_humans output")
+    update_simulation(sim_id, max_concurrent=a.max_concurrent, runs_per_digital_human=a.runs)
+    dh_ids = humans_on_simulation(sim_id)
+    run_id = queue(sim_id, dh_ids, a.runs)
+    run_url = f"{app_url()}/simulations/{sim_id}/runs/{run_id}"
+    print(run_url, flush=True)
+    print(
+        "\nwhen the run is final:\n"
+        f"  uv run python verifiers/verify_run.py {run_id}\n"
+        f"  uv run python verifiers/verify_task_run.py {run_id} --industry {a.industry} --harness {a.harness}\n"
+        f"  uv run python scripts/bluejay_run_to_csv.py {run_id} --industry {a.industry} --harness {a.harness}\n",
+        flush=True,
+    )
+    if a.no_wait:
+        print(f"resume with: bluejay.py poll --run {run_id}", flush=True)
+        return 0
+    poll(run_id, interval=a.interval, timeout_min=a.timeout_min)
+    print(f"run {run_id} final → {run_url}", flush=True)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    load_dotenv()
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    def pair_args(sp: argparse.ArgumentParser) -> None:
+        sp.add_argument("--harness", default=os.environ.get("HARNESS", "openai/realtime-2.1"))
+        sp.add_argument("--industry", default=os.environ.get("INDUSTRY", "control-industry"))
+        sp.add_argument("--url", help="public wss:// Bluejay should dial (default: wss://{slug}.$MIVAS_BASE_DOMAIN)")
+        sp.add_argument("--user", default=os.environ.get("CHIRP_USER", "mivas"))
+        sp.add_argument("--password", default=os.environ.get("CHIRP_PASS", "mivas"))
+
+    def poll_args(sp: argparse.ArgumentParser) -> None:
+        sp.add_argument("--interval", type=int, default=30, help="seconds between polls")
+        sp.add_argument("--timeout-min", type=int, default=240)
+
+    sp = sub.add_parser("ensure-agent", help="create or repoint the Bluejay WEBSOCKET agent for this pair")
+    pair_args(sp); sp.add_argument("--name"); sp.set_defaults(fn=cmd_ensure_agent)
+
+    sp = sub.add_parser("smoke", help="3 smoke calls on Bluejay, scored by the rubric")
+    pair_args(sp); poll_args(sp)
+    sp.add_argument("--calls", type=int, default=3)
+    sp.add_argument("--max-concurrent", type=int, default=1)
+    sp.add_argument("--minutes", type=int, default=4, help="max call duration")
+    sp.add_argument("--agent-id", type=int)
+    sp.add_argument("--out")
+    sp.add_argument("--in-pod-tools", action="store_true", help="count in-pod tool_post logs as the tool check")
+    sp.set_defaults(fn=cmd_smoke)
+
+    sp = sub.add_parser("queue", help="queue a run on an existing simulation")
+    poll_args(sp)
+    sp.add_argument("--sim", type=int, required=True)
+    sp.add_argument("--dh-ids", nargs="*", help="default: every digital human on the simulation")
+    sp.add_argument("--runs", type=int, default=1)
+    sp.set_defaults(fn=cmd_queue)
+
+    sp = sub.add_parser("poll", help="wait for a run to be final")
+    poll_args(sp); sp.add_argument("--run", type=int, required=True); sp.set_defaults(fn=cmd_poll)
+
+    sp = sub.add_parser("results", help="dump every result of a run as JSON")
+    sp.add_argument("--run", type=int, required=True); sp.add_argument("--out", required=True)
+    sp.set_defaults(fn=cmd_results)
+
+    sp = sub.add_parser("score", help="rubric over a results directory")
+    sp.add_argument("dir"); sp.add_argument("--in-pod-tools", action="store_true"); sp.set_defaults(fn=cmd_score)
+
+    sp = sub.add_parser("full", help="run the whole industry task suite (k runs per task)")
+    pair_args(sp); poll_args(sp)
+    sp.add_argument("--agent-id", type=int)
+    sp.add_argument("--runs", type=int, default=5, help="k conversations per task (Pass^k)")
+    sp.add_argument("--max-concurrent", type=int, default=3, help="≤ MIVAS_REPLICAS × in-process socket limit")
+    sp.add_argument("--no-wait", action="store_true")
+    sp.set_defaults(fn=cmd_full)
+
+    a = p.parse_args(argv)
+    return a.fn(a)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/mivas-run/scripts/preflight.py
+++ b/.claude/skills/mivas-run/scripts/preflight.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Phase-0/1 gate: is this machine, this pair, and this deployment ready for Bluejay?
+
+    uv run python .claude/skills/mivas-run/scripts/preflight.py --harness openai/realtime-2.1 --industry control-industry
+    uv run python .claude/skills/mivas-run/scripts/preflight.py ... --k8s                 # pods + wss probe via MIVAS_BASE_DOMAIN
+    uv run python .claude/skills/mivas-run/scripts/preflight.py ... --url wss://HOST      # probe an explicit URL (tunnel, Baseten proxy)
+
+Prints one PASS/FAIL/WARN/SKIP line per check; exit 1 on any FAIL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import shutil
+import socket
+import ssl
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[3]
+sys.path.insert(0, str(ROOT))
+
+PROVIDER_KEYS = {
+    "openai": [["OPENAI_API_KEY"]],
+    "gemini": [["GOOGLE_API_KEY"], ["LIVEKIT_URL"], ["LIVEKIT_API_KEY"], ["LIVEKIT_API_SECRET"]],
+    "aws": [["AWS_ACCESS_KEY_ID", "AWS_PROFILE"], ["AWS_SECRET_ACCESS_KEY", "AWS_PROFILE"]],
+    "grok": [["GROK_API_KEY", "XAI_API_KEY"]],
+    "qwen": [["DASHSCOPE_API_KEY", "QWEN_API_KEY"]],
+    "nvidia": [["NVIDIA_API_KEY", "NEMOTRON_LLM_BASE_URL"]],
+    "livekit": [["LIVEKIT_URL"], ["LIVEKIT_API_KEY"], ["LIVEKIT_API_SECRET"], ["OPENAI_API_KEY"], ["DEEPGRAM_API_KEY"], ["ELEVENLABS_API_KEY"]],
+}
+WORKER_FAMILIES = {"livekit", "gemini"}
+
+rows: list[tuple[str, str, str]] = []
+
+
+def rec(status: str, name: str, detail: str = "") -> None:
+    rows.append((status, name, detail))
+    print(f"{status:<5} {name:<34} {detail}", flush=True)
+
+
+def load_dotenv() -> None:
+    path = ROOT / ".env"
+    if not path.is_file():
+        rec("WARN", ".env", "missing; copy .env.example and fill keys")
+        return
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        os.environ.setdefault(k.strip(), v.strip().strip("'").strip('"'))
+
+
+def which(name: str, required: bool = True) -> bool:
+    ok = shutil.which(name) is not None
+    rec("PASS" if ok else ("FAIL" if required else "WARN"), f"tool: {name}", shutil.which(name) or "not on PATH")
+    return ok
+
+
+def check_bluejay_key() -> None:
+    key = os.environ.get("BLUEJAY_API_KEY", "").strip()
+    if not key:
+        rec("FAIL", "BLUEJAY_API_KEY", "unset — create one under API Keys in the Bluejay app")
+        return
+    api = os.environ.get("BLUEJAY_API_URL", "https://api.getbluejay.ai/v1").rstrip("/")
+    req = urllib.request.Request(f"{api}/all-agents", headers={"X-API-Key": key})
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            body = json.load(r)
+        rows_ = body if isinstance(body, list) else (body.get("agents") or body.get("data") or [])
+        rec("PASS", "BLUEJAY_API_KEY", f"GET all-agents 200 ({len(rows_)} agents visible)")
+    except urllib.error.HTTPError as e:
+        rec("FAIL", "BLUEJAY_API_KEY", f"GET all-agents → {e.code} (wrong key or org?)")
+    except urllib.error.URLError as e:
+        rec("FAIL", "BLUEJAY_API_KEY", f"{api} unreachable: {e}")
+
+
+def check_pair(harness: str, industry: str) -> None:
+    from run import harness_paths, ingress_adapter, split_harness
+
+    family, _ = split_harness(harness)
+    family_dir, agent_dir = harness_paths(harness)
+    rec("PASS" if (agent_dir / "agent.py").is_file() else "FAIL", "harness agent.py", str(agent_dir / "agent.py"))
+    rec("PASS" if (agent_dir / "Dockerfile").is_file() else "FAIL", "harness Dockerfile", str(agent_dir / "Dockerfile"))
+    if family in WORKER_FAMILIES:
+        rec("PASS", "harness ingress", f"{family} is a LiveKit SIP worker (no CHIRP adapter)")
+    else:
+        adapter = ingress_adapter(harness)
+        rec("PASS" if adapter.is_file() else "FAIL", "harness ingress adapter", str(adapter))
+    ind = ROOT / "industries" / industry
+    for f in ("agent_blueprint.json", "tools.json", "tool_server.py", "db/schema.sql", "db/seed.sql"):
+        rec("PASS" if (ind / f).is_file() else "FAIL", f"industry {f}", str(ind / f))
+    tasks = ind / "tasks"
+    if tasks.is_dir():
+        rec("PASS", "industry tasks", f"{len(list(tasks.iterdir()))} cases")
+    else:
+        rec("WARN", "industry tasks", "none — control-industry is a wiring smoke, not a scored suite")
+
+
+def check_provider_keys(harness: str) -> None:
+    family = harness.split("/", 1)[0]
+    groups = PROVIDER_KEYS.get(family)
+    if groups is None:
+        rec("WARN", "provider keys", f"unknown family {family}; check its README for env vars")
+        return
+    for alts in groups:
+        if any(os.environ.get(k, "").strip() for k in alts):
+            rec("PASS", f"env {' | '.join(alts)}", "set")
+        else:
+            rec("FAIL", f"env {' | '.join(alts)}", "unset — the pod reads it from mivas-secrets (synced from .env on --apply)")
+
+
+def check_blueprint(harness: str, industry: str) -> None:
+    cmd = ["uv", "run", "python", "run.py", "--harness", harness, "--industry", industry, "--check"]
+    # .env AGENTS= (a fleet list) would override --harness/--industry inside run.py
+    proc = subprocess.run(cmd, cwd=str(ROOT), capture_output=True, text=True, timeout=300,
+                          env={**os.environ, "AGENTS": ""})
+    tail = (proc.stdout + proc.stderr).strip().splitlines()[-1:] or [""]
+    rec("PASS" if proc.returncode == 0 else "FAIL", "run.py --check", tail[0][:110])
+
+
+def check_storage() -> None:
+    bucket = os.environ.get("MIVAS_SNAPSHOT_BUCKET", "").strip()
+    if not bucket:
+        rec("WARN", "snapshot store", "MIVAS_SNAPSHOT_BUCKET unset — hangup state stays in the pod; verifier state compare is skipped")
+        return
+    try:
+        import boto3
+    except ImportError:
+        rec("FAIL", "snapshot store", "boto3 missing in this venv (uv sync)")
+        return
+    try:
+        region = os.environ.get("AWS_DEFAULT_REGION") or os.environ.get("AWS_REGION") or "us-west-1"
+        boto3.client("s3", region_name=region).head_bucket(Bucket=bucket)
+        ep = os.environ.get("AWS_ENDPOINT_URL_S3", "") or "aws"
+        rec("PASS", "snapshot store", f"s3://{bucket} reachable from here (endpoint {ep})")
+    except Exception as e:  # noqa: BLE001
+        rec("FAIL", "snapshot store", f"head_bucket {bucket}: {type(e).__name__}: {str(e)[:90]}")
+
+
+def check_k8s(harness: str, industry: str) -> str | None:
+    from run import slug
+
+    if not which("kubectl"):
+        return None
+    ctx = subprocess.run(["kubectl", "config", "current-context"], capture_output=True, text=True)
+    rec("PASS" if ctx.returncode == 0 else "FAIL", "kube context", ctx.stdout.strip() or ctx.stderr.strip()[:100])
+    name = f"mivas-{slug(harness, industry)}"
+    dep = subprocess.run(["kubectl", "get", "deploy", name, "-o", "json"], capture_output=True, text=True)
+    if dep.returncode != 0:
+        rec("FAIL", f"deployment {name}", "not found — run.py --build --apply (or --codebuild) first")
+        return None
+    st = json.loads(dep.stdout).get("status") or {}
+    ready, want = st.get("readyReplicas", 0), st.get("replicas", 0)
+    rec("PASS" if ready and ready == want else "FAIL", f"deployment {name}", f"{ready}/{want} ready")
+    pods = subprocess.run(["kubectl", "get", "pods", "-l", f"mivas.slug={slug(harness, industry)}", "-o", "name"],
+                          capture_output=True, text=True).stdout.split()
+    listening = 0
+    for pod in pods:
+        logs = subprocess.run(["kubectl", "logs", pod, "--tail=400"], capture_output=True, text=True).stdout
+        if any(tok in logs for tok in ("ws↔", "starting CHIRP", "starting LiveKit SIP worker", "listening")):
+            listening += 1
+        if "snapshot: NO AWS CREDENTIALS" in logs:
+            rec("FAIL", f"{pod} snapshot creds", "pod has a bucket but no credentials (Pod Identity / IRSA / static keys)")
+    rec("PASS" if pods and listening == len(pods) else "FAIL", "CHIRP listening", f"{listening}/{len(pods)} pods log the bind line")
+    base = os.environ.get("MIVAS_BASE_DOMAIN", "").strip()
+    return f"wss://{slug(harness, industry)}.{base}" if base and harness.split('/')[0] not in WORKER_FAMILIES else None
+
+
+def probe_wss(url: str, user: str, password: str) -> None:
+    """One WebSocket upgrade with CHIRP basic auth. 101 = ingress, TLS and auth all work."""
+    from urllib.parse import urlparse
+
+    u = urlparse(url)
+    host, port = u.hostname or "", u.port or (443 if u.scheme == "wss" else 80)
+    path = u.path or "/"
+    key = base64.b64encode(os.urandom(16)).decode()
+    auth = base64.b64encode(f"{user}:{password}".encode()).decode()
+    request = (
+        f"GET {path} HTTP/1.1\r\nHost: {host}\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n"
+        f"Sec-WebSocket-Key: {key}\r\nSec-WebSocket-Version: 13\r\nAuthorization: Basic {auth}\r\n"
+        f"X-Simulation-Result-Id: preflight\r\n\r\n"
+    )
+    try:
+        raw = socket.create_connection((host, port), timeout=15)
+        sock = ssl.create_default_context().wrap_socket(raw, server_hostname=host) if u.scheme == "wss" else raw
+        sock.sendall(request.encode())
+        head = sock.recv(4096).decode(errors="replace").split("\r\n", 1)[0]
+        sock.close()
+    except Exception as e:  # noqa: BLE001
+        rec("FAIL", "wss probe", f"{url}: {type(e).__name__}: {str(e)[:100]}")
+        return
+    if " 101 " in head:
+        rec("PASS", "wss probe", f"{url} → {head}")
+    elif " 401 " in head or " 403 " in head:
+        rec("FAIL", "wss probe", f"{url} → {head} (CHIRP_USER/CHIRP_PASS mismatch with the Bluejay agent)")
+    else:
+        rec("FAIL", "wss probe", f"{url} → {head}")
+    if u.scheme != "wss":
+        rec("FAIL", "wss probe", "Bluejay requires wss:// — put a tunnel or TLS ingress in front")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--harness", default=os.environ.get("HARNESS", "openai/realtime-2.1"))
+    p.add_argument("--industry", default=os.environ.get("INDUSTRY", "control-industry"))
+    p.add_argument("--k8s", action="store_true", help="also check the Deployment and probe wss://{slug}.$MIVAS_BASE_DOMAIN")
+    p.add_argument("--url", help="probe this wss:// URL instead (tunnel, Baseten proxy, custom DNS)")
+    p.add_argument("--skip-check", action="store_true", help="skip run.py --check (slow on first uv sync)")
+    a = p.parse_args(argv)
+    load_dotenv()
+    print(f"preflight {a.harness} × {a.industry}\n", flush=True)
+    which("uv"); which("docker", required=False)
+    v = sys.version_info
+    rec("PASS" if (v.major, v.minor) >= (3, 12) else "FAIL", "python", f"{v.major}.{v.minor}")
+    check_bluejay_key()
+    check_pair(a.harness, a.industry)
+    check_provider_keys(a.harness)
+    if not a.skip_check:
+        check_blueprint(a.harness, a.industry)
+    check_storage()
+    url = a.url
+    if a.k8s:
+        url = check_k8s(a.harness, a.industry) or url
+    if url:
+        probe_wss(url, os.environ.get("CHIRP_USER", "mivas"), os.environ.get("CHIRP_PASS", "mivas"))
+    elif a.k8s:
+        rec("SKIP", "wss probe", "no MIVAS_BASE_DOMAIN and no --url (worker family, or local: pass the tunnel URL)")
+    fails = [r for r in rows if r[0] == "FAIL"]
+    print(f"\n{len(fails)} FAIL · {sum(r[0] == 'WARN' for r in rows)} WARN · {sum(r[0] == 'PASS' for r in rows)} PASS", flush=True)
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/mivas-run/scripts/score_rubric.py
+++ b/.claude/skills/mivas-run/scripts/score_rubric.py
@@ -1,0 +1,402 @@
+#!/usr/bin/env python3
+"""Score one Bluejay get_simulation_result JSON against the MIVAS smoke rubric.
+
+Stdlib only. Reads a result payload (MCP envelope or the simulation_result object)
+and optional transcript JSON. Prints one JSON object per call and exits 0 iff every
+file PASSes all six checks.
+
+    python scripts/score_rubric.py result.json [result.json ...]
+    python scripts/score_rubric.py --self-test
+
+Do not eyeball time_to_first_agent_utterance — this script is the source of truth
+for check 6 (opening silence).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+from urllib.request import urlopen
+
+TTFA_MAX_MS = 3000
+PUNCT_MAX_MS = 25000
+GAP_MAX_MS = 8000
+CLIP_EPS = 0.001
+NUDGE_RE = re.compile(
+    r"are you still there|haven't heard from you",
+    re.IGNORECASE,
+)
+HANGUP_GAP_OK = frozenset({"transfer_to_human", "end_call"})
+MAX_LENGTH_RE = re.compile(r"max call length reached", re.IGNORECASE)
+CHECKS = (
+    "utterances",
+    "tool_calls",
+    "traces",
+    "dead_air",
+    "audio_continuity",
+    "opening_silence",
+)
+
+
+def _unwrap(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise SystemExit("result JSON must be an object")
+    if isinstance(payload.get("simulation_result"), dict):
+        inner = payload["simulation_result"]
+        if isinstance(inner.get("simulation_result"), dict):
+            return inner["simulation_result"]
+        return inner
+    if isinstance(payload.get("data"), dict) and isinstance(
+        payload["data"].get("simulation_result"), dict
+    ):
+        return payload["data"]["simulation_result"]
+    return payload
+
+
+def _metric(result: dict[str, Any], name: str) -> Any:
+    for row in result.get("metrics") or []:
+        if isinstance(row, dict) and row.get("name") == name:
+            return row.get("value")
+    return None
+
+
+def _num(value: Any) -> float | None:
+    if value is None or value is False:
+        return None
+    if isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _turns(result: dict[str, Any]) -> int:
+    evals = result.get("evaluations") or []
+    if evals and isinstance(evals[0], dict) and evals[0].get("num_turns") is not None:
+        try:
+            return int(evals[0]["num_turns"])
+        except (TypeError, ValueError):
+            pass
+    n = _metric(result, "num_turns")
+    return int(n) if n is not None else 0
+
+
+def _has_actual(result: dict[str, Any]) -> bool:
+    for row in result.get("tool_calls") or []:
+        if isinstance(row, dict) and row.get("actual"):
+            return True
+    return False
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text())
+
+
+def _fetch_transcript(url: str) -> list[dict[str, Any]] | None:
+    try:
+        with urlopen(url, timeout=30) as resp:
+            data = json.loads(resp.read().decode())
+    except Exception:
+        return None
+    if isinstance(data, list):
+        return [t for t in data if isinstance(t, dict)]
+    if isinstance(data, dict):
+        for key in ("transcript", "utterances", "turns"):
+            rows = data.get(key)
+            if isinstance(rows, list):
+                return [t for t in rows if isinstance(t, dict)]
+    return None
+
+
+def _speaker(turn: dict[str, Any]) -> str:
+    raw = (
+        turn.get("speaker")
+        or turn.get("role")
+        or turn.get("type")
+        or ""
+    )
+    return str(raw).strip().lower()
+
+
+def _is_agent(turn: dict[str, Any]) -> bool:
+    sp = _speaker(turn)
+    return sp in {"agent", "assistant", "bot", "ai"}
+
+
+def _is_user(turn: dict[str, Any]) -> bool:
+    sp = _speaker(turn)
+    return sp in {"user", "customer", "human", "caller"}
+
+
+def _text(turn: dict[str, Any]) -> str:
+    return str(turn.get("text") or turn.get("content") or turn.get("transcript") or "")
+
+
+def _offset(turn: dict[str, Any], key: str) -> float | None:
+    return _num(turn.get(key) or turn.get(key.replace("_ms", "")))
+
+
+def _nudge_turns(transcript: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [t for t in transcript if _is_user(t) and NUDGE_RE.search(_text(t))]
+
+
+def _first_agent_start_ms(transcript: list[dict[str, Any]]) -> float | None:
+    for turn in transcript:
+        if _is_agent(turn):
+            return _offset(turn, "start_offset_ms") or _offset(turn, "start_ts") or 0.0
+    return None
+
+
+def _user_agent_gaps(
+    transcript: list[dict[str, Any]],
+    *,
+    hangup_after_ms: float | None,
+) -> list[float]:
+    gaps: list[float] = []
+    for i, turn in enumerate(transcript):
+        if not _is_user(turn):
+            continue
+        end = _offset(turn, "end_offset_ms")
+        if end is None:
+            continue
+        nxt = next((t for t in transcript[i + 1 :] if _is_agent(t)), None)
+        if nxt is None:
+            continue
+        start = _offset(nxt, "start_offset_ms")
+        if start is None:
+            continue
+        if MAX_LENGTH_RE.search(_text(nxt)):
+            continue
+        if hangup_after_ms is not None and end >= hangup_after_ms:
+            continue
+        gaps.append(start - end)
+    return gaps
+
+
+def _tools_after_nudge(
+    result: dict[str, Any], transcript: list[dict[str, Any]]
+) -> bool:
+    nudges = _nudge_turns(transcript)
+    if not nudges:
+        return False
+    earliest = min(
+        (_offset(t, "start_offset_ms") or 0.0) for t in nudges
+    )
+    for row in result.get("tool_calls") or []:
+        if not isinstance(row, dict):
+            continue
+        for actual in row.get("actual") or []:
+            if not isinstance(actual, dict):
+                continue
+            start = _num(actual.get("start_offset_ms"))
+            if start is not None and start >= earliest:
+                return True
+    return False
+
+
+def _hangup_after_ms(result: dict[str, Any]) -> float | None:
+    earliest: float | None = None
+    for row in result.get("tool_calls") or []:
+        if not isinstance(row, dict):
+            continue
+        if str(row.get("name") or "") not in HANGUP_GAP_OK:
+            continue
+        for actual in row.get("actual") or []:
+            if not isinstance(actual, dict):
+                continue
+            start = _num(actual.get("start_offset_ms"))
+            if start is None:
+                continue
+            earliest = start if earliest is None else min(earliest, start)
+    return earliest
+
+
+def score_call(
+    result: dict[str, Any],
+    *,
+    transcript: list[dict[str, Any]] | None = None,
+    in_pod_tools: bool = False,
+) -> dict[str, Any]:
+    result = _unwrap(result)
+    checks: dict[str, dict[str, Any]] = {}
+
+    turns = _turns(result)
+    url = result.get("transcript_url") or ""
+    checks["utterances"] = {
+        "pass": turns > 0 and bool(url),
+        "num_turns": turns,
+        "transcript_url": bool(url),
+    }
+
+    has_actual = _has_actual(result)
+    checks["tool_calls"] = {
+        "pass": has_actual or in_pod_tools,
+        "has_actual": has_actual,
+        "in_pod_tools": in_pod_tools,
+    }
+
+    traces = [t for t in (result.get("trace_ids") or []) if t]
+    checks["traces"] = {"pass": bool(traces), "trace_ids": traces}
+
+    punct = _num(_metric(result, "max_punctuation_latency"))
+    dead = {
+        "max_punctuation_latency": punct,
+        "nudge": False,
+        "max_user_agent_gap_ms": None,
+        "tool_after_nudge": False,
+    }
+    dead_ok = punct is not None and punct <= PUNCT_MAX_MS
+    if transcript is not None:
+        dead["nudge"] = bool(_nudge_turns(transcript))
+        gaps = _user_agent_gaps(transcript, hangup_after_ms=_hangup_after_ms(result))
+        dead["max_user_agent_gap_ms"] = max(gaps) if gaps else 0.0
+        dead["tool_after_nudge"] = _tools_after_nudge(result, transcript)
+        dead_ok = (
+            dead_ok
+            and not dead["nudge"]
+            and dead["max_user_agent_gap_ms"] <= GAP_MAX_MS
+            and not dead["tool_after_nudge"]
+        )
+    dead["pass"] = dead_ok
+    checks["dead_air"] = dead
+
+    dropouts = _num(_metric(result, "agent_audio_dropouts"))
+    clipping = _num(_metric(result, "agent_audio_clipping"))
+    clip_ok = clipping is not None and clipping < CLIP_EPS
+    drop_ok = dropouts is not None and dropouts == 0
+    checks["audio_continuity"] = {
+        "pass": drop_ok and clip_ok,
+        "agent_audio_dropouts": dropouts,
+        "agent_audio_clipping": clipping,
+    }
+
+    ttfa = _num(_metric(result, "time_to_first_agent_utterance"))
+    first_agent = _first_agent_start_ms(transcript) if transcript is not None else None
+    opening_ok = ttfa is not None and ttfa <= TTFA_MAX_MS
+    if first_agent is not None:
+        opening_ok = opening_ok and first_agent <= TTFA_MAX_MS
+    checks["opening_silence"] = {
+        "pass": opening_ok,
+        "time_to_first_agent_utterance": ttfa,
+        "first_agent_start_offset_ms": first_agent,
+        "max_ms": TTFA_MAX_MS,
+    }
+
+    passed = all(checks[name]["pass"] for name in CHECKS)
+    return {
+        "id": result.get("id"),
+        "digital_human_id": result.get("digital_human_id"),
+        "pass": passed,
+        "checks": checks,
+    }
+
+
+def _print_score(score: dict[str, Any]) -> None:
+    flags = " ".join(
+        f"{name}={'PASS' if score['checks'][name]['pass'] else 'FAIL'}"
+        for name in CHECKS
+    )
+    ttfa = score["checks"]["opening_silence"].get("time_to_first_agent_utterance")
+    print(
+        f"{'PASS' if score['pass'] else 'FAIL'} id={score.get('id')} "
+        f"dh={score.get('digital_human_id')} ttfa_ms={ttfa} {flags}",
+        flush=True,
+    )
+    print(json.dumps(score, indent=2), flush=True)
+
+
+def _self_test() -> int:
+    base = {
+        "id": 1,
+        "digital_human_id": 1,
+        "transcript_url": "https://example.invalid/t.json",
+        "trace_ids": ["abc"],
+        "evaluations": [{"num_turns": 8}],
+        "tool_calls": [{"name": "identify_patient", "actual": [{"start_offset_ms": 1000}]}],
+        "metrics": [
+            {"name": "max_punctuation_latency", "value": 12000},
+            {"name": "agent_audio_dropouts", "value": 0},
+            {"name": "agent_audio_clipping", "value": 0},
+            {"name": "time_to_first_agent_utterance", "value": 80},
+        ],
+    }
+    greeting = [
+        {"speaker": "agent", "text": "Thanks for calling", "start_offset_ms": 80, "end_offset_ms": 4000},
+        {"speaker": "user", "text": "hi", "start_offset_ms": 5000, "end_offset_ms": 6000},
+        {"speaker": "agent", "text": "sure", "start_offset_ms": 7500, "end_offset_ms": 9000},
+    ]
+    ok = score_call(base, transcript=greeting)
+    assert ok["pass"], ok
+
+    silent = json.loads(json.dumps(base))
+    silent["metrics"][3]["value"] = 18105
+    bad = score_call(silent, transcript=[
+        {"speaker": "agent", "text": "hi", "start_offset_ms": 18105, "end_offset_ms": 20000},
+    ])
+    assert not bad["pass"]
+    assert not bad["checks"]["opening_silence"]["pass"]
+
+    edge = json.loads(json.dumps(base))
+    edge["metrics"][3]["value"] = TTFA_MAX_MS
+    assert score_call(edge, transcript=[
+        {"speaker": "agent", "text": "hi", "start_offset_ms": TTFA_MAX_MS, "end_offset_ms": TTFA_MAX_MS + 1000},
+    ])["checks"]["opening_silence"]["pass"]
+
+    over = json.loads(json.dumps(base))
+    over["metrics"][3]["value"] = TTFA_MAX_MS + 1
+    assert not score_call(over)["checks"]["opening_silence"]["pass"]
+
+    missing = json.loads(json.dumps(base))
+    missing["metrics"] = [m for m in missing["metrics"] if m["name"] != "time_to_first_agent_utterance"]
+    assert not score_call(missing)["checks"]["opening_silence"]["pass"]
+
+    envelope = {"simulation_result": base}
+    assert score_call(envelope, transcript=greeting)["pass"]
+
+    print("self-test ok", flush=True)
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument("results", nargs="*", type=Path, help="get_simulation_result JSON files")
+    p.add_argument("--transcript", type=Path, help="optional transcript JSON (applies to every file)")
+    p.add_argument("--in-pod-tools", action="store_true", help="treat in-pod tool_post as check 2 pass")
+    p.add_argument("--fetch-transcript", action="store_true", help="HTTP GET transcript_url when local file omitted")
+    p.add_argument("--self-test", action="store_true")
+    args = p.parse_args(argv)
+    if args.self_test:
+        return _self_test()
+    if not args.results:
+        p.error("need result JSON files (or --self-test)")
+    transcript = None
+    if args.transcript:
+        raw = _load_json(args.transcript)
+        if isinstance(raw, list):
+            transcript = [t for t in raw if isinstance(t, dict)]
+        elif isinstance(raw, dict):
+            for key in ("transcript", "utterances", "turns"):
+                rows = raw.get(key)
+                if isinstance(rows, list):
+                    transcript = [t for t in rows if isinstance(t, dict)]
+                    break
+    failed = 0
+    for path in args.results:
+        result = _unwrap(_load_json(path))
+        turns = transcript
+        if turns is None and args.fetch_transcript and result.get("transcript_url"):
+            turns = _fetch_transcript(str(result["transcript_url"]))
+        score = score_call(result, transcript=turns, in_pod_tools=args.in_pod_tools)
+        _print_score(score)
+        if not score["pass"]:
+            failed += 1
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/mivas-run/scripts/verify_integrity.py
+++ b/.claude/skills/mivas-run/scripts/verify_integrity.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Phase 3: harness integrity + benchmark integrity after a passing smoke.
+
+    uv run python .claude/skills/mivas-run/scripts/verify_integrity.py \
+        --harness openai/realtime-2.1 --industry healthcare \
+        --smoke-dir verify-out/smoke/openai-realtime-2-1-healthcare/RUN_ID [--k8s]
+
+Harness integrity: repo unit tests, blueprint --check, smoke rubric all PASS,
+every smoke result is scorable (verify_run.py), and a hangup snapshot exists for
+every smoke conversation (S3-compatible store, or the pod's /data/calls).
+Benchmark integrity (scored industries): task suite builds into digital humans
+without contract errors, expected final states replay cleanly onto the pack's
+seed, and the verifier tests pass. Exit 1 on any FAIL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+ROOT = HERE.parents[3]
+sys.path.insert(0, str(ROOT))
+sys.path.insert(0, str(HERE))
+
+rows: list[tuple[str, str, str]] = []
+
+
+def rec(status: str, name: str, detail: str = "") -> None:
+    rows.append((status, name, detail))
+    print(f"{status:<5} {name:<36} {detail}", flush=True)
+
+
+def load_dotenv() -> None:
+    path = ROOT / ".env"
+    if not path.is_file():
+        return
+    for raw in path.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        k, _, v = line.partition("=")
+        os.environ.setdefault(k.strip(), v.strip().strip("'").strip('"'))
+
+
+def sh(name: str, cmd: list[str], *, ok_detail: str = "ok", timeout: int = 900) -> bool:
+    # AGENTS="" so a fleet list in .env cannot override --harness/--industry inside run.py
+    proc = subprocess.run(cmd, cwd=str(ROOT), capture_output=True, text=True, timeout=timeout,
+                          env={**os.environ, "AGENTS": ""})
+    out = (proc.stdout + proc.stderr).strip().splitlines()
+    if proc.returncode == 0:
+        rec("PASS", name, ok_detail if ok_detail != "tail" else (out[-1][:100] if out else ""))
+        return True
+    failed = [l for l in out if l.startswith("FAILED") or "Error" in l or "error" in l][:4]
+    rec("FAIL", name, " | ".join(failed or out[-2:])[:160])
+    return False
+
+
+def smoke_results(smoke_dir: Path) -> list[dict]:
+    import score_rubric
+
+    return [score_rubric._unwrap(json.loads(p.read_text())) for p in sorted(smoke_dir.glob("*.json")) if p.name != "smoke.json"]
+
+
+def check_snapshots(results: list[dict], slug: str, k8s: bool) -> None:
+    ids = [str(r.get("id")) for r in results if r.get("id") is not None]
+    bucket = os.environ.get("MIVAS_SNAPSHOT_BUCKET", "").strip()
+    prefix = (os.environ.get("MIVAS_SNAPSHOT_PREFIX", "mivas").strip() or "mivas").strip("/")
+    if bucket:
+        import boto3
+
+        region = os.environ.get("AWS_DEFAULT_REGION") or os.environ.get("AWS_REGION") or "us-west-1"
+        s3 = boto3.client("s3", region_name=region)
+        missing = []
+        for rid in ids:
+            try:
+                s3.head_object(Bucket=bucket, Key=f"{prefix}/{slug}/{rid}.final.json")
+            except Exception:  # noqa: BLE001
+                missing.append(rid)
+        rec("PASS" if not missing else "FAIL", "hangup snapshots (S3)",
+            f"{len(ids) - len(missing)}/{len(ids)} in s3://{bucket}/{prefix}/{slug}/" + (f" missing {missing}" if missing else ""))
+        return
+    if k8s:
+        pods = subprocess.run(["kubectl", "get", "pods", "-l", f"mivas.slug={slug}", "-o", "name"],
+                              capture_output=True, text=True).stdout.split()
+        found = set()
+        for pod in pods:
+            ls = subprocess.run(["kubectl", "exec", pod, "--", "ls", "/data/calls"], capture_output=True, text=True).stdout
+            for rid in ids:
+                if f"{rid}.final.json" in ls:
+                    found.add(rid)
+        rec("PASS" if found == set(ids) else "FAIL", "hangup snapshots (pod /data/calls)",
+            f"{len(found)}/{len(ids)} present across {len(pods)} pod(s); set MIVAS_SNAPSHOT_BUCKET before a full run")
+        return
+    rec("SKIP", "hangup snapshots", "no MIVAS_SNAPSHOT_BUCKET and not --k8s")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--harness", default=os.environ.get("HARNESS", "openai/realtime-2.1"))
+    p.add_argument("--industry", default=os.environ.get("INDUSTRY", "control-industry"))
+    p.add_argument("--smoke-dir", type=Path, help="results dir written by bluejay.py smoke")
+    p.add_argument("--k8s", action="store_true", help="look for snapshots in the pods when no bucket is set")
+    p.add_argument("--skip-tests", action="store_true")
+    a = p.parse_args(argv)
+    load_dotenv()
+    from run import slug
+
+    pair = slug(a.harness, a.industry)
+    print(f"integrity {a.harness} × {a.industry}\n== harness", flush=True)
+
+    if not a.skip_tests:
+        sh("repo unit tests", ["uv", "run", "pytest", "tests", "-q", "-p", "no:cacheprovider"], ok_detail="tail")
+    sh("blueprint --check", ["uv", "run", "python", "run.py", "--harness", a.harness, "--industry", a.industry, "--check"])
+
+    if a.smoke_dir and a.smoke_dir.is_dir():
+        results = smoke_results(a.smoke_dir)
+        sh("smoke rubric", [sys.executable, str(HERE / "bluejay.py"), "score", str(a.smoke_dir)], ok_detail=f"{len(results)} calls PASS")
+        run_id = None
+        meta = a.smoke_dir / "smoke.json"
+        if meta.is_file():
+            run_id = json.loads(meta.read_text()).get("run_id")
+        if run_id:
+            sh("scorable (verify_run.py)", ["uv", "run", "python", "verifiers/verify_run.py", str(run_id)], ok_detail="no void results")
+        else:
+            rec("SKIP", "scorable (verify_run.py)", "smoke.json missing run_id")
+        check_snapshots(results, pair, a.k8s)
+    else:
+        rec("SKIP", "smoke rubric", "pass --smoke-dir from bluejay.py smoke")
+
+    print("== benchmark", flush=True)
+    tasks = ROOT / "industries" / a.industry / "tasks"
+    if not tasks.is_dir():
+        rec("SKIP", "task suite", f"{a.industry} has no scored tasks (control-industry is wiring-only)")
+    else:
+        with tempfile.TemporaryDirectory() as tmp:
+            dh_json = Path(tmp) / "dh.json"
+            proc = subprocess.run(["uv", "run", "python", "scripts/tasks_to_digital_humans.py", "--industry", a.industry, "--json"],
+                                  cwd=str(ROOT), capture_output=True, text=True)
+            if proc.returncode == 0:
+                dh_json.write_text(proc.stdout)
+                parsed = json.loads(proc.stdout)
+                n = len(parsed.get("digital_humans", parsed) if isinstance(parsed, dict) else parsed)
+                rec("PASS", "tasks → digital humans", f"{n} cases pass the pack contract check")
+                sh("expected final states replay", ["uv", "run", "python", "verifiers/expected_final_state.py",
+                    "--industry", a.industry, "--from-json", str(dh_json), "--out", str(Path(tmp) / "expected")],
+                   ok_detail="every task's exp_tool_calls replay onto seed")
+            else:
+                rec("FAIL", "tasks → digital humans", (proc.stderr or proc.stdout).strip().splitlines()[-1][:150])
+        if not a.skip_tests:
+            sh("verifier tests", ["uv", "run", "pytest", "-q", "-p", "no:cacheprovider",
+                "tests/test_expected_final_state.py", "tests/test_verify_task_run.py",
+                "tests/test_tasks_to_digital_humans.py", "tests/test_industry_contract.py",
+                "tests/test_tool_server.py", "tests/test_snapshot.py", "tests/test_snapshot_coverage.py"], ok_detail="tail")
+
+    fails = [r for r in rows if r[0] == "FAIL"]
+    print(f"\n{len(fails)} FAIL · {sum(r[0] == 'SKIP' for r in rows)} SKIP · {sum(r[0] == 'PASS' for r in rows)} PASS", flush=True)
+    print("INTEGRITY PASS" if not fails else "INTEGRITY FAIL", flush=True)
+    return 1 if fails else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.env.example
+++ b/.env.example
@@ -125,6 +125,18 @@ MIVAS_IMAGE_PREFIX=
 # MIVAS_SNAPSHOT_BUCKET=   # S3 bucket for hangup {id}.final.json + {id}.db
 # MIVAS_SNAPSHOT_PREFIX=mivas
 # AWS_DEFAULT_REGION=
+# S3-compatible store instead of AWS S3 (MinIO in-cluster, Cloudflare R2, GCS interop):
+# AWS_ENDPOINT_URL_S3=http://minio:9000   # pods; use the port-forward URL when running verifiers locally
+# AWS_ACCESS_KEY_ID= / AWS_SECRET_ACCESS_KEY= then hold that store's keys
+# EKS IRSA instead of Pod Identity: annotate the mivas-bench ServiceAccount
+# MIVAS_IRSA_ROLE_ARN=
+#
+# Non-EKS clusters (kind, k3s, GKE, AKS, DOKS, ...): any ingress controller + cert-manager.
+# Set the class and the app renders k8s/ingress-generic.yaml instead of the EKS ALB pair
+# (MIVAS_ACM_CERTIFICATE_ARN is not needed). Wildcard DNS *.MIVAS_BASE_DOMAIN → controller IP.
+# MIVAS_INGRESS_CLASS=nginx
+# MIVAS_CLUSTER_ISSUER=letsencrypt-prod   # cert-manager ClusterIssuer; or
+# MIVAS_TLS_SECRET=mivas-wildcard-tls     # a TLS Secret you provisioned yourself
 
 #
 # Local / kind (no MIVAS_BASE_DOMAIN):

--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,6 @@ Thumbs.db
 # call areas and one-pager under docs/<industry>/, and none of it is tracked.
 docs/
 graphify-out/
-.claude/
+# .claude/skills/ ships with the repo (mivas-run); the rest stays local.
+.claude/*
+!.claude/skills/

--- a/README.md
+++ b/README.md
@@ -310,6 +310,8 @@ See [tests/README.md](tests/README.md) for the text fallback and additional loca
 
 ## Deployment
 
+The end-to-end consumer path (prerequisites, Kubernetes targets, Bluejay smoke calls, integrity checks, full industry run) is the `mivas-run` skill in [`.claude/skills/mivas-run/`](.claude/skills/mivas-run/SKILL.md); it works as plain documentation too.
+
 Each harness and industry pair becomes a Kubernetes Deployment and Service:
 
 ```bash

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -251,6 +251,13 @@ spec:
                   name: mivas-secrets
                   key: AWS_SESSION_TOKEN
                   optional: true
+            # S3-compatible snapshot store (MinIO / R2 / GCS interop). Unset = AWS S3.
+            - name: AWS_ENDPOINT_URL_S3
+              valueFrom:
+                secretKeyRef:
+                  name: mivas-secrets
+                  key: AWS_ENDPOINT_URL_S3
+                  optional: true
             - name: LIVEKIT_URL
               valueFrom:
                 secretKeyRef:

--- a/k8s/ingress-generic.yaml
+++ b/k8s/ingress-generic.yaml
@@ -1,0 +1,38 @@
+# Any ingress controller (ingress-nginx, traefik, GKE, ...) when MIVAS_INGRESS_CLASS is set.
+# Host: __HOST__  →  wss://__HOST__/ (Bluejay dials)  and  https://__HOST__/ (PUBLIC_URL)
+# TLS: cert-manager issues mivas-<slug>-tls when MIVAS_CLUSTER_ISSUER is set, or point
+# MIVAS_TLS_SECRET at a Secret you provisioned (wildcard cert for *.MIVAS_BASE_DOMAIN).
+# CHIRP sockets live for the whole call; the timeouts below stop nginx cutting them at 60s.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mivas-__SLUG__
+  labels:
+    app: mivas-bench
+    mivas.harness_family: "__HARNESS_FAMILY__"
+    mivas.harness_runtime: "__HARNESS_RUNTIME__"
+    mivas.industry: "__INDUSTRY__"
+    mivas.slug: "__SLUG__"
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-body-size: "16m"
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    __CLUSTER_ISSUER_ANNOTATION__
+spec:
+  ingressClassName: __INGRESS_CLASS__
+  tls:
+    - hosts:
+        - __HOST__
+      secretName: __TLS_SECRET__
+  rules:
+    - host: __HOST__
+      http:
+        paths:
+          - path: __INGRESS_PATH__
+            pathType: Prefix
+            backend:
+              service:
+                name: mivas-__SLUG__
+                port:
+                  name: __INGRESS_PORT_NAME__

--- a/k8s/secret.example.yaml
+++ b/k8s/secret.example.yaml
@@ -34,6 +34,8 @@ stringData:
   AWS_ACCESS_KEY_ID: ""
   AWS_SECRET_ACCESS_KEY: ""
   AWS_SESSION_TOKEN: ""
+  # S3-compatible endpoint for snapshots (MinIO/R2). Empty = AWS S3.
+  AWS_ENDPOINT_URL_S3: ""
   DAILY_API_KEY: ""
   LIVEKIT_URL: ""
   LIVEKIT_API_KEY: ""

--- a/k8s/serviceaccount.yaml
+++ b/k8s/serviceaccount.yaml
@@ -1,0 +1,12 @@
+# Pod identity for every MIVAS Deployment. Rendered on every --apply so a fresh
+# cluster (kind, k3s, GKE, ...) has it. On EKS attach S3 access to this name
+# (Pod Identity association or IRSA via MIVAS_IRSA_ROLE_ARN); elsewhere put
+# AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY (+ AWS_ENDPOINT_URL_S3) in mivas-secrets.
+# Private registries: kubectl patch serviceaccount mivas-bench -p '{"imagePullSecrets":[{"name":"regcred"}]}'
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mivas-bench
+  labels:
+    app: mivas-bench
+  annotations: __SA_ANNOTATIONS__

--- a/run.py
+++ b/run.py
@@ -7,6 +7,7 @@ import argparse
 import base64
 import json
 import os
+import platform
 import signal
 import subprocess
 import sys
@@ -187,6 +188,33 @@ def ingress_enabled() -> bool:
     return bool(os.environ.get("MIVAS_BASE_DOMAIN", "").strip())
 
 
+def ingress_class() -> str:
+    """MIVAS_INGRESS_CLASS; empty means the EKS Auto Mode ALB pair (mivas-alb)."""
+    return os.environ.get("MIVAS_INGRESS_CLASS", "").strip()
+
+
+def generic_ingress() -> bool:
+    """Any non-EKS controller (nginx, traefik, ...) → k8s/ingress-generic.yaml."""
+    cls = ingress_class()
+    return bool(cls) and cls != "mivas-alb"
+
+
+def tls_secret_name(harness: str, industry: str) -> str:
+    return os.environ.get("MIVAS_TLS_SECRET", "").strip() or f"mivas-{slug(harness, industry)}-tls"
+
+
+def cluster_issuer_annotation() -> str:
+    issuer = os.environ.get("MIVAS_CLUSTER_ISSUER", "").strip()
+    if issuer:
+        return f'cert-manager.io/cluster-issuer: "{issuer}"'
+    return 'mivas.tls: "provisioned"'
+
+
+def service_account_annotations() -> str:
+    role = os.environ.get("MIVAS_IRSA_ROLE_ARN", "").strip()
+    return f'{{eks.amazonaws.com/role-arn: "{role}"}}' if role else "{}"
+
+
 def _ecr_registry_host(prefix: str) -> str | None:
     """Return the ECR registry host from MIVAS_IMAGE_PREFIX, or None if not ECR."""
     host = prefix.strip().rstrip("/").split("/")[0]
@@ -250,7 +278,8 @@ def build_image(harness: str, industry: str, image: str) -> None:
             ]
         )
         return
-    platforms = platforms or "linux/arm64"
+    host_arch = "arm64" if platform.machine().lower() in {"arm64", "aarch64"} else "amd64"
+    platforms = platforms or f"linux/{host_arch}"
     print(f"building {image} (-f {dockerfile.relative_to(ROOT)}) {platforms}")
     run(
         [
@@ -269,7 +298,14 @@ def build_image(harness: str, industry: str, image: str) -> None:
     )
 
 
-def _render(template_name: str, harness: str, industry: str, image: str, service_type: str) -> str:
+def _render(
+    template_name: str,
+    harness: str,
+    industry: str,
+    image: str,
+    service_type: str,
+    **extra: str,
+) -> str:
     family, runtime = split_harness(harness)
     pair_slug = slug(harness, industry)
     host = pair_dns_host(harness, industry) or ""
@@ -289,6 +325,8 @@ def _render(template_name: str, harness: str, industry: str, image: str, service
     )
     cpu_req, mem_req, mem_lim = pair_resources(harness)
     template = (ROOT / "k8s" / template_name).read_text()
+    for key, value in extra.items():
+        template = template.replace(f"__{key}__", value)
     return (
         template.replace("__HARNESS__", harness)
         .replace("__HARNESS_FAMILY__", family)
@@ -313,6 +351,10 @@ def _render(template_name: str, harness: str, industry: str, image: str, service
         .replace("__SNAPSHOT_BUCKET__", os.environ.get("MIVAS_SNAPSHOT_BUCKET", "").strip())
         .replace("__SNAPSHOT_PREFIX__", os.environ.get("MIVAS_SNAPSHOT_PREFIX", "mivas").strip() or "mivas")
         .replace("__AWS_REGION__", os.environ.get("AWS_DEFAULT_REGION") or os.environ.get("AWS_REGION") or "us-west-1")
+        .replace("__SA_ANNOTATIONS__", service_account_annotations())
+        .replace("__INGRESS_CLASS__", ingress_class())
+        .replace("__TLS_SECRET__", tls_secret_name(harness, industry))
+        .replace("__CLUSTER_ISSUER_ANNOTATION__", cluster_issuer_annotation())
     )
 
 
@@ -408,6 +450,7 @@ _SECRET_ENV_KEYS = (
     "PUBLIC_URL",
     "CHIRP_USER",
     "CHIRP_PASS",
+    "AWS_ENDPOINT_URL_S3",
 )
 
 
@@ -620,23 +663,42 @@ def resolve_pairs(harness: str, industry: str) -> list[tuple[str, str]]:
 def render_agents_yaml(pairs: list[tuple[str, str]], service_type: str) -> str:
     docs: list[str] = []
     use_ingress = ingress_enabled()
-    if use_ingress and not os.environ.get("MIVAS_ACM_CERTIFICATE_ARN", "").strip():
+    generic = generic_ingress()
+    if use_ingress and not generic and not os.environ.get("MIVAS_ACM_CERTIFICATE_ARN", "").strip():
         raise ValueError(
             "MIVAS_BASE_DOMAIN is set but MIVAS_ACM_CERTIFICATE_ARN is missing "
-            "(needed for HTTPS/WSS Ingress on EKS)"
+            "(needed for HTTPS/WSS Ingress on EKS; set MIVAS_INGRESS_CLASS for other clusters)"
         )
-    if use_ingress:
+    if generic and not (
+        os.environ.get("MIVAS_CLUSTER_ISSUER", "").strip() or os.environ.get("MIVAS_TLS_SECRET", "").strip()
+    ):
+        raise ValueError(
+            "MIVAS_INGRESS_CLASS is set but neither MIVAS_CLUSTER_ISSUER (cert-manager) "
+            "nor MIVAS_TLS_SECRET is set; Bluejay needs wss://"
+        )
+    h0, i0 = pairs[0]
+    # Deployments reference serviceAccountName mivas-bench; render it so non-EKS clusters have it.
+    docs.append(_render("serviceaccount.yaml", h0, i0, image_ref(h0, i0), service_type))
+    if use_ingress and not generic:
         # Cluster-scoped; same cert/group for every pair. Render with the first pair
         # so __ACM_CERTIFICATE_ARN__ is filled (other pair fields unused).
-        h0, i0 = pairs[0]
         docs.append(_render("ingressclass.yaml", h0, i0, image_ref(h0, i0), service_type))
     for harness, industry in pairs:
         image = image_ref(harness, industry)
         docs.append(_render("deployment.yaml", harness, industry, image, service_type))
         docs.append(_render("service.yaml", harness, industry, image, service_type))
-        if use_ingress and pair_needs_ingress(harness):
+        if not use_ingress:
+            continue
+        chirp = pair_needs_ingress(harness)
+        if generic:
+            docs.append(_render(
+                "ingress-generic.yaml", harness, industry, image, service_type,
+                INGRESS_PATH="/" if chirp else "/tools",
+                INGRESS_PORT_NAME="chirp" if chirp else "tools",
+            ))
+        elif chirp:
             docs.append(_render("ingress.yaml", harness, industry, image, service_type))
-        elif use_ingress:
+        else:
             docs.append(_render("ingress-tools.yaml", harness, industry, image, service_type))
     return "\n---\n".join(docs) + "\n"
 
@@ -732,10 +794,10 @@ def apply_agents(pairs: list[tuple[str, str]], *, follow_logs: bool) -> None:
             "(auth: CHIRP_USER/CHIRP_PASS). Hostnames are deterministic per slug."
         )
         print("List: kubectl get ingress,svc,deploy -l app=mivas-bench")
-        print("ALB hostname (wildcard CNAME target for MIVAS_BASE_DOMAIN):")
+        print("Ingress address (wildcard DNS target for *.MIVAS_BASE_DOMAIN):")
         print(
             "  kubectl get ingress -l app=mivas-bench "
-            "-o jsonpath='{.items[0].status.loadBalancer.ingress[0].hostname}'"
+            "-o jsonpath='{.items[0].status.loadBalancer.ingress[0]}'"
         )
     elif chirp_pairs:
         print("Point each Bluejay agent websocket_url at its Service (auth: CHIRP_USER/CHIRP_PASS).")

--- a/runtime/chirp_health.py
+++ b/runtime/chirp_health.py
@@ -1,0 +1,22 @@
+"""Plain HTTP on the CHIRP port: GET /health → 200, anything else non-WebSocket → 404.
+
+Platforms that can only probe the port the WebSocket listens on (Baseten's
+docker_server readiness/liveness) need this; Kubernetes keeps probing the
+in-pod tool server on :8000. Pass as ``serve(..., process_request=process_request)``
+(websockets>=14 asyncio server).
+"""
+
+from __future__ import annotations
+
+from http import HTTPStatus
+
+HEALTH_PATHS = frozenset({"/health", "/healthz"})
+
+
+def process_request(connection, request):
+    if request.headers.get("Upgrade", "").lower() == "websocket":
+        return None
+    path = request.path.split("?", 1)[0].rstrip("/") or "/"
+    if path in HEALTH_PATHS:
+        return connection.respond(HTTPStatus.OK, '{"status":"ok"}\n')
+    return connection.respond(HTTPStatus.NOT_FOUND, "not found\n")

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -58,7 +58,7 @@ def test_render_agents_yaml_two_pairs(monkeypatch: pytest.MonkeyPatch) -> None:
         "LoadBalancer",
     )
     assert yaml_text.count("kind: Deployment") == 2
-    assert yaml_text.count("kind: Service") == 2
+    assert yaml_text.count("kind: Service\n") == 2
     assert "name: tools" in yaml_text
     assert "---" in yaml_text
     assert f"name: mivas-{slug('openai/realtime-2.1', 'healthcare')}" in yaml_text
@@ -269,3 +269,48 @@ def test_cascaded_nemotron_gets_heavier_pod() -> None:
     assert yaml_text.count("cpu: 250m") == 1
     assert "__CPU_REQUEST__" not in yaml_text
     assert "__MEMORY_LIMIT__" not in yaml_text
+
+
+def test_service_account_always_rendered(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MIVAS_BASE_DOMAIN", raising=False)
+    monkeypatch.delenv("MIVAS_IRSA_ROLE_ARN", raising=False)
+    yaml_text = render_agents_yaml([("openai/realtime-2.1", "control-industry")], "LoadBalancer")
+    assert yaml_text.count("kind: ServiceAccount") == 1
+    assert "name: mivas-bench" in yaml_text
+    assert "annotations: {}" in yaml_text
+    monkeypatch.setenv("MIVAS_IRSA_ROLE_ARN", "arn:aws:iam::123456789012:role/mivas")
+    yaml_text = render_agents_yaml([("openai/realtime-2.1", "control-industry")], "LoadBalancer")
+    assert 'eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/mivas"' in yaml_text
+
+
+def test_generic_ingress_render(monkeypatch: pytest.MonkeyPatch) -> None:
+    from run import generic_ingress
+
+    monkeypatch.setenv("MIVAS_BASE_DOMAIN", "mivas.example.org")
+    monkeypatch.setenv("MIVAS_INGRESS_CLASS", "nginx")
+    monkeypatch.setenv("MIVAS_CLUSTER_ISSUER", "letsencrypt-prod")
+    monkeypatch.delenv("MIVAS_ACM_CERTIFICATE_ARN", raising=False)
+    monkeypatch.delenv("MIVAS_TLS_SECRET", raising=False)
+    assert generic_ingress()
+    yaml_text = render_agents_yaml(
+        [("openai/realtime-2.1", "healthcare"), ("livekit/cascaded", "healthcare")], "ClusterIP",
+    )
+    s = slug("openai/realtime-2.1", "healthcare")
+    assert "kind: IngressClassParams" not in yaml_text
+    assert yaml_text.count("\nkind: Ingress\n") == 2
+    assert "ingressClassName: nginx" in yaml_text
+    assert 'cert-manager.io/cluster-issuer: "letsencrypt-prod"' in yaml_text
+    assert f"secretName: mivas-{s}-tls" in yaml_text
+    assert f"host: {s}.mivas.example.org" in yaml_text
+    assert "path: /\n" in yaml_text and "path: /tools\n" in yaml_text
+    assert "name: chirp\n" in yaml_text and "name: tools\n" in yaml_text
+    assert "__INGRESS_PATH__" not in yaml_text and "__INGRESS_PORT_NAME__" not in yaml_text
+    assert "__CLUSTER_ISSUER_ANNOTATION__" not in yaml_text
+
+    monkeypatch.delenv("MIVAS_CLUSTER_ISSUER")
+    with pytest.raises(ValueError, match="MIVAS_TLS_SECRET"):
+        render_agents_yaml([("openai/realtime-2.1", "healthcare")], "ClusterIP")
+    monkeypatch.setenv("MIVAS_TLS_SECRET", "wildcard-tls")
+    yaml_text = render_agents_yaml([("openai/realtime-2.1", "healthcare")], "ClusterIP")
+    assert "secretName: wildcard-tls" in yaml_text
+    assert 'mivas.tls: "provisioned"' in yaml_text

--- a/tests/test_chirp_health.py
+++ b/tests/test_chirp_health.py
@@ -1,0 +1,48 @@
+"""GET /health on the CHIRP port answers 200 while WebSocket upgrades still work."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "runtime"))
+
+from chirp_health import process_request  # noqa: E402
+
+
+async def _roundtrip() -> tuple[int, int, str]:
+    from websockets.asyncio.client import connect
+    from websockets.asyncio.server import serve
+
+    async def echo(ws):
+        async for msg in ws:
+            await ws.send(msg)
+
+    async with serve(echo, "127.0.0.1", 0, process_request=process_request) as server:
+        port = server.sockets[0].getsockname()[1]
+        loop = asyncio.get_running_loop()
+
+        def get(path: str) -> int:
+            try:
+                with urllib.request.urlopen(f"http://127.0.0.1:{port}{path}", timeout=5) as r:
+                    return r.status
+            except urllib.error.HTTPError as e:
+                return e.code
+
+        health = await loop.run_in_executor(None, get, "/health")
+        other = await loop.run_in_executor(None, get, "/")
+        async with connect(f"ws://127.0.0.1:{port}/") as ws:
+            await ws.send("ping")
+            echoed = await ws.recv()
+        return health, other, echoed
+
+
+def test_health_and_upgrade_coexist() -> None:
+    health, other, echoed = asyncio.run(_roundtrip())
+    assert health == 200
+    assert other == 404
+    assert echoed == "ping"

--- a/voice-agent-harnesses/grok/voice/adapters/chirp.py
+++ b/voice-agent-harnesses/grok/voice/adapters/chirp.py
@@ -39,6 +39,8 @@ from typing import Any
 from websockets.asyncio.server import serve
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "runtime"))  # repo runtime/ when not in-pod
+from chirp_health import process_request as _health  # noqa: E402
 from harness import (  # noqa: E402
     END_CALL_CLOSE_DELAY_S,
     MODEL,
@@ -880,7 +882,7 @@ def main(model: str | None = None) -> None:
     )
 
     async def run() -> None:
-        async with serve(lambda ws: _handler(ws, a.industry, a.model), a.host, a.port):
+        async with serve(lambda ws: _handler(ws, a.industry, a.model), a.host, a.port, process_request=_health):
             await asyncio.Future()
 
     asyncio.run(run())

--- a/voice-agent-harnesses/nvidia/nemotron-voicechat/adapters/chirp.py
+++ b/voice-agent-harnesses/nvidia/nemotron-voicechat/adapters/chirp.py
@@ -29,6 +29,8 @@ from typing import Any
 from websockets.asyncio.server import serve
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[4] / "runtime"))  # repo runtime/ when not in-pod
+from chirp_health import process_request as _health  # noqa: E402
 from harness import industry_path, load_blueprint, set_call_id  # noqa: E402
 from report import RealtimeSpanTracer, traced_run  # noqa: E402
 from voicechat import (  # noqa: E402
@@ -911,7 +913,7 @@ def main(model: str | None = None) -> None:
     )
 
     async def run() -> None:
-        async with serve(lambda ws: _handler(ws, a.industry), a.host, a.port):
+        async with serve(lambda ws: _handler(ws, a.industry), a.host, a.port, process_request=_health):
             await asyncio.Future()
 
     asyncio.run(run())

--- a/voice-agent-harnesses/openai/adapters/chirp.py
+++ b/voice-agent-harnesses/openai/adapters/chirp.py
@@ -24,6 +24,8 @@ from agents.realtime import RealtimeModelSendRawMessage
 from websockets.asyncio.server import serve
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "runtime"))  # repo runtime/ when not in-pod
+from chirp_health import process_request as _health  # noqa: E402
 from harness import build_from_blueprint, industry_path, log_ws_accept, set_call_id  # noqa: E402
 from report import traced_run  # noqa: E402
 
@@ -222,7 +224,7 @@ def main(model: str | None = None) -> None:
     print(f"ws↔OpenAI {a.model} × {a.industry} :{a.port} auth={bool(_auth())}", flush=True)
 
     async def run() -> None:
-        async with serve(lambda ws: _handler(ws, a.model, a.industry), a.host, a.port):
+        async with serve(lambda ws: _handler(ws, a.model, a.industry), a.host, a.port, process_request=_health):
             await asyncio.Future()
 
     asyncio.run(run())

--- a/voice-agent-harnesses/qwen/adapters/chirp.py
+++ b/voice-agent-harnesses/qwen/adapters/chirp.py
@@ -30,6 +30,8 @@ from typing import Any
 from websockets.asyncio.server import serve
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "runtime"))  # repo runtime/ when not in-pod
+from chirp_health import process_request as _health  # noqa: E402
 from harness import (  # noqa: E402
     END_CALL_CLOSE_DELAY_S,
     INPUT_RATE,
@@ -317,7 +319,7 @@ def main(model: str | None = None) -> None:
     )
 
     async def run() -> None:
-        async with serve(lambda ws: _handler(ws, a.model, a.industry), a.host, a.port):
+        async with serve(lambda ws: _handler(ws, a.model, a.industry), a.host, a.port, process_request=_health):
             await asyncio.Future()
 
     asyncio.run(run())


### PR DESCRIPTION
## What

`.claude/skills/mivas-run/` lets anyone run MIVAS Bench end to end with only a Bluejay API key, a harness they control, and their own Kubernetes. It is a consumer-side skill: public REST API + `X-API-Key`, no internal infrastructure.

Ladder (each rung gates the next):

1. `scripts/preflight.py` — tools, key validity, pair on disk, provider keys, `run.py --check`, snapshot store, k8s readiness, raw `wss://` upgrade probe.
2. Deploy per `DEPLOY.md` — local k8s + tunnel, EKS (Auto Mode or classic), Baseten Custom Server, any Kubernetes (ingress-nginx + cert-manager + MinIO).
3. `scripts/bluejay.py smoke` — agent → 4-minute simulation → smoke digital humans → 3 calls → six-check rubric (utterances, actual tools, traces, dead air, audio continuity, opening silence).
4. `scripts/verify_integrity.py` — repo tests, blueprint check, rubric, scorable results, hangup snapshots present; task suite builds, expected final states replay onto seed.
5. `scripts/bluejay.py full` — whole industry, k runs per task, then `verify_task_run.py` + CSV.

`HARNESS.md` covers picking an existing harness or building one (contract + repo registration checklist). `BLUEJAY.md` covers the endpoints, API quirks, and how to read a result.

## Repo changes

- `k8s/serviceaccount.yaml` rendered on every apply; `MIVAS_IRSA_ROLE_ARN` adds the IRSA annotation.
- `MIVAS_INGRESS_CLASS` + `MIVAS_CLUSTER_ISSUER` / `MIVAS_TLS_SECRET` render `k8s/ingress-generic.yaml` for non-EKS controllers; ACM not required there.
- `AWS_ENDPOINT_URL_S3` passed into pods (S3-compatible snapshot stores).
- `runtime/chirp_health.py`: `GET /health` on the CHIRP port, wired into the six asyncio CHIRP adapters.
- Local `run.py --build` defaults to the host architecture.
- `.gitignore`: `.claude/skills/` is tracked, the rest of `.claude/` stays ignored.

## Verification

- `uv run pytest tests`: 300 passed, 8 skipped; the 2 failures (`test_scenario_clock::test_hangup_and_simulator_pins_cannot_skip_work`, `test_tasks_to_digital_humans::test_legal_fairness_c2h1_state_pin_and_rm_lookup_only`) are pre-existing on `main`.
- New tests: `tests/test_chirp_health.py`, generic-ingress and ServiceAccount render tests in `tests/test_agents.py`.
- Live OpenAI CHIRP process: `GET /health` 200, `GET /` 404, WebSocket bind unchanged. All six patched adapters import.
- `preflight.py` and `verify_integrity.py --industry healthcare` run clean against a real key (72 tasks build, expected-state replay passes).
- Not exercised here: a live Bluejay smoke run from a fresh cluster, the generic-ingress path on a non-EKS cluster, and the Baseten proxy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `mivas-run` skill so anyone with a Bluejay API key, a harness they control, and their own Kubernetes can run MIVAS Bench end to end through the public REST API, and makes deployment work on any cluster instead of only EKS Auto Mode.

**Skill**
- `.claude/skills/mivas-run/` gates a ladder: `preflight.py` checks prerequisites, `DEPLOY.md` covers local / EKS / Baseten / any Kubernetes, `bluejay.py smoke` runs three calls scored against a six-check rubric, `verify_integrity.py` checks harness and benchmark integrity, then `bluejay.py full` runs the whole industry.
- `HARNESS.md` and `BLUEJAY.md` document the harness contract and consumer-side API; bundled assets include a Baseten auth-proxy Worker and a MinIO manifest for local snapshot storage.

**Deployment**
- Every apply renders the `mivas-bench` ServiceAccount; EKS uses IRSA via `MIVAS_IRSA_ROLE_ARN`, other clusters use static keys.
- `MIVAS_INGRESS_CLASS` with `MIVAS_CLUSTER_ISSUER` or `MIVAS_TLS_SECRET` renders a generic ingress for any non-EKS controller; EKS Auto Mode keeps the ALB pair.
- `AWS_ENDPOINT_URL_S3` is passed into pods so MinIO / R2 / GCS can serve as the snapshot store, and the CHIRP adapters now answer `GET /health` on the WebSocket port for platform probes.
- Local `--build` defaults to the host architecture; `.claude/skills/` is tracked while the rest of `.claude/` stays ignored.

<sup>Written for commit 38c45fc873f5c3fc22be2322f8022ed84bba8822. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/bluejay-ai-dev/mivas-bench/pull/59?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->